### PR TITLE
fix(zoom): Use scaleBy instead of scaleTo for zoom

### DIFF
--- a/package/src/additional-components/Controls/Controls.vue
+++ b/package/src/additional-components/Controls/Controls.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { useZoomPanHelper, useVueFlow } from '../../composables'
-import type { ControlProps, ControlEvents } from '../../types/components'
+import type { ControlProps } from '../../types/components'
 import ControlButton from './ControlButton.vue'
 import PlusIcon from '~/assets/icons/plus.svg'
 import MinusIcon from '~/assets/icons/minus.svg'
@@ -13,7 +13,12 @@ const props = withDefaults(defineProps<ControlProps>(), {
   showFitView: true,
   showInteractive: true,
 })
-const emit = defineEmits<ControlEvents>()
+const emit = defineEmits<{
+  (event: 'zoom-in'): void
+  (event: 'zoom-out'): void
+  (event: 'fit-view'): void
+  (event: 'interaction-change', active: boolean): void
+}>()
 
 const { store } = useVueFlow()
 const { zoomIn, zoomOut, fitView } = useZoomPanHelper()

--- a/package/src/composables/useZoomPanHelper.ts
+++ b/package/src/composables/useZoomPanHelper.ts
@@ -44,7 +44,7 @@ export default (store: Store = useVueFlow().store): ViewportFuncs => {
     if (!hasDimensions.value) await untilDimensions(store)
 
     if (store.d3Selection && store.d3Zoom) {
-      store.d3Zoom.scaleTo(transition(store.d3Selection, duration), scale)
+      store.d3Zoom.scaleBy(transition(store.d3Selection, duration), scale)
     }
   }
 

--- a/package/src/types/components.ts
+++ b/package/src/types/components.ts
@@ -54,13 +54,6 @@ export interface ControlProps {
   fitViewParams?: FitViewParams
 }
 
-export interface ControlEvents {
-  (event: 'zoom-in'): void
-  (event: 'zoom-out'): void
-  (event: 'fit-view'): void
-  (event: 'interaction-change', active: boolean): void
-}
-
 /** expects a node and returns a color value */
 export type MiniMapNodeFunc<Data = ElementData> = (node: GraphNode<Data>) => string
 // hack for vue-type imports


### PR DESCRIPTION
# What's changed?

* Allow user to pass refs to composable (will not trigger an automatic re-set of state when refs are changed)