### PR TITLE
fix(vue-flow): set `applyDefault` regardless of true/false

### DIFF
--- a/packages/vue-flow/src/container/VueFlow/watch.ts
+++ b/packages/vue-flow/src/container/VueFlow/watch.ts
@@ -156,6 +156,9 @@ export default (models: ToRefs<Pick<FlowProps, 'nodes' | 'edges' | 'modelValue'>
             if (store.applyDefault.value) {
               store.onNodesChange(store.applyNodeChanges)
               store.onEdgesChange(store.applyEdgeChanges)
+            } else {
+              store.hooks.value.nodesChange.off(store.applyNodeChanges)
+              store.hooks.value.edgesChange.off(store.applyEdgeChanges)
             }
           },
           { immediate: true },


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- set `applyDefault` value in prop watcher regardless of boolean val
- unregister apply changes handler when `applyDefault` is set to false