### PR TITLE
feat(edges): Add source/target nodes to graph edges

### DIFF
--- a/package/src/store/actions.ts
+++ b/package/src/store/actions.ts
@@ -248,6 +248,8 @@ export default (state: State, getters: ComputedGetters): Actions => {
         ...parseEdge(edge, {
           ...state.defaultEdgeOptions,
           ...storedEdge,
+          sourceNode,
+          targetNode,
         }),
       })
 
@@ -287,6 +289,8 @@ export default (state: State, getters: ComputedGetters): Actions => {
         state.edges.push({
           ...state.defaultEdgeOptions,
           ...edge,
+          sourceNode,
+          targetNode,
         })
       }
     })

--- a/package/src/types/edge.ts
+++ b/package/src/types/edge.ts
@@ -97,6 +97,8 @@ export interface EdgePositions {
 export type GraphEdge<Data = ElementData> = Edge<Data> & {
   selected?: boolean
   z?: number
+  sourceNode: GraphNode
+  targetNode: GraphNode
 } & EdgePositions
 
 /** these props are passed to edge components */


### PR DESCRIPTION
# What's changed?

* Bind source and target nodes to graph edges for convenience