### PR TITLE
feat(vue-flow): add `getParentTree` graph utility

### DIFF
--- a/packages/vue-flow/src/index.ts
+++ b/packages/vue-flow/src/index.ts
@@ -26,6 +26,7 @@ export {
   graphPosToZoomedPos,
   getNodesInside,
   getMarkerId,
+  getParentTree,
 } from './utils/graph'
 
 /**

--- a/packages/vue-flow/src/utils/graph.ts
+++ b/packages/vue-flow/src/utils/graph.ts
@@ -340,3 +340,31 @@ export const getMarkerId = (marker: EdgeMarkerType | undefined): string => {
     .map((key) => `${key}=${marker[<keyof EdgeMarkerType>key]}`)
     .join('&')
 }
+
+export const getParentTree = (node: GraphNode | string, elements: Elements): Record<string, GraphNode> => {
+  const tree: Record<string, any> = {}
+
+  const elementIds = elements.map((el) => el.id)
+
+  const getParent = (node: GraphNode): GraphNode | undefined => {
+    if (!node.parentNode) return undefined
+
+    const parent = elements.find((el) => el.id === node.parentNode) as GraphNode
+
+    if (!parent) return undefined
+
+    if (tree[node.id]) return undefined
+
+    tree[node.id] = parent
+
+    return parent
+  }
+
+  while (true) {
+    const parent = typeof node === 'string' ? getParent(elements[elementIds.indexOf(node)] as GraphNode) : getParent(node)
+    if (!parent) break
+    node = parent
+  }
+
+  return tree
+}


### PR DESCRIPTION
# What's changed?

* export `getParentTree` graph utility
* creates an object of parents from a starting node as `Record<string, GraphNode>`

