### PR TITLE
feat(vue-flow): add `autoConnect` option

### DIFF
--- a/docs/src/guide/vue-flow/config.md
+++ b/docs/src/guide/vue-flow/config.md
@@ -722,6 +722,58 @@ const elements = ref([
 
   Does not work for the `addEdge` utility!
 
+### auto-connect <Badge class="text-white" style="line-height: inherit" text="optional" vertical="top" />
+
+- Type: `boolean` | [`Connector`](/typedocs/types/Connector.html/)
+
+- Default: `false`
+
+- Details:
+
+  When connection is emitted, automatically create a new edge from params.
+
+  Also accepts a [`Connector`](/typedocs/types/Connector.html/) which returns an edge-like object or false (if creating an edge is not allowed).
+
+  This option can be used as a shorthand for `onConnect((params) => addEdges([params]))`.
+
+#### Examples
+
+##### Boolean value
+
+```vue:no-line-numbers{2}
+<template>
+  <VueFlow v-model="elements" auto-connect />
+</template>
+```
+
+#### [Connector](/typedocs/types/Connector.html/)
+
+```vue:no-line-numbers{6-18,22}
+<script setup>
+import { ref } from 'vue'
+
+const elements = ref([/** elements omitted for simplicity */])
+
+const connector = (params) => {
+  if (params.source.id === params.target.id) {
+    return false
+  }
+  
+  return {
+    id: `edge-${params.source.id}-${params.target.id}`,
+    source: params.source.id,
+    target: params.target.id,
+    label: `Edge ${params.source.id}-${params.target.id}`,
+    animated: true,
+  }
+}
+</script>
+
+<template>
+  <VueFlow v-model="elements" :auto-connect="connector" />
+</template>
+```
+
 ## Global Element Options
 
 ### only-render-visible-elements <Badge class="text-white" style="line-height: inherit" text="optional" vertical="top" />

--- a/packages/vue-flow/src/container/VueFlow/VueFlow.vue
+++ b/packages/vue-flow/src/container/VueFlow/VueFlow.vue
@@ -36,6 +36,7 @@ const props = withDefaults(defineProps<FlowProps>(), {
   fitViewOnInit: undefined,
   connectOnClick: undefined,
   connectionLineStyle: undefined,
+  autoConnect: undefined,
 })
 
 const emit = defineEmits<{

--- a/packages/vue-flow/src/store/state.ts
+++ b/packages/vue-flow/src/store/state.ts
@@ -101,6 +101,7 @@ const defaultState = (): State => ({
   hooks: createHooks(),
 
   applyDefault: true,
+  autoConnect: false,
 
   fitViewOnInit: false,
   noDragClassName: 'nodrag',

--- a/packages/vue-flow/src/types/connection.ts
+++ b/packages/vue-flow/src/types/connection.ts
@@ -2,6 +2,7 @@ import type { CSSProperties } from 'vue'
 import type { Position } from './flow'
 import type { GraphNode } from './node'
 import type { HandleElement, HandleType } from './handle'
+import type { Edge } from './edge'
 
 /** Connection line types (same as default edge types */
 export enum ConnectionLineType {
@@ -22,6 +23,10 @@ export interface Connection {
   /** Target handle id */
   targetHandle: string | null
 }
+
+export type Connector = (
+  params: Connection,
+) => Promise<(Connection & Partial<Edge>) | false> | ((Connection & Partial<Edge>) | false)
 
 /** The source nodes params when connection is initiated */
 export interface OnConnectStartParams {

--- a/packages/vue-flow/src/types/flow.ts
+++ b/packages/vue-flow/src/types/flow.ts
@@ -1,7 +1,7 @@
 import type { CSSProperties } from 'vue'
 import type { DefaultEdgeOptions, Edge, GraphEdge } from './edge'
 import type { CoordinateExtent, GraphNode, Node } from './node'
-import type { ConnectionLineType, ConnectionMode } from './connection'
+import type { ConnectionLineType, ConnectionMode, Connector } from './connection'
 import type { KeyCode, PanOnScrollMode } from './zoom'
 import type { DefaultEdgeTypes, DefaultNodeTypes, EdgeComponent, NodeComponent } from './components'
 
@@ -122,6 +122,8 @@ export interface FlowProps {
   connectOnClick?: boolean
   /** apply default change handlers for position, dimensions, adding/removing nodes. set this to false if you want to apply the changes manually */
   applyDefault?: boolean
+  /** automatically create an edge when connection is triggered */
+  autoConnect?: boolean | Connector
   noDragClassName?: string
   noWheelClassName?: string
   noPanClassName?: string

--- a/packages/vue-flow/src/types/store.ts
+++ b/packages/vue-flow/src/types/store.ts
@@ -1,7 +1,7 @@
 import type { CSSProperties, ComputedRef, ToRefs } from 'vue'
 import type { Dimensions, ElementData, Elements, FlowElements, FlowExportObject, FlowOptions, SnapGrid, XYPosition } from './flow'
 import type { DefaultEdgeTypes, DefaultNodeTypes, EdgeComponent, NodeComponent } from './components'
-import type { Connection, ConnectionLineType, ConnectionMode } from './connection'
+import type { Connection, ConnectionLineType, ConnectionMode, Connector } from './connection'
 import type { DefaultEdgeOptions, Edge, GraphEdge } from './edge'
 import type { CoordinateExtent, GraphNode, Node } from './node'
 import type { D3Selection, D3Zoom, D3ZoomHandler, KeyCode, PanOnScrollMode, Viewport, ViewportFunctions } from './zoom'
@@ -88,6 +88,7 @@ export interface State extends Omit<FlowOptions, 'id' | 'modelValue'> {
 
   initialized: boolean
   applyDefault: boolean
+  autoConnect: boolean | Connector
 
   fitViewOnInit?: boolean
 


### PR DESCRIPTION
# What's changed?

* auto-connect allows to easily enable the default add edge change handler (shown in the examples)
* allow auto-connect to be a function that returns false when connection is cancelled or partial edge when it should be created

# To-Do
- [x] Add documentation for auto-connect feature