### PR TITLE
refactor(nodes,edges): Remove `BaseElement` type

### DIFF
--- a/docs/.eslintrc.js
+++ b/docs/.eslintrc.js
@@ -1,7 +1,0 @@
-module.exports = {
-  rules: {
-    'no-use-before-define': 0,
-    'no-console': 0,
-  },
-  extends: ['../.eslintrc.js'],
-}

--- a/docs/components/home/Features.vue
+++ b/docs/components/home/Features.vue
@@ -25,13 +25,11 @@ watchDebounced([breakpoints.sm, breakpoints.md, breakpoints.lg, breakpoints.xl, 
     <div
       class="flex flex-col divide-y divide-gray-500 md:divide-y-0 gap-12 md:gap-24 lg:gap-36 max-w-9/12 md:max-w-11/12 lg:max-w-9/12 m-auto py-12 md:py-24 text-center md:text-left"
     >
-      <div ref="basic">
-        <XyzTransition appear-visible xyz="fade down ease-out-back">
-          <div class="flex flex-col md:flex-row gap-12 md:gap-24">
-            <Basic @pane="onLoad" />
-          </div>
-        </XyzTransition>
-      </div>
+      <XyzTransition appear-visible xyz="fade down ease-out-back">
+        <div class="flex flex-col md:flex-row gap-12 md:gap-24">
+          <Basic @pane="onLoad" />
+        </div>
+      </XyzTransition>
 
       <XyzTransition appear-visible xyz="fade down ease-out-back">
         <div class="flex flex-col-reverse md:flex-row flex-unwrap gap-12 md:gap-24">

--- a/docs/components/home/flows/Basic.vue
+++ b/docs/components/home/flows/Basic.vue
@@ -1,8 +1,11 @@
 <script lang="ts" setup>
-import { Background, ClassFunc, ConnectionLineType, Controls, GraphEdge, useVueFlow, VueFlow } from "@braks/vue-flow";
-import Cross from "~icons/mdi/window-close";
+import type { ClassFunc, GraphEdge, GraphNode, StyleFunc } from '@braks/vue-flow'
+import { Background, ConnectionLineType, Controls, VueFlow, useVueFlow } from '@braks/vue-flow'
+import Cross from '~icons/mdi/window-close'
 
-const getClass: ClassFunc = (el) => {
+const emit = defineEmits(['pane'])
+
+const getNodeClass: ClassFunc<GraphNode> = (el) => {
   const classes = ['font-semibold', '!border-2', 'transition-colors', 'duration-300', 'ease-in-out']
   if (el.selected)
     classes.push(
@@ -12,7 +15,18 @@ const getClass: ClassFunc = (el) => {
   return classes.join(' ')
 }
 
-const emit = defineEmits(['pane'])
+const getEdgeClass: ClassFunc<GraphEdge> = (el) => {
+  const classes = ['transition-colors duration-300', el.sourceNode.selected ? 'font-semibold' : '']
+  return classes.join(' ')
+}
+
+const getEdgeStyle: StyleFunc<GraphEdge> = (el) => {
+  const sourceNodeSelected = el.sourceNode.selected
+  return {
+    transition: 'stroke ease-in-out 300ms',
+    stroke: el.selected || sourceNodeSelected ? 'var(--secondary)' : '',
+  }
+}
 
 const { onPaneReady, onConnect, addEdges, viewport } = useVueFlow({
   connectionLineType: ConnectionLineType.SmoothStep,
@@ -26,21 +40,21 @@ const { onPaneReady, onConnect, addEdges, viewport } = useVueFlow({
       type: 'input',
       label: 'Start',
       position: { x: 250, y: 5 },
-      class: getClass,
+      class: getNodeClass,
     },
     {
       id: '2',
       label: 'Waypoint',
       position: { x: 100, y: 100 },
-      class: getClass,
+      class: getNodeClass,
     },
-    { id: '3', label: 'Waypoint', position: { x: 400, y: 100 }, class: getClass },
+    { id: '3', label: 'Waypoint', position: { x: 400, y: 100 }, class: getNodeClass },
     {
       id: '4',
       type: 'output',
       label: 'End',
       position: { x: 250, y: 225 },
-      class: getClass,
+      class: getNodeClass,
     },
     {
       id: 'e1-2',
@@ -48,29 +62,17 @@ const { onPaneReady, onConnect, addEdges, viewport } = useVueFlow({
       label: 'animated edge',
       target: '2',
       animated: true,
-      class: (el) => {
-        const classes = ['transition-colors duration-300', (<GraphEdge>el).sourceNode.selected ? 'font-semibold' : '']
-        return classes.join(' ')
-      },
-      style: (el) => {
-        const sourceNodeSelected = (<GraphEdge>el).sourceNode.selected
-        return {
-          transition: 'stroke ease-in-out 300ms',
-          stroke: el.selected || sourceNodeSelected ? 'var(--secondary)' : '',
-        }
-      },
+      class: getEdgeClass,
+      style: getEdgeStyle,
     },
     {
       id: 'e1-3',
       source: '1',
       target: '3',
       label: 'default edge',
-      class: (el) => {
-        const classes = ['transition-colors duration-300', (<GraphEdge>el).sourceNode.selected ? 'font-semibold' : '']
-        return classes.join(' ')
-      },
-      style: (el) => {
-        const sourceNodeSelected = (<GraphEdge>el).sourceNode.selected
+      class: getEdgeClass,
+      style: (el: GraphEdge) => {
+        const sourceNodeSelected = el.sourceNode.selected
         return {
           transition: 'stroke ease-in-out 300ms',
           stroke: el.selected || sourceNodeSelected ? 'red' : '',
@@ -83,37 +85,31 @@ const { onPaneReady, onConnect, addEdges, viewport } = useVueFlow({
       target: '4',
       type: 'step',
       animated: true,
-      class: (el) => {
-        const classes = ['transition-colors duration-300', (<GraphEdge>el).sourceNode.selected ? 'font-semibold' : '']
-        return classes.join(' ')
-      },
-      style: (el) => {
-        const sourceNodeSelected = (<GraphEdge>el).sourceNode.selected
-        return {
-          transition: 'stroke ease-in-out 300ms',
-          stroke: el.selected || sourceNodeSelected ? 'var(--secondary)' : '',
-        }
-      },
+      class: getEdgeClass,
+      style: getEdgeStyle,
     },
   ],
 })
 
 onPaneReady((i) => emit('pane', i))
 onConnect((param) => {
-  addEdges([{
-    ...param,
-    type: 'smoothstep',
-    animated: true,
-  }])
+  addEdges([
+    {
+      ...param,
+      type: 'smoothstep',
+      animated: true,
+    },
+  ])
 })
 </script>
+
 <template>
   <div class="md:max-w-1/3 flex flex-col justify-center">
     <div class="flex flex-col items-center md:items-start">
       <h1>Interactive Graphs</h1>
       <p>
-        Vue Flow comes with built-in features like zoom & pan and dedicated controls, single & multi-selections, draggable elements,
-        customizable nodes and edges and a bunch of event handlers.
+        Vue Flow comes with built-in features like zoom & pan and dedicated controls, single & multi-selections, draggable
+        elements, customizable nodes and edges and a bunch of event handlers.
       </p>
       <router-link class="button max-w-max" to="/guide/"> Documentation </router-link>
     </div>
@@ -123,7 +119,7 @@ onConnect((param) => {
   >
     <VueFlow class="basic">
       <Controls class="md:(!left-auto !right-[10px])" />
-      <Background pattern-color="#aaa" :gap="60">
+      <Background :gap="60">
         <template #pattern>
           <Cross :style="{ fontSize: `${8 * viewport.zoom || 1}px` }" class="text-[#10b981] opacity-50" />
         </template>
@@ -131,6 +127,7 @@ onConnect((param) => {
     </VueFlow>
   </div>
 </template>
+
 <style>
 .basic .vue-flow__node-input.selected .vue-flow__handle {
   @apply bg-green-500;

--- a/packages/vue-flow/src/types/edge.ts
+++ b/packages/vue-flow/src/types/edge.ts
@@ -1,5 +1,5 @@
 import type { CSSProperties, Component, VNode } from 'vue'
-import type { BaseElement, ElementData, Position } from './flow'
+import type { ClassFunc, ElementData, Position, StyleFunc, Styles } from './flow'
 import type { GraphNode } from './node'
 import type { DefaultEdgeTypes, EdgeComponent, EdgeTextProps } from './components'
 
@@ -42,9 +42,12 @@ export interface MarkerProps {
 
 export type EdgeMarkerType = string | MarkerType | EdgeMarker
 
-export interface Edge<Data = ElementData> extends BaseElement<Data> {
+export interface Edge<Data = ElementData> {
+  /** Unique edge id */
+  id: string
+  /** An edge label */
   label?: string | VNode | Component<EdgeTextProps>
-  /** node type, can be a default type or a custom type */
+  /** Edge type, can be a default type or a custom type */
   type?: keyof DefaultEdgeTypes | string
   /** Source node id */
   source: string
@@ -78,9 +81,16 @@ export interface Edge<Data = ElementData> extends BaseElement<Data> {
   updatable?: boolean
   /** Disable/enable selecting edge */
   selectable?: boolean
-
-  /** overwrites current edge type */
+  /** Additional class names, can be a string or a callback returning a string (receives current flow element) */
+  class?: string | ClassFunc<GraphEdge<Data>>
+  /** Additional styles, can be an object or a callback returning an object (receives current flow element) */
+  style?: Styles | StyleFunc<GraphEdge<Data>>
+  /** Is edge hidden */
+  hidden?: boolean
+  /** Overwrites current edge type */
   template?: EdgeComponent
+  /** Additional data that is passed to your custom components */
+  data?: Data
 }
 
 export type DefaultEdgeOptions = Omit<

--- a/packages/vue-flow/src/types/flow.ts
+++ b/packages/vue-flow/src/types/flow.ts
@@ -1,4 +1,4 @@
-import type { CSSProperties, Component, VNode } from 'vue'
+import type { CSSProperties } from 'vue'
 import type { DefaultEdgeOptions, Edge, GraphEdge } from './edge'
 import type { CoordinateExtent, GraphNode, Node } from './node'
 import type { ConnectionLineType, ConnectionMode } from './connection'
@@ -7,9 +7,13 @@ import type { DefaultEdgeTypes, DefaultNodeTypes, EdgeComponent, NodeComponent }
 
 export type ElementData = any
 
-/** an internal element  */
+/** A flow element (after parsing into state)  */
 export type FlowElement<Data = ElementData> = GraphNode<Data> | GraphEdge<Data>
 export type FlowElements<Data = ElementData> = FlowElement<Data>[]
+
+/** Initial elements (before parsing into state) */
+export type Element<Data = ElementData> = Node<Data> | Edge<Data>
+export type Elements<Data = ElementData> = Element<Data>[]
 
 export type CustomThemeVars = Record<string, string | number>
 export type CSSVars =
@@ -21,21 +25,8 @@ export type CSSVars =
   | '--vf-handle'
 export type ThemeVars = { [key in CSSVars]?: CSSProperties['color'] }
 export type Styles = CSSProperties & ThemeVars & CustomThemeVars
-export type ClassFunc<Data = ElementData> = (element: FlowElement<Data>) => string | void
-export type StyleFunc<Data = ElementData> = (element: FlowElement<Data>) => Styles | void
-
-/** base element props */
-export interface BaseElement<Data extends ElementData = ElementData> {
-  id: string
-  label?: string | VNode | Component
-  type?: string
-  data?: Data
-  class?: string | ClassFunc<Data>
-  style?: Styles | StyleFunc<Data>
-  hidden?: boolean
-}
-export type Element<Data = ElementData> = Node<Data> | Edge<Data>
-export type Elements<Data = ElementData> = Element<Data>[]
+export type ClassFunc<ElementType extends FlowElement = FlowElement> = (element: ElementType) => string | void
+export type StyleFunc<ElementType extends FlowElement = FlowElement> = (element: ElementType) => Styles | void
 
 /** Handle Positions */
 export enum Position {

--- a/packages/vue-flow/src/types/node.ts
+++ b/packages/vue-flow/src/types/node.ts
@@ -1,5 +1,5 @@
 import type { Component, VNode } from 'vue'
-import type { BaseElement, Dimensions, ElementData, Position, SnapGrid, XYPosition, XYZPosition } from './flow'
+import type { ClassFunc, Dimensions, ElementData, Position, SnapGrid, StyleFunc, Styles, XYPosition, XYZPosition } from './flow'
 import type { DefaultNodeTypes, NodeComponent } from './components'
 import type { HandleElement, ValidConnectionFunc } from './handle'
 
@@ -16,7 +16,11 @@ type WidthFunc = <Data = ElementData>(node: GraphNode<Data>) => number | string 
 // eslint-disable-next-line no-use-before-define
 type HeightFunc = <Data = ElementData>(node: GraphNode<Data>) => number | string | void
 
-export interface Node<Data = ElementData> extends BaseElement<Data> {
+export interface Node<Data = ElementData> {
+  /** Unique node id */
+  id: string
+  /** A node label */
+  label?: string | VNode | Component<NodeProps>
   /** initial node position x, y */
   position: XYPosition
   /** node type, can be a default type or a custom type */
@@ -56,8 +60,16 @@ export interface Node<Data = ElementData> extends BaseElement<Data> {
    */
   height?: number | string | HeightFunc
 
+  /** Additional class names, can be a string or a callback returning a string (receives current flow element) */
+  class?: string | ClassFunc<GraphNode<Data>>
+  /** Additional styles, can be an object or a callback returning an object (receives current flow element) */
+  style?: Styles | StyleFunc<GraphNode<Data>>
+  /** Is node hidden */
+  hidden?: boolean
   /** overwrites current node type */
   template?: NodeComponent
+  /** Additional data that is passed to your custom components */
+  data?: Data
 }
 
 export interface GraphNode<Data = ElementData> extends Node<Data> {


### PR DESCRIPTION
# What's changed?

* Remove `BaseElement` type
* Merge base element props into `Node` and `Edge` types
* Allow `ClassFunc` and `StyleFunc` types to specify what element type is used in callback