### PR TITLE
refactor(vue-flow,viewpane): remove instance property and merge into `useVueFlow`

### DIFF
--- a/docs/components/examples/basic/App.vue
+++ b/docs/components/examples/basic/App.vue
@@ -7,7 +7,7 @@ import { initialElements } from './initial-elements.js'
  * useVueFlow provides all event handlers and store properties
  * You can pass the composable an object that has the same properties as the VueFlow component props
  */
-const { onPaneReady, onNodeDragStop, onConnect, instance, addEdges } = useVueFlow()
+const { onPaneReady, onNodeDragStop, onConnect, addEdges, setTransform, toObject } = useVueFlow()
 
 /**
  * Our elements
@@ -50,12 +50,12 @@ const updatePos = () =>
 /**
  * toObject transforms your current graph data to an easily persist-able object
  */
-const logToObject = () => console.log(instance.value?.toObject())
+const logToObject = () => console.log(toObject())
 
 /**
  * Resets the current viewpane transformation (zoom & pan)
  */
-const resetTransform = () => instance.value?.setTransform({ x: 0, y: 0, zoom: 1 })
+const resetTransform = () => setTransform({ x: 0, y: 0, zoom: 1 })
 
 const toggleClass = () => {
   dark.value = !dark.value

--- a/docs/components/examples/dnd/App.vue
+++ b/docs/components/examples/dnd/App.vue
@@ -5,7 +5,7 @@ import Sidebar from './Sidebar.vue'
 let id = 0
 const getId = () => `dndnode_${id++}`
 
-const { instance, onConnect, nodes, edges, addEdges, addNodes, viewport } = useVueFlow({
+const { onConnect, nodes, edges, addEdges, addNodes, viewport, project } = useVueFlow({
   nodes: [
     {
       id: '1',
@@ -25,17 +25,15 @@ const onDragOver = (event) => {
 onConnect((params) => addEdges([params]))
 
 const onDrop = (event) => {
-  if (instance.value) {
-    const type = event.dataTransfer?.getData('application/vueflow')
-    const position = instance.value.project({ x: event.clientX - 40, y: event.clientY - 18 })
-    const newNode = {
-      id: getId(),
-      type,
-      position,
-      label: `${type} node`,
-    }
-    addNodes([newNode])
+  const type = event.dataTransfer?.getData('application/vueflow')
+  const position = project({ x: event.clientX - 40, y: event.clientY - 18 })
+  const newNode = {
+    id: getId(),
+    type,
+    position,
+    label: `${type} node`,
   }
+  addNodes([newNode])
 }
 </script>
 

--- a/docs/components/examples/save-restore/Controls.vue
+++ b/docs/components/examples/save-restore/Controls.vue
@@ -3,10 +3,10 @@ import { useVueFlow } from '@braks/vue-flow'
 
 const flowKey = 'example-flow'
 
-const { nodes, addNodes, setNodes, setEdges, instance, dimensions } = useVueFlow()
+const { nodes, addNodes, setNodes, setEdges, dimensions, setTransform, toObject } = useVueFlow()
 
 const onSave = () => {
-  localStorage.setItem(flowKey, JSON.stringify(instance.value?.toObject()))
+  localStorage.setItem(flowKey, JSON.stringify(toObject()))
 }
 
 const onRestore = () => {
@@ -16,7 +16,7 @@ const onRestore = () => {
     const [x = 0, y = 0] = flow.position
     setNodes(flow.nodes)
     setEdges(flow.edges)
-    instance.value.setTransform({ x, y, zoom: flow.zoom || 0 })
+    setTransform({ x, y, zoom: flow.zoom || 0 })
   }
 }
 
@@ -35,6 +35,6 @@ const onAdd = () => {
   <div class="save__controls">
     <button style="background-color: #33a6b8" @click="onSave">save</button>
     <button style="background-color: #113285" @click="onRestore">restore</button>
-    <button style="background-color: #6F3381" @click="onAdd">add node</button>
+    <button style="background-color: #6f3381" @click="onAdd">add node</button>
   </div>
 </template>

--- a/docs/components/examples/stress/App.vue
+++ b/docs/components/examples/stress/App.vue
@@ -6,13 +6,13 @@ import { getElements } from './utils.js'
 const { nodes, edges } = getElements(15, 15)
 const elements = ref([...nodes, ...edges])
 
-const { onPaneReady, dimensions, instance, onNodeClick, getEdges } = useVueFlow()
+const { onPaneReady, dimensions, onNodeClick, getEdges, fitView } = useVueFlow()
 
 onPaneReady((i) => {
   i.fitView({
     padding: 0.2,
   })
-  console.log(i.getElements())
+  console.log(i.getElements.value)
 })
 
 const toggleClass = () => elements.value.forEach((el) => (el.class = el.class === 'light' ? 'dark' : 'light'))
@@ -27,7 +27,7 @@ const updatePos = () => {
     }
   })
   nextTick(() => {
-    instance.value.fitView({ duration: 1000, padding: 0.5 })
+    fitView({ duration: 1000, padding: 0.5 })
   })
 }
 

--- a/docs/components/home/Features.vue
+++ b/docs/components/home/Features.vue
@@ -1,11 +1,11 @@
 <script lang="ts" setup>
-import { reactive, watch } from 'vue'
+import { watch } from 'vue'
 import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
 import type { VueFlowStore } from '@braks/vue-flow'
 
 const breakpoints = useBreakpoints(breakpointsTailwind)
 
-const instances = reactive<VueFlowStore[]>([])
+const instances: VueFlowStore[] = []
 
 const onLoad = (instance: VueFlowStore) => {
   instances.push(instance)

--- a/docs/components/home/Features.vue
+++ b/docs/components/home/Features.vue
@@ -1,13 +1,13 @@
 <script lang="ts" setup>
 import { reactive, watch } from 'vue'
 import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
-import type { FlowInstance } from '@braks/vue-flow'
+import type { VueFlowStore } from '@braks/vue-flow'
 
 const breakpoints = useBreakpoints(breakpointsTailwind)
 
-const instances = reactive<FlowInstance[]>([])
+const instances = reactive<VueFlowStore[]>([])
 
-const onLoad = (instance: FlowInstance) => {
+const onLoad = (instance: VueFlowStore) => {
   instances.push(instance)
   instance.fitView()
 }

--- a/docs/components/home/Features.vue
+++ b/docs/components/home/Features.vue
@@ -1,5 +1,4 @@
 <script lang="ts" setup>
-import { watch } from 'vue'
 import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
 import type { VueFlowStore } from '@braks/vue-flow'
 
@@ -16,11 +15,9 @@ const fitViews = () => {
   instances.forEach((i) => i.fitView())
 }
 
-watch([breakpoints.sm, breakpoints.md, breakpoints.lg, breakpoints.xl, breakpoints['2xl']], () =>
-  setTimeout(() => {
-    fitViews()
-  }, 5),
-)
+watchDebounced([breakpoints.sm, breakpoints.md, breakpoints.lg, breakpoints.xl, breakpoints['2xl']], () => fitViews(), {
+  debounce: 50,
+})
 </script>
 
 <template>

--- a/docs/components/home/flows/Intro.vue
+++ b/docs/components/home/flows/Intro.vue
@@ -41,7 +41,7 @@ const initialEdges = [
     style: { strokeWidth: 2, stroke: '#0ea5e9' },
   },
 ]
-const { dimensions, instance, onNodeClick, getNodes, getNode, getEdge, updateEdge, edges, setEdges } = useVueFlow({
+const { dimensions, onNodeClick, getNodes, fitView, getNode, getEdge, updateEdge, edges, setEdges } = useVueFlow({
   nodes: [
     { id: 'intro', type: 'box', position: { x: 0, y: 0 } },
     { id: 'examples', type: 'box', position: { x: -50, y: 400 } },
@@ -102,8 +102,6 @@ onNodeClick(async ({ node }) => {
 
 const init = ref(false)
 const el = templateRef<HTMLDivElement>('el', null)
-
-let stopObserver: () => void
 
 const setNodes = () => {
   if (breakpoints.isSmaller('md')) {
@@ -192,7 +190,7 @@ const setNodes = () => {
   }
 
   nextTick(() => {
-    instance.value?.fitView()
+    fitView()
     if (!init.value) init.value = true
   })
 }

--- a/docs/components/home/flows/Intro.vue
+++ b/docs/components/home/flows/Intro.vue
@@ -100,7 +100,6 @@ onNodeClick(async ({ node }) => {
   }
 })
 
-const init = ref(false)
 const el = templateRef<HTMLDivElement>('el', null)
 
 const setNodes = () => {
@@ -191,7 +190,6 @@ const setNodes = () => {
 
   nextTick(() => {
     fitView()
-    if (!init.value) init.value = true
   })
 }
 

--- a/docs/src/guide/composables.md
+++ b/docs/src/guide/composables.md
@@ -6,7 +6,8 @@ If you're using the options API of Vue you will soon notice that your access to 
 
 This is where the composition API comes in.
 
-The composition API and the power of provide/inject allows us to act more flexible with the way we provide states inside a component tree.
+The composition API and the power of provide/inject allows us to act more flexible with the way we provide states inside
+a component tree.
 Thus accessing the internal state of Vue Flow becomes super easy when using composition.
 
 ```vue:no-line-numbers
@@ -38,7 +39,9 @@ The values are reactive, meaning changing the state values returned from `useVue
 
 ## [useZoomPanHelper](https://types.vueflow.dev/modules.html#useZoomPanHelper)
 
-Similar to the Vue Flow instance the zoom pan helper composable can be used to modify the viewport of the Vue Flow graph.
+The `useZoomPanHelper` utility can be used to access core store functions like getting Elements or
+using viewpane transforms.
+All functions can also be accessed from `useVueFlow`.
 It requires a valid Vue Flow store in its context.
 
 ```vue:no-line-numbers
@@ -55,11 +58,13 @@ const { fitView } = useZoomPanHelper()
 ## [useHandle](https://types.vueflow.dev/modules.html#useHandle)
 
 Instead of using the Handle component you can use the useHandle composable to create your own custom nodes. `useHandle`
-provides you with a mouseDown- and click-handler functions that you can apply to the element you want to use as a node-handle.
+provides you with a mouseDown- and click-handler functions that you can apply to the element you want to use as a
+node-handle.
 
 This is how the default handle component is built:
 
 ```vue
+
 <script lang="ts" setup>
 import { NodeId, useHandle, useVueFlow } from '@braks/vue-flow'
 import type { HandleProps, Position } from '@braks/vue-flow'

--- a/docs/src/guide/utils/instance.md
+++ b/docs/src/guide/utils/instance.md
@@ -1,9 +1,7 @@
-# Instance
+# Viewport Functions
 
-The Vue Flow instance provides easy access to zoom-pan-helper functions.
-It can be accessed either directly from the state using `useVueFlow` or
-you can receive the instance with a `onPaneReady` event handler.
-
+Viewport Functions can be accessed via the `useVueFlow` utility or with the `VueFlowStore` instance provided by
+`onPaneReady`.
 
 <CodeGroup>
   <CodeGroupItem title="Composition API" active>
@@ -12,15 +10,10 @@ you can receive the instance with a `onPaneReady` event handler.
 <script setup>
 import { VueFlow, useVueFlow } from '@braks/vue-flow'
 
-const { onPaneReady, instance } = useVueFlow()
+const { onPaneReady } = useVueFlow()
 
 // event handler
 onPaneReady((instance) => instance.fitView())
-
-onMounted(() => {
-  // or directly try to access the instance
-  instance.value?.fitView()
-})
 </script>
 ```
 

--- a/examples/vite/src/Basic/Basic.vue
+++ b/examples/vite/src/Basic/Basic.vue
@@ -10,7 +10,7 @@ const elements = ref<Elements>([
   { id: 'e1-2', source: '1', target: '2', animated: true },
   { id: 'e1-3', source: '1', target: '3' },
 ])
-const { onPaneReady, onNodeDragStop, onConnect, instance, addEdges } = useVueFlow({
+const { onPaneReady, onNodeDragStop, onConnect, addEdges, setTransform, toObject } = useVueFlow({
   defaultZoom: 1.5,
   minZoom: 0.2,
   maxZoom: 4,
@@ -32,8 +32,8 @@ const updatePos = () =>
     }
   })
 
-const logToObject = () => console.log(instance.value?.toObject())
-const resetTransform = () => instance.value?.setTransform({ x: 0, y: 0, zoom: 1 })
+const logToObject = () => console.log(toObject())
+const resetTransform = () => setTransform({ x: 0, y: 0, zoom: 1 })
 const toggleclass = () => elements.value.forEach((el) => (el.class = el.class === 'light' ? 'dark' : 'light'))
 </script>
 

--- a/examples/vite/src/Basic/BasicOptionsAPI.vue
+++ b/examples/vite/src/Basic/BasicOptionsAPI.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { Elements, FlowEvents, FlowInstance } from '@braks/vue-flow'
+import type { Elements, FlowEvents, VueFlowStore } from '@braks/vue-flow'
 import { Background, Controls, MiniMap, VueFlow, addEdge, isNode } from '@braks/vue-flow'
 
 export default defineComponent({
@@ -7,7 +7,7 @@ export default defineComponent({
   components: { VueFlow, Background, MiniMap, Controls },
   data() {
     return {
-      instance: null as FlowInstance | null,
+      instance: null as VueFlowStore | null,
       elements: [
         { id: '1', type: 'input', label: 'Node 1', position: { x: 250, y: 5 }, class: 'light' },
         { id: '2', label: 'Node 2', position: { x: 100, y: 100 }, class: 'light' },

--- a/examples/vite/src/CustomNode/CustomNode.vue
+++ b/examples/vite/src/CustomNode/CustomNode.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import type { Elements, Node, SnapGrid } from '@braks/vue-flow'
-import { ConnectionMode, Controls, MiniMap, Position, VueFlow, isEdge, useVueFlow } from '@braks/vue-flow'
+import { ConnectionMode, Controls, MiniMap, Position, VueFlow, isEdge, useVueFlow } from '@braks/vue-flow/src/index'
 import ColorSelectorNode from './ColorSelectorNode.vue'
 
 const elements = ref<Elements>([])

--- a/examples/vite/src/EdgeTypes/EdgeTypesExample.vue
+++ b/examples/vite/src/EdgeTypes/EdgeTypesExample.vue
@@ -1,9 +1,9 @@
 <script lang="ts" setup>
-import type { FlowInstance } from '@braks/vue-flow'
+import type { VueFlowStore } from '@braks/vue-flow'
 import { Controls, MiniMap, VueFlow } from '@braks/vue-flow'
 import { getElements } from './utils'
 
-const onLoad = (flowInstance: FlowInstance) => {
+const onLoad = (flowInstance: VueFlowStore) => {
   flowInstance.fitView()
   console.log(flowInstance.getElements())
 }

--- a/examples/vite/src/Empty/EmptyExample.vue
+++ b/examples/vite/src/Empty/EmptyExample.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import type { Node } from '@braks/vue-flow'
-import { Background, BackgroundVariant, Controls, MiniMap, VueFlow, useVueFlow } from '@braks/vue-flow'
+import { Background, BackgroundVariant, Controls, MiniMap, VueFlow, useVueFlow } from '@braks/vue-flow/src/index'
 
 const { nodes, addNodes, edges, addEdges, onConnect, onPaneReady, onNodeDragStop, dimensions } = useVueFlow()
 

--- a/examples/vite/src/NodeTypeChange/NodeTypeChangeExample.vue
+++ b/examples/vite/src/NodeTypeChange/NodeTypeChangeExample.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import type { Connection, Edge, Elements, FlowInstance } from '@braks/vue-flow'
+import type { Connection, Edge, Elements, VueFlowStore } from '@braks/vue-flow'
 import { Position, VueFlow, addEdge, isEdge } from '@braks/vue-flow'
 
 const initialElements: Elements = [
@@ -25,7 +25,7 @@ const elements = ref<Elements>(initialElements)
 
 const onConnect = (params: Connection | Edge) => (elements.value = addEdge(params, elements.value))
 
-const onLoad = (flowInstance: FlowInstance) => flowInstance.fitView()
+const onLoad = (flowInstance: VueFlowStore) => flowInstance.fitView()
 
 const changeType = () => {
   elements.value.forEach((el) => {

--- a/examples/vite/src/Overview/Overview.vue
+++ b/examples/vite/src/Overview/Overview.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import type { Connection, Edge, Elements, FlowEvents, FlowInstance, FlowTransform, Node, SnapGrid } from '@braks/vue-flow'
+import type { Connection, Edge, Elements, FlowEvents, VueFlowStore, FlowTransform, Node, SnapGrid } from '@braks/vue-flow'
 import { Background, Controls, MarkerType, MiniMap, VueFlow, addEdge } from '@braks/vue-flow'
 
 const onNodeDragStart = (e: FlowEvents['nodeDragStart']) => console.log('drag start', e)
@@ -13,7 +13,7 @@ const onSelectionDrag = (e: FlowEvents['selectionDrag']) => console.log('selecti
 const onSelectionDragStart = (e: FlowEvents['selectionDragStart']) => console.log('selection drag start', e)
 const onSelectionDragStop = (e: FlowEvents['selectionDragStop']) => console.log('selection drag stop', e)
 const onSelectionContextMenu = (e: FlowEvents['selectionContextMenu']) => console.log('selection context menu', e)
-const onLoad = (flowInstance: FlowInstance) => {
+const onLoad = (flowInstance: VueFlowStore) => {
   console.log('flow loaded:', flowInstance)
   flowInstance.fitView()
 }

--- a/examples/vite/src/Provider/ProviderExample.vue
+++ b/examples/vite/src/Provider/ProviderExample.vue
@@ -1,9 +1,9 @@
 <script lang="ts" setup>
-import type { Elements, FlowInstance } from '@braks/vue-flow'
+import type { Elements, VueFlowStore } from '@braks/vue-flow'
 import { ConnectionMode, Controls, VueFlow, useVueFlow } from '@braks/vue-flow'
 import Sidebar from './Sidebar.vue'
 
-const onLoad = (flowInstance: FlowInstance) => console.log('flow loaded:', flowInstance)
+const onLoad = (flowInstance: VueFlowStore) => console.log('flow loaded:', flowInstance)
 
 const initialElements: Elements = [
   { id: '1', type: 'input', label: 'Node 1', position: { x: 250, y: 5 } },

--- a/examples/vite/src/RGBFlow/RGBFlow.vue
+++ b/examples/vite/src/RGBFlow/RGBFlow.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { templateRef } from '@vueuse/core'
-import type { Elements, FlowInstance } from '@braks/vue-flow'
+import type { Elements, VueFlowStore } from '@braks/vue-flow'
 import { VueFlow } from '@braks/vue-flow'
 import RGBNode from './RGBNode.vue'
 import RGBOutputNode from './RGBOutputNode.vue'
@@ -22,7 +22,7 @@ const elements = ref<Elements>([
 
 const el = templateRef<HTMLDivElement>('page', null)
 
-const onLoad = (flowInstance: FlowInstance) => {
+const onLoad = (flowInstance: VueFlowStore) => {
   flowInstance.fitView({ padding: 1 })
 }
 const color = ref<Colors>({

--- a/examples/vite/src/UpdatableEdge/UpdatableEdgeExample.vue
+++ b/examples/vite/src/UpdatableEdge/UpdatableEdgeExample.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import type { Connection, Edge, Elements, FlowEvents, FlowInstance } from '@braks/vue-flow'
+import type { Connection, Edge, Elements, FlowEvents, VueFlowStore } from '@braks/vue-flow'
 import { ConnectionMode, Controls, VueFlow, addEdge, updateEdge } from '@braks/vue-flow'
 
 const initialElements: Elements = [
@@ -24,7 +24,7 @@ const initialElements: Elements = [
 ]
 
 const elements = ref(initialElements)
-const onLoad = (flowInstance: FlowInstance) => flowInstance.fitView()
+const onLoad = (flowInstance: VueFlowStore) => flowInstance.fitView()
 const onEdgeUpdateStart = (edge: Edge) => console.log('start update', edge)
 const onEdgeUpdateEnd = (edge: Edge) => console.log('end update', edge)
 const onEdgeUpdate = ({ edge, connection }: FlowEvents['edgeUpdate']) => {

--- a/examples/vite/src/Validation/ValidationExample.vue
+++ b/examples/vite/src/Validation/ValidationExample.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import type { Connection, FlowInstance, OnConnectStartParams } from '@braks/vue-flow'
+import type { Connection, OnConnectStartParams, VueFlowStore } from '@braks/vue-flow'
 import { VueFlow, useVueFlow } from '@braks/vue-flow'
 import CustomInput from './CustomInput.vue'
 import CustomNode from './CustomNode.vue'
@@ -17,7 +17,7 @@ const { nodes, edges, addEdges } = useVueFlow({
     { id: 'C', type: 'customnode', position: { x: 250, y: 300 }, isValidSourcePos: (connection) => connection.target === 'B' },
   ],
 })
-const onLoad = (flowInstance: FlowInstance) => flowInstance.fitView()
+const onLoad = (flowInstance: VueFlowStore) => flowInstance.fitView()
 const onConnectStart = ({ nodeId, handleType }: OnConnectStartParams) => console.log('on connect start', { nodeId, handleType })
 const onConnectStop = (event: MouseEvent) => console.log('on connect stop', event)
 const onConnectEnd = (event: MouseEvent) => console.log('on connect end', event)

--- a/packages/pathfinding-edge/example/App.vue
+++ b/packages/pathfinding-edge/example/App.vue
@@ -1,16 +1,12 @@
 <script lang="ts" setup>
-import type { Connection, Edge, Elements, FlowInstance } from '@braks/vue-flow'
+import type { Connection, Edge, Elements } from '@braks/vue-flow'
 import { Background, VueFlow, addEdge } from '@braks/vue-flow'
+import { ref } from 'vue'
 import initialElements from './elements'
 import { PathFindingEdge, PerfectArrow } from '~/index'
 
 const elements = ref<Elements>(initialElements)
-const rfInstance = ref<FlowInstance | null>(null)
 const onConnect = (params: Edge | Connection) => (elements.value = addEdge(params, elements.value))
-const onLoad = (flowInstance: FlowInstance) => {
-  flowInstance.fitView({ padding: 1 })
-  rfInstance.value = flowInstance
-}
 </script>
 
 <template>
@@ -18,9 +14,9 @@ const onLoad = (flowInstance: FlowInstance) => {
     <VueFlow
       v-model="elements"
       :default-edge-options="{ type: 'perfectArrow' }"
+      :fit-view-on-init="true"
       class="vue-flow-basic-example"
       @connect="onConnect"
-      @pane-ready="onLoad"
     >
       <template #edge-pathFinding="props">
         <PathFindingEdge v-bind="props" />

--- a/packages/resize-rotate-node/example/App.vue
+++ b/packages/resize-rotate-node/example/App.vue
@@ -1,21 +1,17 @@
 <script lang="ts" setup>
-import type { Connection, Edge, Elements, FlowInstance } from '@braks/vue-flow'
+import type { Connection, Edge, Elements } from '@braks/vue-flow'
 import { Background, Controls, MiniMap, VueFlow, addEdge } from '@braks/vue-flow'
+import { ref } from 'vue'
 import { ResizeRotateNode } from '../src'
 import initialElements from './elements'
 
 const elements = ref<Elements>(initialElements)
-const rfInstance = ref<FlowInstance | null>(null)
 const onConnect = (params: Edge | Connection) => (elements.value = addEdge(params, elements.value))
-const onLoad = (flowInstance: FlowInstance) => {
-  flowInstance.fitView({ padding: 1 })
-  rfInstance.value = flowInstance
-}
 </script>
 
 <template>
   <div style="height: 100%">
-    <VueFlow v-model="elements" class="vue-flow-basic-example" @connect="onConnect" @pane-ready="onLoad">
+    <VueFlow v-model="elements" class="vue-flow-basic-example" :fit-view-on-init="true" @connect="onConnect">
       <template #node-resize-rotate="props">
         <ResizeRotateNode v-bind="props" />
       </template>

--- a/packages/vue-flow/src/additional-components/Controls/Controls.vue
+++ b/packages/vue-flow/src/additional-components/Controls/Controls.vue
@@ -17,22 +17,22 @@ const emit = defineEmits<{
   (event: 'interactionChange', active: boolean): void
 }>()
 
-const { instance, nodesDraggable, nodesConnectable, elementsSelectable, setInteractive } = $(useVueFlow())
+const { nodesDraggable, nodesConnectable, elementsSelectable, setInteractive, zoomIn, zoomOut, fitView } = $(useVueFlow())
 
 const isInteractive = computed(() => nodesDraggable && nodesConnectable && elementsSelectable)
 
 const onZoomInHandler = () => {
-  instance?.zoomIn()
+  zoomIn()
   emit('zoomIn')
 }
 
 const onZoomOutHandler = () => {
-  instance?.zoomOut()
+  zoomOut()
   emit('zoomOut')
 }
 
 const onFitViewHandler = () => {
-  instance?.fitView(fitViewParams)
+  fitView(fitViewParams)
   emit('fitView')
 }
 

--- a/packages/vue-flow/src/components/Nodes/NodeWrapper.vue
+++ b/packages/vue-flow/src/components/Nodes/NodeWrapper.vue
@@ -69,6 +69,8 @@ watch(
 onBeforeUnmount(() => observer.stop())
 
 onMounted(() => {
+  updateNodeDimensions([{ id, nodeElement: nodeElement.value, forceUpdate: true }])
+
   watch(
     [
       () => node.position.x,

--- a/packages/vue-flow/src/components/Nodes/NodeWrapper.vue
+++ b/packages/vue-flow/src/components/Nodes/NodeWrapper.vue
@@ -54,23 +54,21 @@ const dragging = useDrag({
   },
 })
 
-onMounted(() => {
-  const observer = useResizeObserver(nodeElement, () =>
-    updateNodeDimensions([{ id, nodeElement: nodeElement.value, forceUpdate: true }]),
-  )
-
-  watch(
-    [() => node.type, () => node.sourcePosition, () => node.targetPosition],
-    () => {
-      updateNodeDimensions([{ id, nodeElement: nodeElement.value }])
-    },
-    { flush: 'post' },
-  )
-
-  onBeforeUnmount(() => observer.stop())
-
+const observer = useResizeObserver(nodeElement, () => {
   updateNodeDimensions([{ id, nodeElement: nodeElement.value, forceUpdate: true }])
+})
 
+watch(
+  [() => node.width, () => node.height, () => node.type, () => node.sourcePosition, () => node.targetPosition],
+  () => {
+    updateNodeDimensions([{ id, nodeElement: nodeElement.value }])
+  },
+  { flush: 'post' },
+)
+
+onBeforeUnmount(() => observer.stop())
+
+onMounted(() => {
   watch(
     [
       () => node.position.x,

--- a/packages/vue-flow/src/composables/useVueFlow.ts
+++ b/packages/vue-flow/src/composables/useVueFlow.ts
@@ -38,7 +38,7 @@ export class Storage {
 
     const getters = useGetters(reactiveState)
 
-    const actions = useActions(reactiveState, getters)
+    const actions = useActions(reactiveState, getters, id)
 
     const hooksOn = <any>{}
     Object.entries(reactiveState.hooks).forEach(([n, h]) => {

--- a/packages/vue-flow/src/composables/useVueFlow.ts
+++ b/packages/vue-flow/src/composables/useVueFlow.ts
@@ -38,7 +38,7 @@ export class Storage {
 
     const getters = useGetters(reactiveState)
 
-    const actions = useActions(reactiveState, getters, id)
+    const actions = useActions(reactiveState, getters)
 
     const hooksOn = <any>{}
     Object.entries(reactiveState.hooks).forEach(([n, h]) => {

--- a/packages/vue-flow/src/composables/useZoomPanHelper.ts
+++ b/packages/vue-flow/src/composables/useZoomPanHelper.ts
@@ -28,7 +28,7 @@ const untilDimensions = async (dimensions: Dimensions, getNodes: Getters['getNod
   return true
 }
 
-export default (): ViewportFunctions => {
+export default (vueFlowId?: string): ViewportFunctions => {
   const {
     onPaneReady,
     nodes,
@@ -42,7 +42,7 @@ export default (): ViewportFunctions => {
     snapToGrid,
     snapGrid,
     getNodes,
-  } = $(useVueFlow())
+  } = $(useVueFlow({ id: vueFlowId }))
 
   let hasDimensions = $ref(false)
 

--- a/packages/vue-flow/src/composables/useZoomPanHelper.ts
+++ b/packages/vue-flow/src/composables/useZoomPanHelper.ts
@@ -2,7 +2,7 @@ import { zoomIdentity } from 'd3-zoom'
 import useVueFlow from './useVueFlow'
 import useWindow from './useWindow'
 import { clampPosition, getRectOfNodes, getTransformForBounds, pointToRendererPoint } from '~/utils'
-import type { D3Selection, Dimensions, Getters, GraphNode, ViewportFuncs } from '~/types'
+import type { D3Selection, Dimensions, Getters, GraphNode, ViewportFunctions } from '~/types'
 
 const DEFAULT_PADDING = 0.1
 
@@ -28,7 +28,7 @@ const untilDimensions = async (dimensions: Dimensions, getNodes: Getters['getNod
   return true
 }
 
-export default (): ViewportFuncs => {
+export default (): ViewportFunctions => {
   const {
     onPaneReady,
     nodes,
@@ -48,7 +48,7 @@ export default (): ViewportFuncs => {
 
   onPaneReady(() => (hasDimensions = true))
 
-  const zoomTo: ViewportFuncs['zoomTo'] = async (zoomLevel, options) => {
+  const zoomTo: ViewportFunctions['zoomTo'] = async (zoomLevel, options) => {
     if (!hasDimensions) await untilDimensions(dimensions, getNodes)
 
     if (d3Selection && d3Zoom) {
@@ -64,11 +64,11 @@ export default (): ViewportFuncs => {
     }
   }
 
-  const zoomIn: ViewportFuncs['zoomIn'] = async (options) => {
+  const zoomIn: ViewportFunctions['zoomIn'] = async (options) => {
     await zoom(1.2, options?.duration)
   }
 
-  const zoomOut: ViewportFuncs['zoomOut'] = async (options) => {
+  const zoomOut: ViewportFunctions['zoomOut'] = async (options) => {
     await zoom(1 / 1.2, options?.duration)
   }
 

--- a/packages/vue-flow/src/container/Viewport/Transform.vue
+++ b/packages/vue-flow/src/container/Viewport/Transform.vue
@@ -1,10 +1,12 @@
 <script lang="ts" setup>
 import NodeRenderer from '../NodeRenderer/NodeRenderer.vue'
 import EdgeRenderer from '../EdgeRenderer/EdgeRenderer.vue'
-import { useVueFlow, useWindow } from '../../composables'
+import { useVueFlow, useWindow, useZoomPanHelper } from '../../composables'
 import type { Dimensions } from '../../types'
 
-const { id, nodes, edges, viewport, snapToGrid, snapGrid, dimensions, setState, fitViewOnInit, emits, fitView } = $(useVueFlow())
+const { id, nodes, edges, viewport, snapToGrid, snapGrid, dimensions, setState, fitViewOnInit, emits } = $(useVueFlow())
+// eslint-disable-next-line prefer-const
+let { fitView, zoomIn, zoomOut, zoomTo, setTransform, setCenter, fitBounds, ...rest } = useVueFlow()
 
 const untilDimensions = async (dim: Dimensions) => {
   // if ssr we can't wait for dimensions, they'll never really exist
@@ -23,11 +25,24 @@ onMounted(async () => {
   // wait until proper dimensions have been established, otherwise fitView will have wrong bounds when called at paneReady
   await untilDimensions(dimensions)
 
+  // create new instance and set to state
+  const zoomPanHelper = useZoomPanHelper()
+
+  fitView = (params = { padding: 0.1 }) => {
+    zoomPanHelper.fitView(params)
+  }
+  zoomIn = zoomPanHelper.zoomIn
+  zoomOut = zoomPanHelper.zoomOut
+  zoomTo = zoomPanHelper.zoomTo
+  setTransform = zoomPanHelper.setTransform
+  setCenter = zoomPanHelper.setCenter
+  fitBounds = zoomPanHelper.fitBounds
+
   // hide graph until dimensions are ready, so we don't have jumping graphs (ssr for example)
   ready = true
 
   fitViewOnInit && fitView()
-  emits.paneReady(useVueFlow())
+  emits.paneReady({ fitView, zoomIn, zoomOut, zoomTo, setTransform, setCenter, fitBounds, ...rest })
 })
 </script>
 

--- a/packages/vue-flow/src/container/Viewport/Transform.vue
+++ b/packages/vue-flow/src/container/Viewport/Transform.vue
@@ -27,7 +27,7 @@ onMounted(async () => {
   // hide graph until dimensions are ready, so we don't have jumping graphs (ssr for example)
   ready = true
 
-  fitViewOnInit && fitView()
+  fitViewOnInit?.value && fitView()
   emits.paneReady({
     id,
     nodes,

--- a/packages/vue-flow/src/container/Viewport/Transform.vue
+++ b/packages/vue-flow/src/container/Viewport/Transform.vue
@@ -1,12 +1,11 @@
 <script lang="ts" setup>
 import NodeRenderer from '../NodeRenderer/NodeRenderer.vue'
 import EdgeRenderer from '../EdgeRenderer/EdgeRenderer.vue'
-import { useVueFlow, useWindow, useZoomPanHelper } from '../../composables'
+import { useVueFlow, useWindow } from '../../composables'
 import type { Dimensions } from '../../types'
 
-const { id, nodes, edges, viewport, snapToGrid, snapGrid, dimensions, setState, fitViewOnInit, emits } = $(useVueFlow())
-// eslint-disable-next-line prefer-const
-let { fitView, zoomIn, zoomOut, zoomTo, setTransform, setCenter, fitBounds, ...rest } = useVueFlow()
+const { id, nodes, edges, viewport, snapToGrid, snapGrid, dimensions, setState, fitViewOnInit, emits, fitView, ...rest } =
+  useVueFlow()
 
 const untilDimensions = async (dim: Dimensions) => {
   // if ssr we can't wait for dimensions, they'll never really exist
@@ -23,26 +22,26 @@ let ready = $ref(false)
 
 onMounted(async () => {
   // wait until proper dimensions have been established, otherwise fitView will have wrong bounds when called at paneReady
-  await untilDimensions(dimensions)
-
-  // create new instance and set to state
-  const zoomPanHelper = useZoomPanHelper()
-
-  fitView = (params = { padding: 0.1 }) => {
-    zoomPanHelper.fitView(params)
-  }
-  zoomIn = zoomPanHelper.zoomIn
-  zoomOut = zoomPanHelper.zoomOut
-  zoomTo = zoomPanHelper.zoomTo
-  setTransform = zoomPanHelper.setTransform
-  setCenter = zoomPanHelper.setCenter
-  fitBounds = zoomPanHelper.fitBounds
+  await untilDimensions(dimensions.value)
 
   // hide graph until dimensions are ready, so we don't have jumping graphs (ssr for example)
   ready = true
 
   fitViewOnInit && fitView()
-  emits.paneReady({ fitView, zoomIn, zoomOut, zoomTo, setTransform, setCenter, fitBounds, ...rest })
+  emits.paneReady({
+    id,
+    nodes,
+    edges,
+    viewport,
+    snapToGrid,
+    snapGrid,
+    dimensions,
+    setState,
+    fitViewOnInit,
+    fitView,
+    emits,
+    ...rest,
+  })
 })
 </script>
 

--- a/packages/vue-flow/src/container/Viewport/Transform.vue
+++ b/packages/vue-flow/src/container/Viewport/Transform.vue
@@ -27,7 +27,6 @@ onMounted(async () => {
   // hide graph until dimensions are ready, so we don't have jumping graphs (ssr for example)
   ready = true
 
-  fitViewOnInit?.value && fitView()
   emits.paneReady({
     id,
     nodes,
@@ -42,6 +41,8 @@ onMounted(async () => {
     emits,
     ...rest,
   })
+
+  fitViewOnInit?.value && fitView()
 })
 </script>
 

--- a/packages/vue-flow/src/container/Viewport/Viewport.vue
+++ b/packages/vue-flow/src/container/Viewport/Viewport.vue
@@ -2,7 +2,7 @@
 import type { D3ZoomEvent, ZoomTransform } from 'd3-zoom'
 import { zoom, zoomIdentity } from 'd3-zoom'
 import { pointer, select } from 'd3-selection'
-import type { FlowTransform } from '../../types'
+import type { ViewpaneTransform } from '../../types'
 import { PanOnScrollMode } from '../../types'
 import { useKeyPress, useVueFlow } from '../../composables'
 import { clamp, clampPosition } from '../../utils'
@@ -35,12 +35,12 @@ const {
 
 const viewportEl = templateRef<HTMLDivElement>('viewport', null)
 
-const viewChanged = (prevTransform: FlowTransform, eventTransform: ZoomTransform): boolean =>
+const viewChanged = (prevTransform: ViewpaneTransform, eventTransform: ZoomTransform): boolean =>
   (prevTransform.x !== eventTransform.x && !isNaN(eventTransform.x)) ||
   (prevTransform.y !== eventTransform.y && !isNaN(eventTransform.y)) ||
   (prevTransform.zoom !== eventTransform.k && !isNaN(eventTransform.k))
 
-const eventToFlowTransform = (eventTransform: ZoomTransform): FlowTransform => ({
+const eventToFlowTransform = (eventTransform: ZoomTransform): ViewpaneTransform => ({
   x: eventTransform.x,
   y: eventTransform.y,
   zoom: eventTransform.k,

--- a/packages/vue-flow/src/store/actions.ts
+++ b/packages/vue-flow/src/store/actions.ts
@@ -5,6 +5,8 @@ import type {
   CoordinateExtent,
   EdgeChange,
   EdgeRemoveChange,
+  FlowExportObject,
+  Getters,
   GraphEdge,
   GraphNode,
   NodeChange,
@@ -32,6 +34,7 @@ import {
   parseEdge,
   updateEdgeAction,
 } from '~/utils'
+import { useZoomPanHelper } from '~/composables'
 
 export default (state: State, getters: ComputedGetters): Actions => {
   const updateNodePositions: Actions['updateNodePositions'] = (dragItems, changed, dragging) => {
@@ -324,6 +327,20 @@ export default (state: State, getters: ComputedGetters): Actions => {
     if (!state.initialized) state.initialized = true
   }
 
+  const toObject = () => {
+    // we have to stringify/parse so objects containing refs (like nodes and edges) can potentially be saved in a storage
+    return JSON.parse(
+      JSON.stringify({
+        nodes: state.nodes,
+        edges: state.edges,
+        position: [state.viewport.x, state.viewport.y],
+        zoom: state.viewport.zoom,
+      } as FlowExportObject),
+    )
+  }
+
+  const { fitView, ...rest } = useZoomPanHelper()
+
   return {
     updateNodePositions,
     updateNodeDimensions,
@@ -348,6 +365,9 @@ export default (state: State, getters: ComputedGetters): Actions => {
     removeSelectedEdges,
     setInteractive,
     setState,
+    fitView: (params = { padding: 0.1 }) => fitView(params),
+    toObject,
+    ...rest,
     $reset: () => {
       setState(useState())
     },

--- a/packages/vue-flow/src/store/actions.ts
+++ b/packages/vue-flow/src/store/actions.ts
@@ -31,9 +31,9 @@ import {
   isGraphNode,
   isNode,
   parseEdge,
+  pointToRendererPoint,
   updateEdgeAction,
 } from '~/utils'
-import { useZoomPanHelper } from '~/composables'
 
 export default (state: State, getters: ComputedGetters): Actions => {
   const updateNodePositions: Actions['updateNodePositions'] = (dragItems, changed, dragging) => {
@@ -338,7 +338,11 @@ export default (state: State, getters: ComputedGetters): Actions => {
     )
   }
 
-  const { fitView, ...rest } = useZoomPanHelper()
+  const paneNotReady = () => {
+    console.warn(
+      `[Vue Flow]: Used viewpane function before pane was ready. Use viewpane functions *after* onPaneReady is emitted.`,
+    )
+  }
 
   return {
     updateNodePositions,
@@ -364,9 +368,22 @@ export default (state: State, getters: ComputedGetters): Actions => {
     removeSelectedEdges,
     setInteractive,
     setState,
-    fitView: (params = { padding: 0.1 }) => fitView(params),
+    fitView: paneNotReady,
+    zoomIn: paneNotReady,
+    zoomOut: paneNotReady,
+    zoomTo: paneNotReady,
+    setTransform: paneNotReady,
+    getTransform: () => ({
+      x: state.viewport.x,
+      y: state.viewport.y,
+      zoom: state.viewport.zoom,
+    }),
+    setCenter: paneNotReady,
+    fitBounds: paneNotReady,
+    project(position) {
+      return pointToRendererPoint(position, state.viewport, state.snapToGrid, state.snapGrid)
+    },
     toObject,
-    ...rest,
     $reset: () => {
       setState(useState())
     },

--- a/packages/vue-flow/src/store/actions.ts
+++ b/packages/vue-flow/src/store/actions.ts
@@ -6,7 +6,6 @@ import type {
   EdgeChange,
   EdgeRemoveChange,
   FlowExportObject,
-  Getters,
   GraphEdge,
   GraphNode,
   NodeChange,

--- a/packages/vue-flow/src/store/actions.ts
+++ b/packages/vue-flow/src/store/actions.ts
@@ -36,7 +36,7 @@ import {
 } from '~/utils'
 import { useZoomPanHelper } from '~/composables'
 
-export default (state: State, getters: ComputedGetters, id: string): Actions => {
+export default (state: State, getters: ComputedGetters): Actions => {
   const updateNodePositions: Actions['updateNodePositions'] = (dragItems, changed, dragging) => {
     const changes: NodePositionChange[] = []
 
@@ -341,12 +341,12 @@ export default (state: State, getters: ComputedGetters, id: string): Actions => 
 
   let zoomPanHelper: ReturnType<typeof useZoomPanHelper>
 
-  state.hooks.paneReady.on(() => {
+  state.hooks.paneReady.on(({ id }) => {
     zoomPanHelper = useZoomPanHelper(id)
   })
 
   const paneReady = async () => {
-    return new Promise<ReturnType<typeof useZoomPanHelper>>((resolve) => {
+    return new Promise<typeof zoomPanHelper>((resolve) => {
       if (!zoomPanHelper) {
         until(() => zoomPanHelper)
           .toBeTruthy()

--- a/packages/vue-flow/src/store/actions.ts
+++ b/packages/vue-flow/src/store/actions.ts
@@ -340,15 +340,17 @@ export default (state: State, getters: ComputedGetters, id: string): Actions => 
   }
 
   let zoomPanHelper: ReturnType<typeof useZoomPanHelper>
-  const paneReady = async () => {
-    const zoompan = useZoomPanHelper(id)
 
+  state.hooks.paneReady.on(() => {
+    zoomPanHelper = useZoomPanHelper(id)
+  })
+
+  const paneReady = async () => {
     return new Promise<ReturnType<typeof useZoomPanHelper>>((resolve) => {
       if (!zoomPanHelper) {
-        state.hooks.paneReady.on(() => {
-          resolve(zoompan)
-          zoomPanHelper = zoompan
-        })
+        until(() => zoomPanHelper)
+          .toBeTruthy()
+          .then(() => resolve(zoomPanHelper))
       } else {
         resolve(zoomPanHelper)
       }

--- a/packages/vue-flow/src/store/getters.ts
+++ b/packages/vue-flow/src/store/getters.ts
@@ -74,6 +74,7 @@ export default (state: State): ComputedGetters => {
       target.dimensions.height
     )
   }
+
   const getEdges = computed<GraphEdge[]>(() => {
     if (!state.onlyRenderVisibleElements) return state.edges.filter((edge) => edgeHidden(edge))
 
@@ -98,8 +99,12 @@ export default (state: State): ComputedGetters => {
     })
   })
 
+  const getElements: ComputedGetters['getElements'] = computed(() => [...getNodes.value, ...getEdges.value])
+
   const getSelectedNodes: ComputedGetters['getSelectedNodes'] = computed(() => state.nodes.filter((n) => n.selected))
+
   const getSelectedEdges: ComputedGetters['getSelectedEdges'] = computed(() => state.edges.filter((e) => e.selected))
+
   const getSelectedElements: ComputedGetters['getSelectedElements'] = computed(() => [
     ...(getSelectedNodes.value ?? []),
     ...(getSelectedEdges.value ?? []),
@@ -108,6 +113,7 @@ export default (state: State): ComputedGetters => {
   return {
     getNode,
     getEdge,
+    getElements,
     getEdgeTypes,
     getNodeTypes,
     getEdges,

--- a/packages/vue-flow/src/store/state.ts
+++ b/packages/vue-flow/src/store/state.ts
@@ -35,7 +35,6 @@ const defaultState = (): State => ({
   edgeTypes: {},
 
   initialized: false,
-  instance: null,
 
   dimensions: {
     width: 0,

--- a/packages/vue-flow/src/types/flow.ts
+++ b/packages/vue-flow/src/types/flow.ts
@@ -85,9 +85,6 @@ export interface FlowExportObject {
   zoom: number
 }
 
-/** @deprecated will be removed soon, only remains for backwards compatability */
-export type FlowInstance = VueFlowStore
-
 export interface FlowProps {
   id?: string
   modelValue?: Elements

--- a/packages/vue-flow/src/types/flow.ts
+++ b/packages/vue-flow/src/types/flow.ts
@@ -2,8 +2,9 @@ import type { CSSProperties, Component, VNode } from 'vue'
 import type { DefaultEdgeOptions, Edge, GraphEdge } from './edge'
 import type { CoordinateExtent, GraphNode, Node } from './node'
 import type { ConnectionLineType, ConnectionMode } from './connection'
-import type { KeyCode, PanOnScrollMode, ViewportFuncs } from './zoom'
+import type { KeyCode, PanOnScrollMode } from './zoom'
 import type { DefaultEdgeTypes, DefaultNodeTypes, EdgeComponent, NodeComponent } from './components'
+import type { VueFlowStore } from './store'
 
 export type ElementData = any
 
@@ -84,14 +85,8 @@ export interface FlowExportObject {
   zoom: number
 }
 
-interface Exports {
-  getElements: () => FlowElements
-  getNodes: () => GraphNode[]
-  getEdges: () => GraphEdge[]
-  toObject: () => FlowExportObject
-}
-
-export type FlowInstance = Exports & ViewportFuncs
+/** @deprecated will be removed soon, only remains for backwards compatability */
+export type FlowInstance = VueFlowStore
 
 export interface FlowProps {
   id?: string

--- a/packages/vue-flow/src/types/flow.ts
+++ b/packages/vue-flow/src/types/flow.ts
@@ -4,7 +4,6 @@ import type { CoordinateExtent, GraphNode, Node } from './node'
 import type { ConnectionLineType, ConnectionMode } from './connection'
 import type { KeyCode, PanOnScrollMode } from './zoom'
 import type { DefaultEdgeTypes, DefaultNodeTypes, EdgeComponent, NodeComponent } from './components'
-import type { VueFlowStore } from './store'
 
 export type ElementData = any
 

--- a/packages/vue-flow/src/types/hooks.ts
+++ b/packages/vue-flow/src/types/hooks.ts
@@ -1,11 +1,11 @@
 import type { EventHook, EventHookOn, EventHookTrigger } from '@vueuse/core'
 import type { D3ZoomEvent } from 'd3-zoom'
-import type { FlowInstance } from './flow'
 import type { GraphEdge } from './edge'
 import type { GraphNode } from './node'
 import type { Connection, OnConnectStartParams } from './connection'
-import type { FlowTransform } from './zoom'
+import type { ViewpaneTransform } from './zoom'
 import type { EdgeChange, NodeChange } from './changes'
+import type { VueFlowStore } from './store'
 
 export type MouseTouchEvent = MouseEvent | TouchEvent | PointerEvent
 
@@ -54,7 +54,7 @@ export interface FlowEvents {
   } & OnConnectStartParams
   connectStop: MouseEvent
   connectEnd: MouseEvent
-  paneReady: FlowInstance
+  paneReady: VueFlowStore
   move: { event: D3ZoomEvent<HTMLDivElement, any>; flowTransform: FlowTransform }
   moveStart: { event: D3ZoomEvent<HTMLDivElement, any>; flowTransform: FlowTransform }
   moveEnd: { event: D3ZoomEvent<HTMLDivElement, any>; flowTransform: FlowTransform }

--- a/packages/vue-flow/src/types/hooks.ts
+++ b/packages/vue-flow/src/types/hooks.ts
@@ -55,9 +55,9 @@ export interface FlowEvents {
   connectStop: MouseEvent
   connectEnd: MouseEvent
   paneReady: VueFlowStore
-  move: { event: D3ZoomEvent<HTMLDivElement, any>; flowTransform: FlowTransform }
-  moveStart: { event: D3ZoomEvent<HTMLDivElement, any>; flowTransform: FlowTransform }
-  moveEnd: { event: D3ZoomEvent<HTMLDivElement, any>; flowTransform: FlowTransform }
+  move: { event: D3ZoomEvent<HTMLDivElement, any>; flowTransform: ViewpaneTransform }
+  moveStart: { event: D3ZoomEvent<HTMLDivElement, any>; flowTransform: ViewpaneTransform }
+  moveEnd: { event: D3ZoomEvent<HTMLDivElement, any>; flowTransform: ViewpaneTransform }
   selectionDragStart: NodeDragEvent
   selectionDrag: NodeDragEvent
   selectionDragStop: NodeDragEvent

--- a/packages/vue-flow/src/types/store.ts
+++ b/packages/vue-flow/src/types/store.ts
@@ -4,7 +4,7 @@ import type { DefaultEdgeTypes, DefaultNodeTypes, EdgeComponent, NodeComponent }
 import type { Connection, ConnectionLineType, ConnectionMode } from './connection'
 import type { DefaultEdgeOptions, Edge, GraphEdge } from './edge'
 import type { CoordinateExtent, GraphNode, Node } from './node'
-import type { D3Selection, D3Zoom, D3ZoomHandler, KeyCode, PanOnScrollMode, Viewport } from './zoom'
+import type { D3Selection, D3Zoom, D3ZoomHandler, KeyCode, PanOnScrollMode, Viewport, ViewportFunctions } from './zoom'
 import type { FlowHooks, FlowHooksEmit, FlowHooksOn } from './hooks'
 import type { EdgeChange, NodeChange, NodeDragItem } from './changes'
 import type { HandleType, StartHandle } from './handle'
@@ -18,7 +18,6 @@ export interface UpdateNodeDimensionsParams {
 export interface State extends Omit<FlowOptions, 'id' | 'modelValue'> {
   /** Event hooks, you can manipulate the triggers at your own peril */
   readonly hooks: FlowHooks
-  readonly instance: FlowInstance | null
 
   /** all stored nodes */
   nodes: GraphNode[]
@@ -121,7 +120,7 @@ export type SetState = (
 export type UpdateNodePosition = (dragItems: NodeDragItem[], changed: boolean, dragging: boolean) => void
 export type UpdateNodeDimensions = (updates: UpdateNodeDimensionsParams[]) => void
 
-export interface Actions {
+export interface Actions extends ViewportFunctions {
   /** parses elements (nodes + edges) and re-sets the state */
   setElements: SetElements
   /** parses nodes and re-sets the state */
@@ -164,6 +163,8 @@ export interface Actions {
   setInteractive: (isInteractive: boolean) => void
   /** set new state */
   setState: SetState
+  /** return an object of graph values (elements, viewpane transform) for storage and re-loading a graph */
+  toObject: () => FlowExportObject
 
   /** internal position updater, you probably don't want to use this */
   updateNodePositions: UpdateNodePosition
@@ -179,6 +180,8 @@ export interface Getters {
   getEdgeTypes: Record<keyof DefaultEdgeTypes | string, EdgeComponent>
   /** returns object containing current node types */
   getNodeTypes: Record<keyof DefaultNodeTypes | string, NodeComponent>
+  /** get all elements (filters hidden elements) */
+  getElements: FlowElements
   /** filters hidden nodes */
   getNodes: GraphNode[]
   /** filters hidden edges */

--- a/packages/vue-flow/src/types/store.ts
+++ b/packages/vue-flow/src/types/store.ts
@@ -1,5 +1,5 @@
 import type { CSSProperties, ComputedRef, ToRefs } from 'vue'
-import type { Dimensions, ElementData, Elements, FlowElements, FlowInstance, FlowOptions, SnapGrid, XYPosition } from './flow'
+import type { Dimensions, ElementData, Elements, FlowElements, FlowExportObject, FlowOptions, SnapGrid, XYPosition } from './flow'
 import type { DefaultEdgeTypes, DefaultNodeTypes, EdgeComponent, NodeComponent } from './components'
 import type { Connection, ConnectionLineType, ConnectionMode } from './connection'
 import type { DefaultEdgeOptions, Edge, GraphEdge } from './edge'

--- a/packages/vue-flow/src/types/zoom.ts
+++ b/packages/vue-flow/src/types/zoom.ts
@@ -20,7 +20,7 @@ export enum PanOnScrollMode {
   Horizontal = 'horizontal',
 }
 
-export interface ViewportFuncsOptions {
+export interface TransitionOptions {
   duration?: number
 }
 
@@ -34,32 +34,47 @@ export type FitViewParams = {
     y?: number
   }
   nodes?: string[]
-} & ViewportFuncsOptions
+} & TransitionOptions
 
-export interface FlowTransform {
+export interface ViewpaneTransform {
   x: number
   y: number
   zoom: number
 }
 
-export type SetCenterOptions = ViewportFuncsOptions & {
+export type SetCenterOptions = TransitionOptions & {
   zoom?: number
 }
 
-export type FitBoundsOptions = ViewportFuncsOptions & {
+export type FitBoundsOptions = TransitionOptions & {
   padding?: number
 }
 
+/** Fit the viewpane around visible nodes */
 export type FitView = (fitViewOptions?: FitViewParams) => void
-export type Project = (position: XYPosition) => XYPosition
-export type SetCenter = (x: number, y: number, options?: SetCenterOptions) => void
-export type FitBounds = (bounds: Rect, options?: FitBoundsOptions) => void
-export type ZoomInOut = (options?: ViewportFuncsOptions) => void
-export type ZoomTo = (zoomLevel: number, options?: ViewportFuncsOptions) => void
-export type GetTransform = () => FlowTransform
-export type SetTransform = (transform: FlowTransform, options?: ViewportFuncsOptions) => void
 
-export interface ViewportFuncs {
+/** project a position onto the viewpane, i.e. a mouse event clientX/clientY onto graph coordinates */
+export type Project = (position: XYPosition) => XYPosition
+
+/** set center of viewpane */
+export type SetCenter = (x: number, y: number, options?: SetCenterOptions) => void
+
+/** fit the viewpane around bounds */
+export type FitBounds = (bounds: Rect, options?: FitBoundsOptions) => void
+
+/** zoom in/out */
+export type ZoomInOut = (options?: TransitionOptions) => void
+
+/** zoom to a specific level */
+export type ZoomTo = (zoomLevel: number, options?: TransitionOptions) => void
+
+/** get current viewpane transform */
+export type GetTransform = () => ViewpaneTransform
+
+/** set current viewpane transform */
+export type SetTransform = (transform: ViewpaneTransform, options?: TransitionOptions) => void
+
+export interface ViewportFunctions {
   zoomIn: ZoomInOut
   zoomOut: ZoomInOut
   zoomTo: ZoomTo

--- a/packages/vue-flow/src/utils/changes.ts
+++ b/packages/vue-flow/src/utils/changes.ts
@@ -15,7 +15,6 @@ import type {
   NodeChange,
   NodeRemoveChange,
   NodeSelectionChange,
-  XYPosition,
 } from '~/types'
 
 function handleParentExpand(updateItem: GraphNode, parent: GraphNode) {

--- a/packages/vue-flow/src/utils/changes.ts
+++ b/packages/vue-flow/src/utils/changes.ts
@@ -15,6 +15,7 @@ import type {
   NodeChange,
   NodeRemoveChange,
   NodeSelectionChange,
+  XYPosition,
 } from '~/types'
 
 function handleParentExpand(updateItem: GraphNode, parent: GraphNode) {


### PR DESCRIPTION
# What's changed?

* Remove the `instance` property from store and merge viewport functions into `useVueFlow`
* Add `getElements` getter
* Rename types
* Deprecate `FlowInstance` type