### PR TITLE
fix(nodes): `getNode` not returning proper node element

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ types/types.ts
 build
 typedocs
 .turbo
+.quasar

--- a/packages/vue-flow/src/components/Nodes/NodeWrapper.vue
+++ b/packages/vue-flow/src/components/Nodes/NodeWrapper.vue
@@ -174,7 +174,7 @@ export default {
       getClass,
     ]"
     :style="{
-      zIndex: node.computedPosition.z ? node.computedPosition.z : node.selected ? 1000 : 0,
+      zIndex: node.computedPosition.z ?? 0,
       transform: `translate(${node.computedPosition.x}px,${node.computedPosition.y}px)`,
       pointerEvents: selectable || draggable ? 'all' : 'none',
       ...getStyle,

--- a/packages/vue-flow/src/container/Viewport/Viewport.vue
+++ b/packages/vue-flow/src/container/Viewport/Viewport.vue
@@ -122,7 +122,7 @@ onMounted(() => {
           const point = pointer(event)
           // taken from https://github.com/d3/d3-zoom/blob/master/src/zoom.js
           const pinchDelta = -event.deltaY * (event.deltaMode === 1 ? 0.05 : event.deltaMode ? 1 : 0.002) * 10
-          const zoom = currentZoom * Math.pow(2, pinchDelta)
+          const zoom = currentZoom * 2 ** pinchDelta
           if (d3Selection) d3Zoom.scaleTo(d3Selection, zoom, point)
 
           return

--- a/packages/vue-flow/src/store/getters.ts
+++ b/packages/vue-flow/src/store/getters.ts
@@ -3,10 +3,8 @@ import type { ComputedGetters, GraphEdge, GraphNode, State } from '~/types'
 import { getNodesInside, isEdgeVisible } from '~/utils'
 
 export default (state: State): ComputedGetters => {
-  const nodeIds = computed(() => state.nodes.map((n) => n.id))
-  const edgeIds = computed(() => state.edges.map((e) => e.id))
-  const getNode: ComputedGetters['getNode'] = computed(() => (id: string) => state.nodes[nodeIds.value.indexOf(id)])
-  const getEdge: ComputedGetters['getEdge'] = computed(() => (id: string) => state.edges[edgeIds.value.indexOf(id)])
+  const getNode: ComputedGetters['getNode'] = computed(() => (id: string) => state.nodes.find((node) => node.id === id))
+  const getEdge: ComputedGetters['getEdge'] = computed(() => (id: string) => state.edges.find((edge) => edge.id === id))
 
   const getEdgeTypes = computed(() => {
     const edgeTypes: Record<string, any> = {


### PR DESCRIPTION
# What's changed?

* use `.find` instead of computed index