### PR TITLE
refactor(nodes): add updateNodeInternals action

### DIFF
--- a/docs/components/examples/teleport/TeleportableNode.vue
+++ b/docs/components/examples/teleport/TeleportableNode.vue
@@ -1,6 +1,5 @@
 <script setup>
 import { Handle, Position } from '@braks/vue-flow'
-import { watch } from 'vue'
 import { useTransition } from './useTransition.js'
 
 const props = defineProps({
@@ -8,17 +7,9 @@ const props = defineProps({
     type: String,
     required: true,
   },
-  nodeElement: {
-    type: Object,
-    required: false,
-  },
 })
 
-const { animation, transition, teleport, nodeElement, onClick } = useTransition(props.id, props.nodeElement)
-
-watch(props, () => {
-  if (props.nodeElement) nodeElement.value = props.nodeElement
-})
+const { animation, transition, teleport, onClick } = useTransition(props.id)
 
 const changeAnimation = () => {
   animation.value = animation.value === 'fade' ? 'shrink' : 'fade'

--- a/docs/components/examples/teleport/useTransition.js
+++ b/docs/components/examples/teleport/useTransition.js
@@ -8,12 +8,11 @@ import { nextTick, ref } from 'vue'
  * Otherwise edges do not connect properly
  */
 export const useTransition = (id) => {
-  const nodeElement = ref()
   const animation = ref('fade')
   const transition = ref(false)
   const teleport = ref(null)
 
-  const { updateNodeDimensions, getNode, edges } = useVueFlow()
+  const { updateNodeInternals, getNode, edges } = useVueFlow()
 
   /**
    * specify a selector to teleport to
@@ -48,7 +47,7 @@ export const useTransition = (id) => {
         setTimeout(() => {
           // if destination is null, defer hiding edges until node is teleported back
           if (!destination) {
-            updateNodeDimensions([{ id, nodeElement: nodeElement.value, forceUpdate: true }])
+            updateNodeInternals([id])
 
             nextTick(() => {
               onFinish()
@@ -103,7 +102,6 @@ export const useTransition = (id) => {
     animation,
     transition,
     teleport,
-    nodeElement,
     onClick,
   }
 }

--- a/examples/vite/src/CustomNode/CustomNode.vue
+++ b/examples/vite/src/CustomNode/CustomNode.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import type { Elements, Node, SnapGrid } from '@braks/vue-flow'
-import { ConnectionMode, Controls, MiniMap, Position, VueFlow, isEdge, useVueFlow } from '@braks/vue-flow/src/index'
+import { ConnectionMode, Controls, MiniMap, Position, VueFlow, isEdge, useVueFlow } from '@braks/vue-flow'
 import ColorSelectorNode from './ColorSelectorNode.vue'
 
 const elements = ref<Elements>([])

--- a/packages/vue-flow/src/components/Nodes/NodeWrapper.vue
+++ b/packages/vue-flow/src/components/Nodes/NodeWrapper.vue
@@ -30,6 +30,7 @@ const {
   multiSelectionActive,
   removeSelectedElements,
   getSelectedNodes,
+  onUpdateNodeInternals,
 } = $(useVueFlow())
 
 const node = $computed(() => getNode(id)!)
@@ -65,6 +66,29 @@ watch(
   },
   { flush: 'post' },
 )
+
+onUpdateNodeInternals((updateIds) => {
+  if (updateIds.includes(id)) {
+    updateNodeDimensions([{ id, nodeElement: nodeElement.value, forceUpdate: true }])
+
+    const xyzPos = {
+      x: node.position.x,
+      y: node.position.y,
+      z: node.computedPosition.z ? node.computedPosition.z : node.selected ? 1000 : 0,
+    }
+
+    if (parentNode) {
+      if (parentNode.computedPosition.x && parentNode.computedPosition.y) {
+        node.computedPosition = getXYZPos(
+          { x: parentNode.computedPosition.x, y: parentNode.computedPosition.y, z: parentNode.computedPosition.z! },
+          xyzPos,
+        )
+      } else {
+        node.computedPosition = xyzPos
+      }
+    }
+  }
+})
 
 onBeforeUnmount(() => observer.stop())
 
@@ -206,7 +230,6 @@ export default {
       :source-position="node.sourcePosition"
       :label="node.label"
       :drag-handle="node.dragHandle"
-      :node-element="nodeElement"
     />
   </div>
 </template>

--- a/packages/vue-flow/src/components/Nodes/NodeWrapper.vue
+++ b/packages/vue-flow/src/components/Nodes/NodeWrapper.vue
@@ -219,7 +219,6 @@ export default {
       :selected="!!node.selected"
       :connectable="connectable"
       :position="node.position"
-      :computed-position="node.computedPosition"
       :dimensions="node.dimensions"
       :is-valid-target-pos="node.isValidTargetPos"
       :is-valid-source-pos="node.isValidSourcePos"

--- a/packages/vue-flow/src/container/VueFlow/VueFlow.vue
+++ b/packages/vue-flow/src/container/VueFlow/VueFlow.vue
@@ -84,6 +84,7 @@ const emit = defineEmits<{
   (event: 'edgeUpdateStart', edgeMouseEvent: MouseEvent): void
   (event: 'edgeUpdate', edgeMouseEvent: MouseEvent): void
   (event: 'edgeUpdateEnd', edgeMouseEvent: MouseEvent): void
+  (event: 'updateNodeInternals', id: string): void
 
   /** v-model event definitions */
   (event: 'update:modelValue', value: FlowElements): void

--- a/packages/vue-flow/src/store/actions.ts
+++ b/packages/vue-flow/src/store/actions.ts
@@ -339,6 +339,10 @@ export default (state: State, getters: ComputedGetters): Actions => {
     )
   }
 
+  const updateNodeInternals: Actions['updateNodeInternals'] = (ids) => {
+    state.hooks.updateNodeInternals.trigger(ids)
+  }
+
   let zoomPanHelper: ReturnType<typeof useZoomPanHelper>
 
   state.hooks.paneReady.on(({ id }) => {
@@ -416,6 +420,7 @@ export default (state: State, getters: ComputedGetters): Actions => {
     },
     project: (position) => pointToRendererPoint(position, state.viewport, state.snapToGrid, state.snapGrid),
     toObject,
+    updateNodeInternals,
     $reset: () => {
       setState(useState())
     },

--- a/packages/vue-flow/src/store/hooks.ts
+++ b/packages/vue-flow/src/store/hooks.ts
@@ -42,6 +42,7 @@ export const createHooks = (): FlowHooks => ({
   edgeUpdateStart: createEventHook(),
   edgeUpdate: createEventHook(),
   edgeUpdateEnd: createEventHook(),
+  updateNodeInternals: createEventHook(),
 })
 
 const bind = (emit: Emits, hooks: FlowHooks) => {

--- a/packages/vue-flow/src/types/hooks.ts
+++ b/packages/vue-flow/src/types/hooks.ts
@@ -75,6 +75,7 @@ export interface FlowEvents {
   edgeUpdateStart: EdgeMouseEvent
   edgeUpdate: EdgeUpdateEvent
   edgeUpdateEnd: EdgeMouseEvent
+  updateNodeInternals: string[]
 }
 
 export type FlowHooks = Readonly<{

--- a/packages/vue-flow/src/types/store.ts
+++ b/packages/vue-flow/src/types/store.ts
@@ -119,6 +119,7 @@ export type SetState = (
 ) => void
 export type UpdateNodePosition = (dragItems: NodeDragItem[], changed: boolean, dragging: boolean) => void
 export type UpdateNodeDimensions = (updates: UpdateNodeDimensionsParams[]) => void
+export type UpdateNodeInternals = (nodeIds: string[]) => void
 
 export interface Actions extends ViewportFunctions {
   /** parses elements (nodes + edges) and re-sets the state */
@@ -165,6 +166,8 @@ export interface Actions extends ViewportFunctions {
   setState: SetState
   /** return an object of graph values (elements, viewpane transform) for storage and re-loading a graph */
   toObject: () => FlowExportObject
+  /** force update node internal data, if handle bounds are incorrect, you might want to use this */
+  updateNodeInternals: UpdateNodeInternals
 
   /** internal position updater, you probably don't want to use this */
   updateNodePositions: UpdateNodePosition


### PR DESCRIPTION
# What's changed?

* remove node element as prop from custom node components
* add `updateNodeInternals` action to force update node dimensions and position (i.e. transitions etc.)
* add `updateNodeInternals` hook to trigger update in nodes
