### PR TITLE
feat: childExtent

### DIFF
--- a/package/src/composables/useZoomPanHelper.ts
+++ b/package/src/composables/useZoomPanHelper.ts
@@ -57,12 +57,11 @@ export default (store: Store = useVueFlow().store): ViewportFuncs => {
   }
 
   const transformViewport = (x: number, y: number, zoom: number, duration?: number) => {
-    const { x: clampedX, y: clampedY } = clampPosition(
-      { x: store.viewport.x - x, y: store.viewport.y - y },
-      store.translateExtent,
-    )
+    // enforce translate extent
+    const { x: clampedX, y: clampedY } = clampPosition({ x: -x, y: -y }, store.translateExtent)
 
     const nextTransform = zoomIdentity.translate(-clampedX, -clampedY).scale(zoom)
+
     if (store.d3Selection && store.d3Zoom) {
       store.d3Zoom.transform(transition(store.d3Selection, duration), nextTransform)
     }

--- a/package/src/types/node.ts
+++ b/package/src/types/node.ts
@@ -16,6 +16,8 @@ type WidthFunc = <Data = ElementData>(node: GraphNode<Data>) => number | string 
 // eslint-disable-next-line no-use-before-define
 type HeightFunc = <Data = ElementData>(node: GraphNode<Data>) => number | string | void
 
+type CoordinateExtent2 = [[number, number], [number, number]]
+
 export interface Node<Data = ElementData> extends Element<Data> {
   /** initial node position x, y */
   position: XYPosition
@@ -41,6 +43,9 @@ export interface Node<Data = ElementData> extends Element<Data> {
   expandParent?: boolean
   /** define node as a child node by setting a parent node id */
   parentNode?: string
+
+  // eslint-disable-next-line no-use-before-define
+  childExtent?: ChildExtent
 
   /**
    * Fixed width of node, applied as style
@@ -70,6 +75,8 @@ export interface GraphNode<Data = ElementData> extends Node<Data> {
   selected: boolean
   dragging: boolean
 }
+
+type ChildExtent = CoordinateExtent2 | ((parent: GraphNode, child: GraphNode) => CoordinateExtent2)
 
 /** these props are passed to node components */
 export interface NodeProps<Data = ElementData> {


### PR DESCRIPTION
# What's changed?

* childExtent allows parent nodes to define an area inside the parent where all children can be moved in without having to specify an extent on each child
* requires children to set extent to `parent`