### PR TITLE
fix(edges): Overflow: visible not working on all browsers

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint --ext \".js,.jsx,.ts,.tsx\" --fix --ignore-path .gitignore ."
   },
   "dependencies": {
-    "@braks/vue-flow": "^0.4.4",
+    "@braks/vue-flow": "^0.4.6",
     "blobity": "^0.1.7"
   },
   "devDependencies": {

--- a/e2e/cypress/integration/1-store/setState.spec.ts
+++ b/e2e/cypress/integration/1-store/setState.spec.ts
@@ -46,6 +46,16 @@ describe('test store state', () => {
 
   it('gets custom edge types', () => {
     store.setState({
+      nodes: [
+        {
+          id: '1',
+          position: { x: 0, y: 0 },
+        },
+        {
+          id: '2',
+          position: { x: 50, y: 50 },
+        },
+      ],
       edges: [
         {
           id: '1',

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,7 +7,7 @@
     "open": "cypress open-ct"
   },
   "dependencies": {
-    "@braks/vue-flow": "^0.4.4"
+    "@braks/vue-flow": "^0.4.6"
   },
   "devDependencies": {
     "@cypress/vite-dev-server": "^2.2.1",

--- a/examples/package.json
+++ b/examples/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint --ext \".js,.jsx,.ts,.tsx\" --fix --ignore-path .gitignore ."
   },
   "dependencies": {
-    "@braks/vue-flow": "^0.4.4"
+    "@braks/vue-flow": "^0.4.6"
   },
   "devDependencies": {
     "@types/dagre": "^0.7.46",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@braks/vue-flow",
-  "version": "0.4.6",
+  "version": "0.4.7-0.pr92",
   "private": false,
   "repository": {
     "type": "git",

--- a/package/src/components/Edges/EdgeWrapper.vue
+++ b/package/src/components/Edges/EdgeWrapper.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { CSSProperties } from 'vue'
 import { useHandle, useVueFlow } from '../../composables'
-import { ConnectionMode, EdgeComponent, GraphEdge, Position } from '../../types'
+import { ConnectionMode, EdgeComponent, GraphEdge, GraphNode, Position } from '../../types'
 import { getEdgePositions, getHandle, getMarkerId } from '../../utils'
 import { Slots } from '../../context'
 import EdgeAnchor from './EdgeAnchor.vue'
@@ -9,6 +9,8 @@ import EdgeAnchor from './EdgeAnchor.vue'
 interface EdgeWrapper {
   id: string
   edge: GraphEdge
+  sourceNode: GraphNode
+  targetNode: GraphNode
   selectable?: boolean
   updatable?: boolean
 }
@@ -59,21 +61,21 @@ const handleEdgeUpdater = (event: MouseEvent, isSourceHandle: boolean) => {
 // when connection type is loose we can define all handles as sources
 const targetNodeHandles = computed(() => {
   if (store.connectionMode === ConnectionMode.Strict) {
-    return edge.value.targetNode.handleBounds.target
+    return props.targetNode.handleBounds.target
   }
 
-  const targetBounds = edge.value.targetNode.handleBounds.target
-  const sourceBounds = edge.value.targetNode.handleBounds.source
+  const targetBounds = props.targetNode.handleBounds.target
+  const sourceBounds = props.targetNode.handleBounds.source
   return targetBounds ?? sourceBounds
 })
 
 const sourceNodeHandles = computed(() => {
   if (store.connectionMode === ConnectionMode.Strict) {
-    return edge.value.sourceNode.handleBounds.source
+    return props.sourceNode.handleBounds.source
   }
 
-  const targetBounds = edge.value.sourceNode.handleBounds.target
-  const sourceBounds = edge.value.sourceNode.handleBounds.source
+  const targetBounds = props.sourceNode.handleBounds.target
+  const sourceBounds = props.sourceNode.handleBounds.source
   return sourceBounds ?? targetBounds
 })
 
@@ -90,19 +92,19 @@ onMounted(() => {
     [
       sourcePosition,
       targetPosition,
-      () => edge.value.sourceNode.position,
-      () => edge.value.targetNode.position,
-      () => edge.value.sourceNode.computedPosition,
-      () => edge.value.targetNode.computedPosition,
-      () => edge.value.sourceNode.dimensions,
-      () => edge.value.targetNode.dimensions,
+      () => props.sourceNode.position,
+      () => props.targetNode.position,
+      () => props.sourceNode.computedPosition,
+      () => props.targetNode.computedPosition,
+      () => props.sourceNode.dimensions,
+      () => props.targetNode.dimensions,
     ],
     () => {
       const { sourceX, sourceY, targetY, targetX } = getEdgePositions(
-        edge.value.sourceNode,
+        props.sourceNode,
         sourceHandle.value,
         sourcePosition.value,
-        edge.value.targetNode,
+        props.targetNode,
         targetHandle.value,
         targetPosition.value,
       )
@@ -185,8 +187,8 @@ export default {
     <component
       :is="type"
       :id="edge.id"
-      :source-node="edge.sourceNode"
-      :target-node="edge.targetNode"
+      :source-node="props.sourceNode"
+      :target-node="props.targetNode"
       :source="edge.source"
       :target="edge.target"
       :updatable="props.updatable"

--- a/package/src/components/Nodes/NodeWrapper.vue
+++ b/package/src/components/Nodes/NodeWrapper.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { useDraggableCore } from '@braks/revue-draggable'
-import { CSSProperties, isVNode } from 'vue'
+import { CSSProperties } from 'vue'
 import { useVueFlow } from '../../composables'
 import { GraphNode, NodeComponent, SnapGrid } from '../../types'
 import { NodeId, Slots } from '../../context'

--- a/package/src/composables/useHandle.ts
+++ b/package/src/composables/useHandle.ts
@@ -160,8 +160,8 @@ export default (store: Store = useVueFlow().store) => {
       const isOwnHandle = connection.source === connection.target
 
       if (isValid && !isOwnHandle) {
-        store.hooks.connect.trigger(connection)
-        onEdgeUpdate?.(connection)
+        if (!onEdgeUpdate) store.hooks.connect.trigger(connection)
+        else onEdgeUpdate(connection)
       }
 
       store.hooks.connectEnd.trigger(event)

--- a/package/src/composables/useZoomPanHelper.ts
+++ b/package/src/composables/useZoomPanHelper.ts
@@ -57,12 +57,11 @@ export default (store: Store = useVueFlow().store): ViewportFuncs => {
   }
 
   const transformViewport = (x: number, y: number, zoom: number, duration?: number) => {
-    const { x: clampedX, y: clampedY } = clampPosition(
-      { x: store.viewport.x - x, y: store.viewport.y - y },
-      store.translateExtent,
-    )
+    // enforce translate extent
+    const { x: clampedX, y: clampedY } = clampPosition({ x: -x, y: -y }, store.translateExtent)
 
     const nextTransform = zoomIdentity.translate(-clampedX, -clampedY).scale(zoom)
+
     if (store.d3Selection && store.d3Zoom) {
       store.d3Zoom.transform(transition(store.d3Selection, duration), nextTransform)
     }

--- a/package/src/container/EdgeRenderer/EdgeRenderer.vue
+++ b/package/src/container/EdgeRenderer/EdgeRenderer.vue
@@ -23,7 +23,11 @@ const connectionLineVisible = controlledComputed(
       store.connectionHandleType
     ),
 )
-const groups = computed(() => groupEdgesByZLevel(store.getEdges, store.getNodes))
+
+const getNode = computed(() => (node: string) => store.getNode(node)!)
+
+const memoizedGroups = useMemoize(groupEdgesByZLevel)
+const groups = computed(() => memoizedGroups(store.getEdges, getNode.value))
 </script>
 <script lang="ts">
 export default {
@@ -39,6 +43,8 @@ export default {
         :id="edge.id"
         :key="edge.id"
         :edge="edge"
+        :source-node="getNode(edge.source)"
+        :target-node="getNode(edge.target)"
         :selectable="typeof edge.selectable === 'undefined' ? store.elementsSelectable : edge.selectable"
         :updatable="typeof edge.updatable === 'undefined' ? store.edgesUpdatable : edge.updatable"
       />

--- a/package/src/container/EdgeRenderer/EdgeRenderer.vue
+++ b/package/src/container/EdgeRenderer/EdgeRenderer.vue
@@ -39,8 +39,8 @@ const rect = computed(() => {
   return {
     width: `${width}px`,
     height: `${height}px`,
-    transformSvg: `translateY(${y}px) translateX(${x}px)`,
-    transformPath: `translateY(${Math.abs(y)}px) translateX(${Math.abs(x)}px)`,
+    transformSvg: y && x > 0 ? undefined : `translateY(${y > 0 ? 0 : y}px) translateX(${x > 0 ? 0 : x}px)`,
+    transformPath: y && x > 0 ? undefined : `translateY(${Math.abs(y > 0 ? 0 : y)}px) translateX(${Math.abs(x > 0 ? 0 : x)}px)`,
   }
 })
 </script>

--- a/package/src/container/NodeRenderer/NodeRenderer.vue
+++ b/package/src/container/NodeRenderer/NodeRenderer.vue
@@ -14,7 +14,7 @@ export default {
     <NodeWrapper
       v-for="node of store.getNodes"
       :id="node.id"
-      :key="`vue-flow__node-${node.id}`"
+      :key="node.id"
       :node="node"
       :draggable="typeof node.draggable === 'undefined' ? store.nodesDraggable : !!node.draggable"
       :selectable="typeof node.selectable === 'undefined' ? store.elementsSelectable : !!node.selectable"

--- a/package/src/store/actions.ts
+++ b/package/src/store/actions.ts
@@ -16,8 +16,7 @@ import {
   ComputedGetters,
 } from '~/types'
 import {
-  applyNodeChanges as applyNodes,
-  applyEdgeChanges as applyEdges,
+  applyChanges,
   connectionExists,
   createPositionChange,
   createSelectionChange,
@@ -241,6 +240,7 @@ export default (state: State, getters: ComputedGetters): Actions => {
       const missingTarget = !targetNode || typeof targetNode === 'undefined'
       if (missingSource) console.warn(`[vueflow]: Couldn't create edge for source id: ${edge.source}; edge id: ${edge.id}`)
       if (missingTarget) console.warn(`[vueflow]: Couldn't create edge for target id: ${edge.target}; edge id: ${edge.id}`)
+      if (missingSource || missingTarget) return res
 
       const storedEdge = getters.getEdge.value(edge.id)
 
@@ -249,8 +249,6 @@ export default (state: State, getters: ComputedGetters): Actions => {
           ...state.defaultEdgeOptions,
           ...storedEdge,
         }),
-        sourceNode,
-        targetNode,
       })
 
       return res
@@ -284,12 +282,11 @@ export default (state: State, getters: ComputedGetters): Actions => {
         const missingTarget = !targetNode || typeof targetNode === 'undefined'
         if (missingSource) console.warn(`[vueflow]: Couldn't create edge for source id: ${edge.source}; edge id: ${edge.id}`)
         if (missingTarget) console.warn(`[vueflow]: Couldn't create edge for target id: ${edge.target}; edge id: ${edge.id}`)
+        if (missingTarget || missingSource) return
 
         state.edges.push({
           ...state.defaultEdgeOptions,
           ...edge,
-          sourceNode,
-          targetNode,
         })
       }
     })
@@ -298,9 +295,9 @@ export default (state: State, getters: ComputedGetters): Actions => {
   const updateEdge: Actions['updateEdge'] = (oldEdge, newConnection) =>
     updateEdgeAction(oldEdge, newConnection, state.edges, addEdges)
 
-  const applyNodeChanges: Actions['applyNodeChanges'] = (changes) => applyNodes(changes, state.nodes)
+  const applyNodeChanges: Actions['applyNodeChanges'] = (changes) => applyChanges(changes, state.nodes, addNodes)
 
-  const applyEdgeChanges: Actions['applyEdgeChanges'] = (changes) => applyEdges(changes, state.edges)
+  const applyEdgeChanges: Actions['applyEdgeChanges'] = (changes) => applyChanges(changes, state.edges, addEdges)
 
   const setState: Actions['setState'] = (options) => {
     const skip = ['modelValue', 'nodes', 'edges', 'maxZoom', 'minZoom', 'translateExtent']

--- a/package/src/types/edge.ts
+++ b/package/src/types/edge.ts
@@ -94,9 +94,7 @@ export interface EdgePositions {
 }
 
 /** Internal edge type */
-export type GraphEdge<Data = ElementData, SourceNodeData = any, TargetNodeData = SourceNodeData> = Edge<Data> & {
-  sourceNode: GraphNode<SourceNodeData>
-  targetNode: GraphNode<TargetNodeData>
+export type GraphEdge<Data = ElementData> = Edge<Data> & {
   selected?: boolean
   z?: number
 } & EdgePositions

--- a/package/src/utils/changes.ts
+++ b/package/src/utils/changes.ts
@@ -1,9 +1,8 @@
-import { clampPosition, isGraphNode } from './graph'
+import { clampPosition, isGraphEdge, isGraphNode } from './graph'
 import {
   EdgeChange,
   EdgeSelectionChange,
   ElementChange,
-  FlowElement,
   FlowElements,
   GraphNode,
   NodeChange,
@@ -13,6 +12,9 @@ import {
   CoordinateExtent,
   XYPosition,
   GraphEdge,
+  Node,
+  FlowElement,
+  Edge,
 } from '~/types'
 
 type CreatePositionChangeParams = {
@@ -90,20 +92,25 @@ function handleParentExpand(updateItem: GraphNode, curr: GraphNode[]) {
 }
 
 export const applyChanges = <
-  T extends FlowElement = GraphNode,
+  T extends Node | Edge | FlowElement = Node,
   C extends ElementChange = T extends GraphNode ? NodeChange : EdgeChange,
 >(
   changes: C[],
   elements: T[],
+  addElement?: (els: T[]) => void,
 ): T[] => {
   let elementIds = elements.map((el) => el.id)
   changes.forEach((change) => {
-    if (change.type === 'add') return elements.push(change.item as any)
+    if (change.type === 'add') {
+      if (addElement) addElement([change.item as any])
+      else elements.push(change.item as any)
+    }
+
     const i = elementIds.indexOf((<any>change).id)
     const el = elements[i]
     switch (change.type) {
       case 'select':
-        el.selected = change.selected
+        if (isGraphNode(el) || isGraphEdge(el)) el.selected = change.selected
         break
       case 'position':
         if (isGraphNode(el)) {

--- a/package/src/utils/edge.ts
+++ b/package/src/utils/edge.ts
@@ -1,5 +1,5 @@
 import { rectToBox } from './graph'
-import { EdgePositions, GraphEdge, GraphNode, HandleElement, Position, Rect, Viewport, XYPosition } from '~/types'
+import { EdgePositions, Getters, GraphEdge, GraphNode, HandleElement, Position, Rect, Viewport, XYPosition } from '~/types'
 
 export const getHandlePosition = (position: Position, rect: Rect, handle?: HandleElement): XYPosition => {
   const x = (handle?.x ?? 0) + rect.x
@@ -126,17 +126,16 @@ export function isEdgeVisible({
   return overlappingArea > 0
 }
 
-export const groupEdgesByZLevel = (edges: GraphEdge[], nodes: GraphNode[]) => {
+export const groupEdgesByZLevel = (edges: GraphEdge[], getNode: Getters['getNode']) => {
   let maxLevel = -1
-  const nodeIds = nodes.map((n) => n.id)
 
   const levelLookup = edges.reduce<Record<string, GraphEdge[]>>((tree, edge) => {
-    const z = edge.z
-      ? edge.z
-      : Math.max(
-          nodes[nodeIds.indexOf(edge.source)]?.computedPosition.z || 0,
-          nodes[nodeIds.indexOf(edge.target)]?.computedPosition.z || 0,
-        )
+    const source = getNode(edge.source)
+    const target = getNode(edge.target)
+
+    if (!source || !target) return tree
+
+    const z = edge.z ? edge.z : Math.max(source.computedPosition.z || 0, target.computedPosition.z || 0)
     if (tree[z]) {
       tree[z].push(edge)
     } else {

--- a/package/src/utils/graph.ts
+++ b/package/src/utils/graph.ts
@@ -195,7 +195,7 @@ export const updateEdge = (oldEdge: Edge, newConnection: Connection, elements: E
     targetHandle: newConnection.targetHandle,
   }
   elements.splice(elements.indexOf(foundEdge), 1, edge)
-  return elements.filter((e) => e.id !== oldEdge.id).concat(edge)
+  return elements.filter((e) => e.id !== oldEdge.id)
 }
 
 export const pointToRendererPoint = (


### PR DESCRIPTION
# What's changed?

* Edges get cut on some browser (Chromium) because the css property `overflow: visible` doesn't work
* Calculate enough size for the edge canvas and move it so the bounds necessarily fit all nodes and edges
* 
# Issues

* #30 
* #96 