### PR TITLE
feat: History plugin

### DIFF
--- a/package/src/composables/useVueFlow.ts
+++ b/package/src/composables/useVueFlow.ts
@@ -1,6 +1,6 @@
 import { EffectScope } from 'vue'
 import { MaybeRef } from '@vueuse/core'
-import { ElementChange, FlowOptions, FlowProps, State, VueFlowStore } from '~/types'
+import { ChangeHistory, FlowOptions, FlowProps, State, VueFlowStore } from '~/types'
 import { VueFlow } from '~/context'
 import useState from '~/store/state'
 import useGetters from '~/store/getters'
@@ -70,20 +70,14 @@ export class Storage {
       id,
     }
 
-    flow.history.value.undo = (type?: ElementChange['type']) => {
+    flow.history.value.undo = (changes: ChangeHistory[]) => {
       if (!flow.history.value.changes.length) return
 
-      let i = 0
-      if (type) {
-        i = flow.history.value.changes.findIndex((historyChanges) => historyChanges.change.type === type)
-      }
-
-      const change = flow.history.value.changes[i]
-      if (change) {
+      changes.forEach((change) => {
+        const index = flow.history.value.changes.indexOf(change)
         change.undo()
-
-        flow.history.value.changes.splice(i, 1)
-      }
+        flow.history.value.changes.splice(index, 1)
+      })
     }
 
     flow.history.value.clear = () => {

--- a/package/src/composables/useVueFlow.ts
+++ b/package/src/composables/useVueFlow.ts
@@ -1,6 +1,6 @@
 import { EffectScope } from 'vue'
 import { MaybeRef } from '@vueuse/core'
-import { FlowOptions, FlowProps, State, VueFlowStore } from '~/types'
+import { ElementChange, FlowOptions, FlowProps, State, VueFlowStore } from '~/types'
 import { VueFlow } from '~/context'
 import useState from '~/store/state'
 import useGetters from '~/store/getters'
@@ -68,6 +68,26 @@ export class Storage {
       ...toRefs(reactiveState),
       emits,
       id,
+    }
+
+    flow.history.value.undo = (type?: ElementChange['type']) => {
+      if (!flow.history.value.changes.length) return
+
+      let i = 0
+      if (type) {
+        i = flow.history.value.changes.findIndex((historyChanges) => historyChanges.change.type === type)
+      }
+
+      const change = flow.history.value.changes[i]
+      if (change) {
+        change.undo()
+
+        flow.history.value.changes.splice(i, 1)
+      }
+    }
+
+    flow.history.value.clear = () => {
+      flow.history.value.changes = []
     }
 
     this.set(id, flow)

--- a/package/src/container/Viewport/Transform.vue
+++ b/package/src/container/Viewport/Transform.vue
@@ -5,7 +5,7 @@ import { useVueFlow, useZoomPanHelper, useWindow } from '../../composables'
 import { Dimensions, FlowExportObject, FlowInstance, XYPosition } from '../../types'
 import { pointToRendererPoint } from '../../utils'
 
-const { id, nodes, edges, viewport, snapToGrid, snapGrid, dimensions, setState, fitViewOnInit, emits } = $(useVueFlow())
+const { id, nodes, edges, history, viewport, snapToGrid, snapGrid, dimensions, setState, fitViewOnInit, emits } = $(useVueFlow())
 
 const untilDimensions = async (dim: Dimensions) => {
   // if ssr we can't wait for dimensions, they'll never really exist
@@ -63,6 +63,8 @@ onMounted(async () => {
   setState({
     instance,
   })
+
+  history.clear()
 
   fitViewOnInit && instance.fitView()
   emits.paneReady(instance)

--- a/package/src/store/actions.ts
+++ b/package/src/store/actions.ts
@@ -18,6 +18,7 @@ import {
 import {
   applyChanges,
   connectionExists,
+  createAdditionChange,
   createPositionChange,
   createSelectionChange,
   getDimensions,
@@ -268,13 +269,17 @@ export default (state: State, getters: ComputedGetters): Actions => {
   const addNodes: Actions['addNodes'] = (nodes, extent) => {
     const curr = nodes instanceof Function ? nodes(state.nodes) : nodes
 
-    state.nodes = [...state.nodes, ...createGraphNodes(curr, getters.getNode.value, state.nodes, extent ?? state.nodeExtent)]
+    const graphNodes = createGraphNodes(curr, getters.getNode.value, state.nodes, extent ?? state.nodeExtent)
+    const changes = graphNodes.map(createAdditionChange)
+
+    if (changes.length) state.hooks.nodesChange.trigger(changes)
   }
 
   const addEdges: Actions['addEdges'] = (params) => {
     const curr = params instanceof Function ? params(state.edges) : params
+    const changes: any[] = []
 
-    curr.reduce<GraphEdge[]>((acc, param) => {
+    curr.forEach((param) => {
       const edge = addEdge(param, state.edges)
       if (edge) {
         const sourceNode = getters.getNode.value(edge.source)!
@@ -284,26 +289,34 @@ export default (state: State, getters: ComputedGetters): Actions => {
         const missingTarget = !targetNode || typeof targetNode === 'undefined'
         if (missingSource) console.warn(`[vueflow]: Couldn't create edge for source id: ${edge.source}; edge id: ${edge.id}`)
         if (missingTarget) console.warn(`[vueflow]: Couldn't create edge for target id: ${edge.target}; edge id: ${edge.id}`)
-        if (missingTarget || missingSource) return acc
+        if (missingTarget || missingSource) return
 
-        acc.push({
+        changes.push({
           ...state.defaultEdgeOptions,
           ...edge,
           sourceNode,
           targetNode,
         })
       }
+    })
 
-      return acc
-    }, state.edges)
+    if (changes.length) state.hooks.edgesChange.trigger(changes)
   }
 
   const updateEdge: Actions['updateEdge'] = (oldEdge, newConnection) =>
     updateEdgeAction(oldEdge, newConnection, state.edges, addEdges)
 
-  const applyNodeChanges: Actions['applyNodeChanges'] = (changes) => applyChanges(changes, state.nodes, addNodes)
+  const applyNodeChanges: Actions['applyNodeChanges'] = (changes) => {
+    const history = applyChanges(changes, state.nodes, addNodes)
+    state.history.changes.unshift(...history)
+    return history
+  }
 
-  const applyEdgeChanges: Actions['applyEdgeChanges'] = (changes) => applyChanges(changes, state.edges, addEdges)
+  const applyEdgeChanges: Actions['applyEdgeChanges'] = (changes) => {
+    const history = applyChanges(changes, state.edges, addEdges)
+    state.history.changes.unshift(...history)
+    return history
+  }
 
   const setState: Actions['setState'] = (options) => {
     const skip = ['modelValue', 'nodes', 'edges', 'maxZoom', 'minZoom', 'translateExtent']

--- a/package/src/store/actions.ts
+++ b/package/src/store/actions.ts
@@ -307,13 +307,13 @@ export default (state: State, getters: ComputedGetters): Actions => {
     updateEdgeAction(oldEdge, newConnection, state.edges, addEdges)
 
   const applyNodeChanges: Actions['applyNodeChanges'] = (changes) => {
-    const history = applyChanges(changes, state.nodes, addNodes)
+    const history = applyChanges(changes, state.nodes)
     state.history.changes.unshift(...history)
     return history
   }
 
   const applyEdgeChanges: Actions['applyEdgeChanges'] = (changes) => {
-    const history = applyChanges(changes, state.edges, addEdges)
+    const history = applyChanges(changes, state.edges)
     state.history.changes.unshift(...history)
     return history
   }

--- a/package/src/store/state.ts
+++ b/package/src/store/state.ts
@@ -41,6 +41,15 @@ const defaultState = (): State => ({
   nodeTypes: {},
   edgeTypes: {},
 
+  nodeTypes: {},
+  edgeTypes: {},
+
+  history: {
+    changes: [],
+    undo: () => {},
+    clear: () => {},
+  },
+
   initialized: false,
   instance: null,
 

--- a/package/src/store/state.ts
+++ b/package/src/store/state.ts
@@ -38,8 +38,6 @@ const isDef = <T>(val: T): val is NonNullable<T> => typeof val !== 'undefined'
 const defaultState = (): State => ({
   nodes: [],
   edges: [],
-  nodeTypes: {},
-  edgeTypes: {},
 
   nodeTypes: {},
   edgeTypes: {},

--- a/package/src/types/changes.ts
+++ b/package/src/types/changes.ts
@@ -58,4 +58,9 @@ export type EdgeResetChange<Data = ElementData> = {
 export type EdgeChange = EdgeSelectionChange | EdgeRemoveChange | EdgeAddChange | EdgeResetChange
 export type ElementChange = NodeChange | EdgeChange
 
-export type ChangeHistory<C extends ElementChange = ElementChange> = { change: C; undo: () => void; redo: () => void }
+export type ChangeHistory<C extends ElementChange = ElementChange> = {
+  change: C
+  undo: () => void
+  redo: () => void
+  timestamp: number
+}

--- a/package/src/types/changes.ts
+++ b/package/src/types/changes.ts
@@ -1,6 +1,6 @@
 import { XYPosition, Dimensions, ElementData } from './flow'
-import { NodeHandleBounds, Node } from './node'
-import { Edge } from './edge'
+import { NodeHandleBounds, Node, GraphNode } from './node'
+import { Edge, GraphEdge } from './edge'
 
 export type NodeDimensionChange = {
   id: string
@@ -28,7 +28,7 @@ export type NodeRemoveChange = {
 }
 
 export type NodeAddChange<Data = ElementData> = {
-  item: Node<Data>
+  item: GraphNode<Data>
   type: 'add'
 }
 
@@ -48,7 +48,7 @@ export type NodeChange =
 export type EdgeSelectionChange = NodeSelectionChange
 export type EdgeRemoveChange = NodeRemoveChange
 export type EdgeAddChange<Data = ElementData> = {
-  item: Edge<Data>
+  item: GraphEdge<Data>
   type: 'add'
 }
 export type EdgeResetChange<Data = ElementData> = {
@@ -57,3 +57,5 @@ export type EdgeResetChange<Data = ElementData> = {
 }
 export type EdgeChange = EdgeSelectionChange | EdgeRemoveChange | EdgeAddChange | EdgeResetChange
 export type ElementChange = NodeChange | EdgeChange
+
+export type ChangeHistory<C extends ElementChange = ElementChange> = { change: C; undo: () => void; redo: () => void }

--- a/package/src/types/store.ts
+++ b/package/src/types/store.ts
@@ -139,9 +139,9 @@ export interface Actions {
   /** updates an edge */
   updateEdge: UpdateEdge
   /** applies default edge change handler */
-  applyEdgeChanges: (changes: EdgeChange[]) => GraphEdge[]
+  applyEdgeChanges: (changes: EdgeChange[]) => ChangeHistory[]
   /** applies default node change handler */
-  applyNodeChanges: (changes: NodeChange[]) => GraphNode[]
+  applyNodeChanges: (changes: NodeChange[]) => ChangeHistory[]
   /** manually select elements and add to state */
   addSelectedElements: (elements: FlowElements) => void
   /** manually select edges and add to state */

--- a/package/src/types/store.ts
+++ b/package/src/types/store.ts
@@ -6,7 +6,7 @@ import { DefaultEdgeOptions, Edge, GraphEdge } from './edge'
 import { GraphNode, CoordinateExtent, Node } from './node'
 import { D3Selection, D3Zoom, D3ZoomHandler, KeyCode, PanOnScrollMode, Viewport } from './zoom'
 import { FlowHooks, FlowHooksEmit, FlowHooksOn } from './hooks'
-import { NodeChange, EdgeChange } from './changes'
+import { NodeChange, EdgeChange, ChangeHistory, ElementChange } from './changes'
 import { StartHandle, HandleType } from './handle'
 
 export type UpdateNodeDimensionsParams = {
@@ -30,6 +30,12 @@ export interface State extends Omit<FlowOptions, 'id' | 'modelValue'> {
   readonly d3Zoom: D3Zoom | null
   readonly d3Selection: D3Selection | null
   readonly d3ZoomHandler: D3ZoomHandler | null
+
+  history: {
+    changes: ChangeHistory[]
+    undo: (type?: ElementChange['type']) => void
+    clear: () => void
+  }
 
   /** use setMinZoom action to change minZoom */
   minZoom: number

--- a/package/src/types/store.ts
+++ b/package/src/types/store.ts
@@ -6,7 +6,7 @@ import { DefaultEdgeOptions, Edge, GraphEdge } from './edge'
 import { GraphNode, CoordinateExtent, Node } from './node'
 import { D3Selection, D3Zoom, D3ZoomHandler, KeyCode, PanOnScrollMode, Viewport } from './zoom'
 import { FlowHooks, FlowHooksEmit, FlowHooksOn } from './hooks'
-import { NodeChange, EdgeChange, ChangeHistory, ElementChange } from './changes'
+import { NodeChange, EdgeChange, ChangeHistory } from './changes'
 import { StartHandle, HandleType } from './handle'
 
 export type UpdateNodeDimensionsParams = {
@@ -33,7 +33,7 @@ export interface State extends Omit<FlowOptions, 'id' | 'modelValue'> {
 
   history: {
     changes: ChangeHistory[]
-    undo: (type?: ElementChange['type']) => void
+    undo: (changes: ChangeHistory[]) => void
     clear: () => void
   }
 

--- a/package/src/utils/changes.ts
+++ b/package/src/utils/changes.ts
@@ -99,7 +99,7 @@ export const applyChanges = <
   elements: FlowElements,
 ): ChangeHistory<C>[] => {
   let elementIds = elements.map((el) => el.id)
-  const rollback: any[] = []
+  const rollback: ChangeHistory<C>[] = []
 
   changes.forEach((change) => {
     const i = elementIds.indexOf((<any>change).id)
@@ -168,8 +168,9 @@ export const applyChanges = <
           break
         case 'remove':
           if (elementIds.includes(change.id)) {
-          elements.splice(i, 1)
-          elementIds = elements.map((el) => el.id)}
+            elements.splice(i, 1)
+            elementIds = elements.map((el) => el.id)
+          }
 
           rollbackFn = () => {
             if (copy) {
@@ -186,6 +187,7 @@ export const applyChanges = <
       change,
       undo: rollbackFn,
       redo: apply,
+      timestamp: Date.now(),
     })
   })
 

--- a/package/src/utils/changes.ts
+++ b/package/src/utils/changes.ts
@@ -1,15 +1,16 @@
 import { clampPosition, isGraphEdge, isGraphNode } from './graph'
 import {
+  ChangeHistory,
+  CoordinateExtent,
   EdgeChange,
   EdgeSelectionChange,
   ElementChange,
   FlowElements,
+  Getters,
   GraphNode,
   NodeChange,
-  NodeSelectionChange,
   NodePositionChange,
-  Getters,
-  CoordinateExtent,
+  NodeSelectionChange,
   XYPosition,
   GraphEdge,
   Node,
@@ -24,8 +25,7 @@ type CreatePositionChangeParams = {
   dragging?: boolean
 }
 
-function handleParentExpand(updateItem: GraphNode, curr: GraphNode[]) {
-  const parent = updateItem.parentNode ? curr.find((el) => el.id === updateItem.parentNode) : undefined
+function handleParentExpand(updateItem: GraphNode, parent: GraphNode) {
   if (parent) {
     const extendWidth = updateItem.position.x + updateItem.dimensions.width - parent.dimensions.width
     const extendHeight = updateItem.position.y + updateItem.dimensions.height - parent.dimensions.height
@@ -96,45 +96,100 @@ export const applyChanges = <
   C extends ElementChange = T extends GraphNode ? NodeChange : EdgeChange,
 >(
   changes: C[],
-  elements: T[],
-  addElement?: (els: T[]) => void,
-): T[] => {
+  elements: FlowElements,
+): ChangeHistory<C>[] => {
   let elementIds = elements.map((el) => el.id)
-  changes.forEach((change) => {
-    if (change.type === 'add') {
-      if (addElement) return addElement([change.item as any])
-      else return elements.push(change.item as any)
-    }
+  const rollback: any[] = []
 
+  changes.forEach((change) => {
     const i = elementIds.indexOf((<any>change).id)
     const el = elements[i]
-    switch (change.type) {
-      case 'select':
-        if (isGraphNode(el) || isGraphEdge(el)) el.selected = change.selected
-        break
-      case 'position':
-        if (isGraphNode(el)) {
-          if (typeof change.position !== 'undefined') el.position = change.position
-          if (typeof change.dragging !== 'undefined') el.dragging = change.dragging
-          if (el.expandParent && el.parentNode) handleParentExpand(el, elements as GraphNode[])
-        }
-        break
-      case 'dimensions':
-        if (isGraphNode(el)) {
-          if (typeof change.dimensions !== 'undefined') el.dimensions = change.dimensions
-          if (el.expandParent && el.parentNode) handleParentExpand(el, elements as GraphNode[])
-        }
-        break
-      case 'remove':
-        if (elementIds.includes(change.id)) {
-          elements.splice(i, 1)
-          elementIds = elements.map((el) => el.id)
-        }
-        break
+    const copy = el ? JSON.parse(JSON.stringify(el)) : null
+
+    let rollbackFn = () => {
+      if (copy) elements[i] = copy
     }
+
+    const apply = () => {
+      if (change.type === 'add') {
+        const item = <FlowElement>change.item
+        elements.push(item)
+
+        rollbackFn = () => {
+          elements.splice(
+            elements.findIndex((el) => el.id === item.id),
+            1,
+          )
+        }
+      }
+
+      switch (change.type) {
+        case 'select':
+          if (isGraphNode(el) || isGraphEdge(el)) el.selected = change.selected
+          break
+        case 'position':
+          if (isGraphNode(el)) {
+            if (typeof change.position !== 'undefined') el.position = change.position
+            if (typeof change.dragging !== 'undefined') el.dragging = change.dragging
+            if (el.expandParent && el.parentNode) {
+              const parent = elements.find((parent) => parent.id === el.parentNode)
+
+              if (parent && isGraphNode(parent)) {
+                const parentCopy = JSON.parse(JSON.stringify(parent))
+
+                rollbackFn = () => {
+                  elements[elements.indexOf(parent)] = parentCopy
+                  rollbackFn()
+                }
+
+                handleParentExpand(el, parent)
+              }
+            }
+          }
+          break
+        case 'dimensions':
+          if (isGraphNode(el)) {
+            if (typeof change.dimensions !== 'undefined') el.dimensions = change.dimensions
+            if (el.expandParent && el.parentNode) {
+              const parent = elements.find((parent) => parent.id === el.parentNode)
+
+              if (parent && isGraphNode(parent)) {
+                const parentCopy = JSON.parse(JSON.stringify(parent))
+
+                rollbackFn = () => {
+                  elements[elements.indexOf(parent)] = parentCopy
+                  rollbackFn()
+                }
+
+                handleParentExpand(el, parent)
+              }
+            }
+          }
+          break
+        case 'remove':
+          if (elementIds.includes(change.id)) {
+          elements.splice(i, 1)
+          elementIds = elements.map((el) => el.id)}
+
+          rollbackFn = () => {
+            if (copy) {
+              elements.push(copy)
+            }
+          }
+          break
+      }
+    }
+
+    apply()
+
+    rollback.push({
+      change,
+      undo: rollbackFn,
+      redo: apply,
+    })
   })
 
-  return elements
+  return rollback
 }
 
 export const applyEdgeChanges = (changes: EdgeChange[], edges: GraphEdge[]) => applyChanges(changes, edges)
@@ -162,13 +217,12 @@ export const createPositionChange = (
     let currentExtent = node.extent === 'parent' || typeof node.extent === 'undefined' ? nodeExtent : node.extent
 
     if (node.extent === 'parent' && parent && node.dimensions.width && node.dimensions.height) {
-      currentExtent =
-        parent.dimensions.width && parent.dimensions.height
-          ? [
-              [0, 0],
-              [parent.dimensions.width - node.dimensions.width, parent.dimensions.height - node.dimensions.height],
-            ]
-          : currentExtent
+      if (parent.dimensions.width && parent.dimensions.height) {
+        currentExtent = [
+          [0, 0],
+          [parent.dimensions.width - node.dimensions.width, parent.dimensions.height - node.dimensions.height],
+        ]
+      }
     }
 
     change.position = currentExtent ? clampPosition(nextPosition, currentExtent) : nextPosition
@@ -176,6 +230,11 @@ export const createPositionChange = (
 
   return change
 }
+
+export const createAdditionChange = (item: any): any => ({
+  item,
+  type: 'add',
+})
 
 const isParentSelected = (node: GraphNode, selectedIds: string[], getNode: Getters['getNode']): boolean => {
   const parent = node.parentNode ? getNode(node.parentNode) : undefined

--- a/package/src/utils/changes.ts
+++ b/package/src/utils/changes.ts
@@ -102,8 +102,8 @@ export const applyChanges = <
   let elementIds = elements.map((el) => el.id)
   changes.forEach((change) => {
     if (change.type === 'add') {
-      if (addElement) addElement([change.item as any])
-      else elements.push(change.item as any)
+      if (addElement) return addElement([change.item as any])
+      else return elements.push(change.item as any)
     }
 
     const i = elementIds.indexOf((<any>change).id)
@@ -126,8 +126,10 @@ export const applyChanges = <
         }
         break
       case 'remove':
-        elements.splice(i, 1)
-        elementIds = elements.map((el) => el.id)
+        if (elementIds.includes(change.id)) {
+          elements.splice(i, 1)
+          elementIds = elements.map((el) => el.id)
+        }
         break
     }
   })


### PR DESCRIPTION
# What's changed?

* Bind __all__ props as models to allow for two-way binding from props to store and back to user, so when the store state gets updated the changes are emitted