### PR TITLE
release!: 1.0.0 w. scope `@vue-flow`

### DIFF
--- a/docs/components/Repl.vue
+++ b/docs/components/Repl.vue
@@ -1,13 +1,13 @@
 <script lang="ts" setup>
 import { Repl, ReplStore } from '@vue/repl'
-import { useVueFlow } from '@braks/vue-flow'
+import { useVueFlow } from '@vue-flow/renderer'
 import '@vue/repl/style.css'
 import { exampleImports } from './examples'
 
 const props = defineProps<{ example: keyof typeof exampleImports; mainFile?: string; dependencies?: Record<string, string> }>()
 const { vueFlowVersion } = useVueFlow()
-let css = `@import 'https://cdn.jsdelivr.net/npm/@braks/vue-flow@${vueFlowVersion.value}/dist/style.css';
-@import 'https://cdn.jsdelivr.net/npm/@braks/vue-flow@${vueFlowVersion.value}/dist/theme-default.css';
+let css = `@import 'https://cdn.jsdelivr.net/npm/@vue-flow/renderer@${vueFlowVersion.value}/dist/style.css';
+@import 'https://cdn.jsdelivr.net/npm/@vue-flow/renderer@${vueFlowVersion.value}/dist/theme-default.css';
 
 html,
 body,
@@ -68,7 +68,7 @@ onMounted(async () => {
   // pre-set import map
   store.setImportMap({
     imports: {
-      '@braks/vue-flow': `${location.origin}/vue-flow.es.js`,
+      '@vue-flow/renderer': `${location.origin}/vue-flow.es.js`,
     },
   })
 })

--- a/docs/components/examples/basic/App.vue
+++ b/docs/components/examples/basic/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Background, Controls, MiniMap, VueFlow, isNode, useVueFlow } from '@braks/vue-flow'
+import { Background, Controls, MiniMap, VueFlow, isNode, useVueFlow } from '@vue-flow/renderer'
 import { ref } from 'vue'
 import { initialElements } from './initial-elements.js'
 

--- a/docs/components/examples/basic/initial-elements.js
+++ b/docs/components/examples/basic/initial-elements.js
@@ -1,4 +1,4 @@
-import { MarkerType } from '@braks/vue-flow'
+import { MarkerType } from '@vue-flow/renderer'
 
 /**
  * You can pass elements together as a v-model value

--- a/docs/components/examples/connectionline/App.vue
+++ b/docs/components/examples/connectionline/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Background, BackgroundVariant, VueFlow } from '@braks/vue-flow'
+import { Background, BackgroundVariant, VueFlow } from '@vue-flow/renderer'
 import { ref } from 'vue'
 import CustomConnectionLine from './CustomConnectionLine.vue'
 

--- a/docs/components/examples/custom-node/App.vue
+++ b/docs/components/examples/custom-node/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ConnectionMode, MiniMap, Position, VueFlow, useVueFlow } from '@braks/vue-flow'
+import { ConnectionMode, MiniMap, Position, VueFlow, useVueFlow } from '@vue-flow/renderer'
 import { computed, h, onMounted, ref } from 'vue'
 import ColorSelectorNode from './CustomNode.vue'
 import { presets } from './presets.js'

--- a/docs/components/examples/custom-node/CustomNode.vue
+++ b/docs/components/examples/custom-node/CustomNode.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Handle, Position } from '@braks/vue-flow'
+import { Handle, Position } from '@vue-flow/renderer'
 import { computed } from 'vue'
 import { presets } from './presets.js'
 

--- a/docs/components/examples/dnd/App.vue
+++ b/docs/components/examples/dnd/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { VueFlow, useVueFlow } from '@braks/vue-flow'
+import { VueFlow, useVueFlow } from '@vue-flow/renderer'
 import Sidebar from './Sidebar.vue'
 
 let id = 0

--- a/docs/components/examples/edges/App.vue
+++ b/docs/components/examples/edges/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Background, Controls, MarkerType, MiniMap, VueFlow } from '@braks/vue-flow'
+import { Background, Controls, MarkerType, MiniMap, VueFlow } from '@vue-flow/renderer'
 import { h, ref } from 'vue'
 import CustomEdge from './CustomEdge.vue'
 import CustomEdge2 from './CustomEdge2.vue'

--- a/docs/components/examples/edges/CustomEdge.vue
+++ b/docs/components/examples/edges/CustomEdge.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { getBezierPath, getEdgeCenter, useVueFlow } from '@braks/vue-flow'
+import { getBezierPath, getEdgeCenter, useVueFlow } from '@vue-flow/renderer'
 import { computed } from 'vue'
 
 const props = defineProps({

--- a/docs/components/examples/edges/CustomEdge2.vue
+++ b/docs/components/examples/edges/CustomEdge2.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { EdgeText, getBezierPath, getEdgeCenter } from '@braks/vue-flow'
+import { EdgeText, getBezierPath, getEdgeCenter } from '@vue-flow/renderer'
 import { computed } from 'vue'
 
 const props = defineProps({

--- a/docs/components/examples/empty/App.vue
+++ b/docs/components/examples/empty/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Background, BackgroundVariant, Controls, MiniMap, VueFlow, useVueFlow } from '@braks/vue-flow'
+import { Background, BackgroundVariant, Controls, MiniMap, VueFlow, useVueFlow } from '@vue-flow/renderer'
 
 const { nodes, addNodes, edges, addEdges, onConnect, onPaneReady, onNodeDragStop, dimensions } = useVueFlow()
 

--- a/docs/components/examples/hidden/App.vue
+++ b/docs/components/examples/hidden/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Controls, MiniMap, VueFlow, useVueFlow } from '@braks/vue-flow'
+import { Controls, MiniMap, VueFlow, useVueFlow } from '@vue-flow/renderer'
 import { ref, watchEffect } from 'vue'
 
 const isHidden = ref(false)

--- a/docs/components/examples/horizontal/App.vue
+++ b/docs/components/examples/horizontal/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Background, Controls, MiniMap, VueFlow, useVueFlow } from '@braks/vue-flow'
+import { Background, Controls, MiniMap, VueFlow, useVueFlow } from '@vue-flow/renderer'
 import { ref } from 'vue'
 import { initialElements } from './initial-elements.js'
 

--- a/docs/components/examples/horizontal/initial-elements.js
+++ b/docs/components/examples/horizontal/initial-elements.js
@@ -1,4 +1,4 @@
-import { MarkerType, Position } from '@braks/vue-flow'
+import { MarkerType, Position } from '@vue-flow/renderer'
 
 export const initialElements = [
   {

--- a/docs/components/examples/interaction/App.vue
+++ b/docs/components/examples/interaction/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { VueFlow } from '@braks/vue-flow'
+import { VueFlow } from '@vue-flow/renderer'
 import { ref } from 'vue'
 import InteractionControls from './InteractionControls.vue'
 

--- a/docs/components/examples/interaction/InteractionControls.vue
+++ b/docs/components/examples/interaction/InteractionControls.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { useVueFlow } from '@braks/vue-flow'
+import { useVueFlow } from '@vue-flow/renderer'
 import { ref } from 'vue'
 
 const {

--- a/docs/components/examples/multi/Flow.vue
+++ b/docs/components/examples/multi/Flow.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Background, VueFlow, isNode } from '@braks/vue-flow'
+import { Background, VueFlow, isNode } from '@vue-flow/renderer'
 import { ref } from 'vue'
 
 const elements = ref([

--- a/docs/components/examples/nested/App.vue
+++ b/docs/components/examples/nested/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Background, ConnectionMode, Controls, MiniMap, VueFlow, useVueFlow } from '@braks/vue-flow'
+import { Background, ConnectionMode, Controls, MiniMap, VueFlow, useVueFlow } from '@vue-flow/renderer'
 import { onMounted } from 'vue'
 
 const { onConnect, nodes, edges, addEdges, addNodes } = useVueFlow({

--- a/docs/components/examples/save-restore/App.vue
+++ b/docs/components/examples/save-restore/App.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { VueFlow } from '@braks/vue-flow'
+import { VueFlow } from '@vue-flow/renderer'
 import { ref } from 'vue'
 import Controls from './Controls.vue'
 

--- a/docs/components/examples/save-restore/Controls.vue
+++ b/docs/components/examples/save-restore/Controls.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { useVueFlow } from '@braks/vue-flow'
+import { useVueFlow } from '@vue-flow/renderer'
 
 const flowKey = 'example-flow'
 

--- a/docs/components/examples/stress/App.vue
+++ b/docs/components/examples/stress/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { VueFlow, isNode, useVueFlow } from '@braks/vue-flow'
+import { VueFlow, isNode, useVueFlow } from '@vue-flow/renderer'
 import { nextTick, ref } from 'vue'
 import { getElements } from './utils.js'
 

--- a/docs/components/examples/teleport/App.vue
+++ b/docs/components/examples/teleport/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { VueFlow } from '@braks/vue-flow'
+import { VueFlow } from '@vue-flow/renderer'
 import { ref } from 'vue'
 import Sidebar from './Sidebar.vue'
 import TeleportableNode from './TeleportableNode.vue'

--- a/docs/components/examples/teleport/TeleportableNode.vue
+++ b/docs/components/examples/teleport/TeleportableNode.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Handle, Position } from '@braks/vue-flow'
+import { Handle, Position } from '@vue-flow/renderer'
 import { useTransition } from './useTransition.js'
 
 const props = defineProps({

--- a/docs/components/examples/teleport/useTransition.js
+++ b/docs/components/examples/teleport/useTransition.js
@@ -1,4 +1,4 @@
-import { getConnectedEdges, useVueFlow } from '@braks/vue-flow'
+import { getConnectedEdges, useVueFlow } from '@vue-flow/renderer'
 import { nextTick, ref } from 'vue'
 
 /**

--- a/docs/components/examples/update-edge/App.vue
+++ b/docs/components/examples/update-edge/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ConnectionMode, Controls, VueFlow, addEdge, updateEdge } from '@braks/vue-flow'
+import { ConnectionMode, Controls, VueFlow, addEdge, updateEdge } from '@vue-flow/renderer'
 import { ref } from 'vue'
 
 const elements = ref([

--- a/docs/components/examples/update-node/App.vue
+++ b/docs/components/examples/update-node/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { VueFlow, useVueFlow } from '@braks/vue-flow'
+import { VueFlow, useVueFlow } from '@vue-flow/renderer'
 import { reactive } from 'vue'
 
 const defaultLabel = '-'

--- a/docs/components/examples/validation/App.vue
+++ b/docs/components/examples/validation/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { VueFlow, addEdge } from '@braks/vue-flow'
+import { VueFlow, addEdge } from '@vue-flow/renderer'
 import { ref } from 'vue'
 import CustomInput from './CustomInput.vue'
 import CustomNode from './CustomNode.vue'

--- a/docs/components/examples/validation/CustomInput.vue
+++ b/docs/components/examples/validation/CustomInput.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Handle, Position } from '@braks/vue-flow'
+import { Handle, Position } from '@vue-flow/renderer'
 
 const props = defineProps({
   isValidTargetPos: {

--- a/docs/components/examples/validation/CustomNode.vue
+++ b/docs/components/examples/validation/CustomNode.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Handle, Position } from '@braks/vue-flow'
+import { Handle, Position } from '@vue-flow/renderer'
 
 const props = defineProps({
   id: {

--- a/docs/components/home/Banner.vue
+++ b/docs/components/home/Banner.vue
@@ -4,7 +4,7 @@ import Star from '~icons/carbon/star'
 import Download from '~icons/carbon/download'
 
 const githubData = await $fetch('https://api.github.com/repos/bcakmakoglu/vue-flow?page=$i&per_page=100')
-const npmData = await $fetch('https://api.npmjs.org/downloads/point/last-month/@braks/vue-flow')
+const npmData = await $fetch('https://api.npmjs.org/downloads/point/last-month/@vue-flow/renderer')
 </script>
 
 <template>

--- a/docs/components/home/Features.vue
+++ b/docs/components/home/Features.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
-import type { VueFlowStore } from '@braks/vue-flow'
+import type { VueFlowStore } from '@vue-flow/renderer'
 
 const breakpoints = useBreakpoints(breakpointsTailwind)
 

--- a/docs/components/home/edges/Custom.vue
+++ b/docs/components/home/edges/Custom.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { computed } from 'vue'
-import type { EdgeProps, MarkerType, Position } from '@braks/vue-flow'
-import { getBezierPath } from '@braks/vue-flow'
+import type { EdgeProps, MarkerType, Position } from '@vue-flow/renderer'
+import { getBezierPath } from '@vue-flow/renderer'
 
 interface CustomEdgeProps extends EdgeProps {
   source: string

--- a/docs/components/home/flows/Additional.vue
+++ b/docs/components/home/flows/Additional.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { ref } from 'vue'
-import type { Elements } from '@braks/vue-flow'
-import { Background, Controls, MiniMap, Position, VueFlow, useVueFlow } from '@braks/vue-flow'
+import type { Elements } from '@vue-flow/renderer'
+import { Background, Controls, MiniMap, Position, VueFlow, useVueFlow } from '@vue-flow/renderer'
 
 const emit = defineEmits(['pane'])
 

--- a/docs/components/home/flows/Basic.vue
+++ b/docs/components/home/flows/Basic.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { ClassFunc, GraphEdge, GraphNode, StyleFunc } from '@braks/vue-flow'
-import { Background, ConnectionLineType, Controls, VueFlow, useVueFlow } from '@braks/vue-flow'
+import type { ClassFunc, GraphEdge, GraphNode, StyleFunc } from '@vue-flow/renderer'
+import { Background, ConnectionLineType, Controls, VueFlow, useVueFlow } from '@vue-flow/renderer'
 import Cross from '~icons/mdi/window-close'
 
 const emit = defineEmits(['pane'])

--- a/docs/components/home/flows/Intro.vue
+++ b/docs/components/home/flows/Intro.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { Background, Handle, Position, VueFlow, useVueFlow } from '@braks/vue-flow'
+import { Background, Handle, Position, VueFlow, useVueFlow } from '@vue-flow/renderer'
 import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
 import confetti from 'canvas-confetti'
 import colors from 'windicss/colors'

--- a/docs/components/home/flows/Nested.vue
+++ b/docs/components/home/flows/Nested.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { Background, ConnectionMode, Controls, VueFlow, useVueFlow } from '@braks/vue-flow'
+import { Background, ConnectionMode, Controls, VueFlow, useVueFlow } from '@vue-flow/renderer'
 import { breakpointsTailwind } from '@vueuse/core'
 
 const emit = defineEmits(['pane'])

--- a/docs/components/home/flows/RGB.vue
+++ b/docs/components/home/flows/RGB.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { MiniMapNodeFunc } from '@braks/vue-flow'
-import { Background, BackgroundVariant, Controls, MiniMap, VueFlow, useVueFlow } from '@braks/vue-flow'
+import type { MiniMapNodeFunc } from '@vue-flow/renderer'
+import { Background, BackgroundVariant, Controls, MiniMap, VueFlow, useVueFlow } from '@vue-flow/renderer'
 import { breakpointsTailwind } from '@vueuse/core'
 import CustomEdge from '../edges/Custom.vue'
 import RGBNode from '../nodes/Input.vue'

--- a/docs/components/home/nodes/Input.vue
+++ b/docs/components/home/nodes/Input.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { NodeProps } from '@braks/vue-flow'
-import { Handle, Position } from '@braks/vue-flow'
+import type { NodeProps } from '@vue-flow/renderer'
+import { Handle, Position } from '@vue-flow/renderer'
 
 interface RGBNodeProps extends NodeProps {
   data: {

--- a/docs/components/home/nodes/Output.vue
+++ b/docs/components/home/nodes/Output.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { NodeProps } from '@braks/vue-flow'
-import { Handle, Position } from '@braks/vue-flow'
+import type { NodeProps } from '@vue-flow/renderer'
+import { Handle, Position } from '@vue-flow/renderer'
 
 interface RBGOutputNodeProps extends NodeProps {
   rgb: string

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@animxyz/core": "^0.6.6",
     "@animxyz/vue3": "^0.6.6",
-    "@braks/vue-flow": "workspace:*",
+    "@vue-flow/renderer": "workspace:*",
     "@stackblitz/sdk": "^1.6.0",
     "@vue/repl": "1.1.2",
     "blobity": "^0.1.7",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "docs",
+  "name": "@vue-flow/docs",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/docs/src/.vuepress/copy-plugin.ts
+++ b/docs/src/.vuepress/copy-plugin.ts
@@ -8,11 +8,11 @@ export function copyVueFlowPlugin(): Plugin {
     generateBundle() {
       const filePath = resolve(
         __dirname,
-        '../../node_modules/@braks/vue-flow/dist/vue-flow.es.js'
+        '../../node_modules/@vue-flow/renderer/dist/vue-flow.es.js'
       )
       if (!existsSync(filePath)) {
         throw new Error(
-          `@braks/vue-flow/dist/vue-flow.es.js not built. ` +
+          `@vue-flow/renderer/dist/vue-flow.es.js not built. ` +
           `Run "pnpm -w build" first.`
         )
       }

--- a/docs/src/.vuepress/theme/index.ts
+++ b/docs/src/.vuepress/theme/index.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'path'
 import { defaultTheme, SidebarConfigArray, Theme } from 'vuepress'
 import { path } from '@vuepress/utils'
-import { useVueFlow } from '@braks/vue-flow'
+import { useVueFlow } from '@vue-flow/renderer'
 import { readdirSync, statSync } from 'fs'
 
 const { vueFlowVersion } = useVueFlow()

--- a/docs/src/.vuepress/theme/layouts/default.vue
+++ b/docs/src/.vuepress/theme/layouts/default.vue
@@ -1,8 +1,8 @@
 <script>
 import 'virtual:windi.css'
 import '@animxyz/core'
-import '@braks/vue-flow/dist/style.css'
-import '@braks/vue-flow/dist/theme-default.css'
+import '@vue-flow/renderer/dist/style.css'
+import '@vue-flow/renderer/dist/theme-default.css'
 import '../../assets/index.css'
 </script>
 <script setup>

--- a/e2e/cypress/integration/1-store/setElements.spec.ts
+++ b/e2e/cypress/integration/1-store/setElements.spec.ts
@@ -1,5 +1,5 @@
-import type { Edge, Node, SetState, VueFlowStore } from '@braks/vue-flow'
-import { isEdge, isNode, useVueFlow } from '@braks/vue-flow'
+import type { Edge, Node, SetState, VueFlowStore } from '@vue-flow/renderer'
+import { isEdge, isNode, useVueFlow } from '@vue-flow/renderer'
 import { getElements } from '../../../../examples/vite/src/Stress/utils'
 
 describe('test store action setElements', () => {

--- a/e2e/cypress/integration/1-store/setState.spec.ts
+++ b/e2e/cypress/integration/1-store/setState.spec.ts
@@ -1,6 +1,6 @@
 import { isRef } from 'vue'
-import type { State } from '@braks/vue-flow'
-import { useVueFlow } from '@braks/vue-flow'
+import type { State } from '@vue-flow/renderer'
+import { useVueFlow } from '@vue-flow/renderer'
 
 describe('test store state', () => {
   let store = useVueFlow()

--- a/e2e/cypress/integration/2-flow/container.spec.ts
+++ b/e2e/cypress/integration/2-flow/container.spec.ts
@@ -1,8 +1,8 @@
 import { mount } from '@cypress/vue'
-import type { Elements } from '@braks/vue-flow'
-import { VueFlow, isEdge, isNode } from '@braks/vue-flow'
-import '@braks/vue-flow/dist/style.css'
-import '@braks/vue-flow/dist/theme-default.css'
+import type { Elements } from '@vue-flow/renderer'
+import { VueFlow, isEdge, isNode } from '@vue-flow/renderer'
+import '@vue-flow/renderer/dist/style.css'
+import '@vue-flow/renderer/dist/theme-default.css'
 
 describe('Render VueFlow', () => {
   const elements: Elements = [

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,7 +7,7 @@
     "open": "cypress open-ct"
   },
   "dependencies": {
-    "@braks/vue-flow": "workspace:*"
+    "@vue-flow/renderer": "workspace:*"
   },
   "devDependencies": {
     "@cypress/vite-dev-server": "^2.2.1",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tests",
+  "name": "@vue-flow/tests",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/examples/nuxt3/app.vue
+++ b/examples/nuxt3/app.vue
@@ -3,8 +3,8 @@
 </template>
 
 <style>
-@import '@braks/vue-flow/dist/style.css';
-@import '@braks/vue-flow/dist/theme-default.css';
+@import '@vue-flow/renderer/dist/style.css';
+@import '@vue-flow/renderer/dist/theme-default.css';
 
 html,
 body,

--- a/examples/nuxt3/components/BasicFlow.vue
+++ b/examples/nuxt3/components/BasicFlow.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Background, Controls, MiniMap, VueFlow, isNode, useVueFlow } from '@braks/vue-flow'
+import { Background, Controls, MiniMap, VueFlow, isNode, useVueFlow } from '@vue-flow/renderer'
 import { ref } from 'vue'
 import { initialElements } from './initial-elements.js'
 

--- a/examples/nuxt3/components/initial-elements.js
+++ b/examples/nuxt3/components/initial-elements.js
@@ -1,4 +1,4 @@
-import { MarkerType } from '@braks/vue-flow'
+import { MarkerType } from '@vue-flow/renderer'
 
 /**
  * You can pass elements together as a v-model value

--- a/examples/nuxt3/package.json
+++ b/examples/nuxt3/package.json
@@ -9,7 +9,7 @@
     "dev": "nuxt dev"
   },
   "dependencies": {
-    "@braks/vue-flow": "workspace:*"
+    "@vue-flow/renderer": "workspace:*"
   },
   "devDependencies": {
     "nuxt": "3.0.0-rc.3"

--- a/examples/nuxt3/package.json
+++ b/examples/nuxt3/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nuxt3-examples",
+  "name": "@vue-flow/nuxt3-examples",
   "version": "0.0.1",
   "description": "Vue Flow Nuxt3 Example",
   "productName": "Nuxt3 App",

--- a/examples/quasar/package.json
+++ b/examples/quasar/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "quasar-examples",
+  "name": "@vue-flow/quasar-examples",
   "version": "0.0.1",
   "description": "Vue Flow Quasar Examples",
   "productName": "Quasar App",

--- a/examples/quasar/package.json
+++ b/examples/quasar/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint --ext .js,.ts,.vue ./"
   },
   "dependencies": {
-    "@braks/vue-flow": "workspace:*",
+    "@vue-flow/renderer": "workspace:*",
     "@quasar/extras": "^1.0.0",
     "quasar": "^2.6.0",
     "vue": "^3.2.15",

--- a/examples/quasar/src/components/BasicFlow.vue
+++ b/examples/quasar/src/components/BasicFlow.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Background, Controls, MiniMap, VueFlow, isNode, useVueFlow } from '@braks/vue-flow'
+import { Background, Controls, MiniMap, VueFlow, isNode, useVueFlow } from '@vue-flow/renderer'
 import { ref } from 'vue'
 import { initialElements } from './initial-elements.js'
 

--- a/examples/quasar/src/components/CustomizedFlow.vue
+++ b/examples/quasar/src/components/CustomizedFlow.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Background, Controls, MiniMap, VueFlow, isNode, useVueFlow } from '@braks/vue-flow'
+import { Background, Controls, MiniMap, VueFlow, isNode, useVueFlow } from '@vue-flow/renderer'
 import { ref } from 'vue'
 import { initialElements } from './customized-elements.js'
 

--- a/examples/quasar/src/components/customized-elements.js
+++ b/examples/quasar/src/components/customized-elements.js
@@ -1,4 +1,4 @@
-import { MarkerType } from '@braks/vue-flow'
+import { MarkerType } from '@vue-flow/renderer'
 
 /**
  * You can pass elements together as a v-model value

--- a/examples/quasar/src/components/initial-elements.js
+++ b/examples/quasar/src/components/initial-elements.js
@@ -1,4 +1,4 @@
-import { MarkerType } from '@braks/vue-flow'
+import { MarkerType } from '@vue-flow/renderer'
 
 /**
  * You can pass elements together as a v-model value

--- a/examples/quasar/src/css/app.css
+++ b/examples/quasar/src/css/app.css
@@ -1,6 +1,6 @@
 /* app global css */
-@import "@braks/vue-flow/dist/style.css";
-@import "@braks/vue-flow/dist/theme-default.css";
+@import "@vue-flow/renderer/dist/style.css";
+@import "@vue-flow/renderer/dist/theme-default.css";
 
 html,
 body,

--- a/examples/vite/index.css
+++ b/examples/vite/index.css
@@ -1,8 +1,8 @@
 /* import the required styles */
-@import 'node_modules/@braks/vue-flow/dist/style.css';
+@import 'node_modules/@vue-flow/renderer/dist/style.css';
 
 /* import the default theme (optional) */
-@import 'node_modules/@braks/vue-flow/dist/theme-default.css';
+@import 'node_modules/@vue-flow/renderer/dist/theme-default.css';
 
 body {
   color: #111;

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vite-examples",
+  "name": "@vue-flow/vite-examples",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint --ext \".js,.jsx,.ts,.tsx\" --fix --ignore-path .gitignore ."
   },
   "dependencies": {
-    "@braks/vue-flow": "workspace:*"
+    "@vue-flow/renderer": "workspace:*"
   },
   "devDependencies": {
     "@types/dagre": "^0.7.46",

--- a/examples/vite/src/Basic/Basic.vue
+++ b/examples/vite/src/Basic/Basic.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { Elements } from '@braks/vue-flow'
-import { Background, Controls, MiniMap, VueFlow, isNode, useVueFlow } from '@braks/vue-flow'
+import type { Elements } from '@vue-flow/renderer'
+import { Background, Controls, MiniMap, VueFlow, isNode, useVueFlow } from '@vue-flow/renderer'
 
 const elements = ref<Elements>([
   { id: '1', type: 'input', label: 'Node 1', position: { x: 250, y: 5 }, class: 'light' },

--- a/examples/vite/src/Basic/BasicOptionsAPI.vue
+++ b/examples/vite/src/Basic/BasicOptionsAPI.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
-import type { Elements, FlowEvents, VueFlowStore } from '@braks/vue-flow'
-import { Background, Controls, MiniMap, VueFlow, addEdge, isNode } from '@braks/vue-flow'
+import type { Elements, FlowEvents, VueFlowStore } from '@vue-flow/renderer'
+import { Background, Controls, MiniMap, VueFlow, addEdge, isNode } from '@vue-flow/renderer'
 
 export default defineComponent({
   name: 'BasicOptionsAPI',

--- a/examples/vite/src/Basic/ResizableNode.vue
+++ b/examples/vite/src/Basic/ResizableNode.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { Position, ValidConnectionFunc } from '@braks/vue-flow'
-import { Handle } from '@braks/vue-flow'
+import type { Position, ValidConnectionFunc } from '@vue-flow/renderer'
+import { Handle } from '@vue-flow/renderer'
 
 interface Props {
   id: string

--- a/examples/vite/src/CustomConnectionLine/CustomConnectionLine.vue
+++ b/examples/vite/src/CustomConnectionLine/CustomConnectionLine.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { Elements } from '@braks/vue-flow'
-import { Background, BackgroundVariant, VueFlow } from '@braks/vue-flow'
+import type { Elements } from '@vue-flow/renderer'
+import { Background, BackgroundVariant, VueFlow } from '@vue-flow/renderer'
 import ConnectionLine from './ConnectionLine.vue'
 
 const elements = ref<Elements>([

--- a/examples/vite/src/CustomNode/ColorSelectorNode.vue
+++ b/examples/vite/src/CustomNode/ColorSelectorNode.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import type { CSSProperties } from 'vue'
-import type { Connection, Edge, NodeProps } from '@braks/vue-flow'
-import { Handle, Position } from '@braks/vue-flow'
+import type { Connection, Edge, NodeProps } from '@vue-flow/renderer'
+import { Handle, Position } from '@vue-flow/renderer'
 
 interface ColorSelectorNodeProps extends NodeProps {
   data: {

--- a/examples/vite/src/CustomNode/CustomNode.vue
+++ b/examples/vite/src/CustomNode/CustomNode.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { Elements, Node, SnapGrid } from '@braks/vue-flow'
-import { ConnectionMode, Controls, MiniMap, Position, VueFlow, isEdge, useVueFlow } from '@braks/vue-flow'
+import type { Elements, Node, SnapGrid } from '@vue-flow/renderer'
+import { ConnectionMode, Controls, MiniMap, Position, VueFlow, isEdge, useVueFlow } from '@vue-flow/renderer'
 import ColorSelectorNode from './ColorSelectorNode.vue'
 
 const elements = ref<Elements>([])

--- a/examples/vite/src/DragNDrop/DnD.vue
+++ b/examples/vite/src/DragNDrop/DnD.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { Node } from '@braks/vue-flow'
-import { VueFlow, useVueFlow } from '@braks/vue-flow'
+import type { Node } from '@vue-flow/renderer'
+import { VueFlow, useVueFlow } from '@vue-flow/renderer'
 import Sidebar from './Sidebar.vue'
 
 let id = 0

--- a/examples/vite/src/EdgeTypes/EdgeTypesExample.vue
+++ b/examples/vite/src/EdgeTypes/EdgeTypesExample.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { VueFlowStore } from '@braks/vue-flow'
-import { Controls, MiniMap, VueFlow } from '@braks/vue-flow'
+import type { VueFlowStore } from '@vue-flow/renderer'
+import { Controls, MiniMap, VueFlow } from '@vue-flow/renderer'
 import { getElements } from './utils'
 
 const onLoad = (flowInstance: VueFlowStore) => {

--- a/examples/vite/src/EdgeTypes/utils.ts
+++ b/examples/vite/src/EdgeTypes/utils.ts
@@ -1,5 +1,5 @@
-import type { Elements } from '@braks/vue-flow'
-import { Position } from '@braks/vue-flow'
+import type { Elements } from '@vue-flow/renderer'
+import { Position } from '@vue-flow/renderer'
 
 const nodeWidth = 80
 const nodeGapWidth = nodeWidth * 2

--- a/examples/vite/src/Edges/CustomEdge.vue
+++ b/examples/vite/src/Edges/CustomEdge.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { EdgeProps, Position } from '@braks/vue-flow'
-import { getBezierPath, getEdgeCenter, useVueFlow } from '@braks/vue-flow'
+import type { EdgeProps, Position } from '@vue-flow/renderer'
+import { getBezierPath, getEdgeCenter, useVueFlow } from '@vue-flow/renderer'
 
 interface CustomEdgeProps<T = any> extends EdgeProps<T> {
   id: string

--- a/examples/vite/src/Edges/CustomEdge2.vue
+++ b/examples/vite/src/Edges/CustomEdge2.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { EdgeProps, Position } from '@braks/vue-flow'
-import { EdgeText, getBezierPath, getEdgeCenter, getMarkerId } from '@braks/vue-flow'
+import type { EdgeProps, Position } from '@vue-flow/renderer'
+import { EdgeText, getBezierPath, getEdgeCenter, getMarkerId } from '@vue-flow/renderer'
 
 interface CustomEdgeProps extends EdgeProps {
   source: string

--- a/examples/vite/src/Edges/EdgesExample.vue
+++ b/examples/vite/src/Edges/EdgesExample.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { Edge, Node } from '@braks/vue-flow'
-import { Background, Controls, MarkerType, MiniMap, VueFlow, useVueFlow } from '@braks/vue-flow'
+import type { Edge, Node } from '@vue-flow/renderer'
+import { Background, Controls, MarkerType, MiniMap, VueFlow, useVueFlow } from '@vue-flow/renderer'
 import CustomEdge from './CustomEdge.vue'
 import CustomEdge2 from './CustomEdge2.vue'
 import CustomLabel from './CustomLabel.vue'

--- a/examples/vite/src/Empty/EmptyExample.vue
+++ b/examples/vite/src/Empty/EmptyExample.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { Node } from '@braks/vue-flow'
-import { Background, BackgroundVariant, Controls, MiniMap, VueFlow, useVueFlow } from '@braks/vue-flow/src/index'
+import type { Node } from '@vue-flow/renderer'
+import { Background, BackgroundVariant, Controls, MiniMap, VueFlow, useVueFlow } from '@vue-flow/renderer/src/index'
 
 const { nodes, addNodes, edges, addEdges, onConnect, onPaneReady, onNodeDragStop, dimensions } = useVueFlow()
 

--- a/examples/vite/src/FloatingEdges/FloatingConnectionLine.vue
+++ b/examples/vite/src/FloatingEdges/FloatingConnectionLine.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { GraphNode, Position } from '@braks/vue-flow'
-import { getBezierPath } from '@braks/vue-flow'
+import type { GraphNode, Position } from '@vue-flow/renderer'
+import { getBezierPath } from '@vue-flow/renderer'
 import { getEdgeParams } from './floating-edge-utils'
 
 interface FloatingConnectionLineProps {

--- a/examples/vite/src/FloatingEdges/FloatingEdge.vue
+++ b/examples/vite/src/FloatingEdges/FloatingEdge.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import type { CSSProperties } from 'vue'
-import type { EdgeProps, GraphNode, MarkerType } from '@braks/vue-flow'
-import { getBezierPath } from '@braks/vue-flow'
+import type { EdgeProps, GraphNode, MarkerType } from '@vue-flow/renderer'
+import { getBezierPath } from '@vue-flow/renderer'
 import { getEdgeParams } from './floating-edge-utils'
 
 interface FloatingEdgeProps extends EdgeProps {

--- a/examples/vite/src/FloatingEdges/FloatingEdges.vue
+++ b/examples/vite/src/FloatingEdges/FloatingEdges.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { Background, Controls, MarkerType, MiniMap, VueFlow, useVueFlow } from '@braks/vue-flow'
+import { Background, Controls, MarkerType, MiniMap, VueFlow, useVueFlow } from '@vue-flow/renderer'
 import FloatingEdge from './FloatingEdge.vue'
 import FloatingConnectionLine from './FloatingConnectionLine.vue'
 import { createElements } from './floating-edge-utils'

--- a/examples/vite/src/FloatingEdges/floating-edge-utils.ts
+++ b/examples/vite/src/FloatingEdges/floating-edge-utils.ts
@@ -1,5 +1,5 @@
-import type { Edge, GraphNode, XYPosition } from '@braks/vue-flow'
-import { MarkerType, Position } from '@braks/vue-flow'
+import type { Edge, GraphNode, XYPosition } from '@vue-flow/renderer'
+import { MarkerType, Position } from '@vue-flow/renderer'
 
 // this helper function returns the intersection point
 // of the line between the center of the intersectionNode and the target node

--- a/examples/vite/src/Hidden/HiddenExample.vue
+++ b/examples/vite/src/Hidden/HiddenExample.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { Controls, MiniMap, VueFlow, useVueFlow } from '@braks/vue-flow'
+import { Controls, MiniMap, VueFlow, useVueFlow } from '@vue-flow/renderer'
 
 const isHidden = ref(false)
 

--- a/examples/vite/src/Interaction/InteractionExample.vue
+++ b/examples/vite/src/Interaction/InteractionExample.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { Controls, MiniMap, VueFlow, useVueFlow } from '@braks/vue-flow'
+import { Controls, MiniMap, VueFlow, useVueFlow } from '@vue-flow/renderer'
 
 const {
   nodesDraggable,

--- a/examples/vite/src/Layouting/LayoutingExample.vue
+++ b/examples/vite/src/Layouting/LayoutingExample.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import dagre from 'dagre'
-import type { CoordinateExtent, Elements } from '@braks/vue-flow'
-import { ConnectionMode, Controls, Position, VueFlow, isNode } from '@braks/vue-flow'
+import type { CoordinateExtent, Elements } from '@vue-flow/renderer'
+import { ConnectionMode, Controls, Position, VueFlow, isNode } from '@vue-flow/renderer'
 import initialElements from './initial-elements'
 
 const dagreGraph = new dagre.graphlib.Graph()

--- a/examples/vite/src/Layouting/initial-elements.ts
+++ b/examples/vite/src/Layouting/initial-elements.ts
@@ -1,4 +1,4 @@
-import type { Elements, XYPosition } from '@braks/vue-flow'
+import type { Elements, XYPosition } from '@vue-flow/renderer'
 
 const position: XYPosition = { x: 0, y: 0 }
 

--- a/examples/vite/src/MultiFlows/Flow.vue
+++ b/examples/vite/src/MultiFlows/Flow.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { Elements } from '@braks/vue-flow'
-import { Background, VueFlow } from '@braks/vue-flow'
+import type { Elements } from '@vue-flow/renderer'
+import { Background, VueFlow } from '@vue-flow/renderer'
 const initialElements: Elements = [
   { id: '1', type: 'input', label: 'Node 1', position: { x: 250, y: 5 }, class: 'light' },
   { id: '2', label: 'Node 2', position: { x: 100, y: 100 }, class: 'light' },

--- a/examples/vite/src/Nesting/GroupNode.vue
+++ b/examples/vite/src/Nesting/GroupNode.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import { Handle, Position, getNodesInside, useVueFlow } from '@braks/vue-flow'
-import type { NodeProps } from '@braks/vue-flow'
+import { Handle, Position, getNodesInside, useVueFlow } from '@vue-flow/renderer'
+import type { NodeProps } from '@vue-flow/renderer'
 
 const props = defineProps<NodeProps>()
 const { onNodeDragStop, getNodes, viewport } = useVueFlow()

--- a/examples/vite/src/Nesting/Nesting.vue
+++ b/examples/vite/src/Nesting/Nesting.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { Background, ConnectionMode, Controls, MiniMap, VueFlow, useVueFlow } from '@braks/vue-flow'
+import { Background, ConnectionMode, Controls, MiniMap, VueFlow, useVueFlow } from '@vue-flow/renderer'
 
 const { onConnect, nodes, edges, addEdges, addNodes } = useVueFlow({
   fitViewOnInit: true,

--- a/examples/vite/src/NodeTypeChange/NodeTypeChangeExample.vue
+++ b/examples/vite/src/NodeTypeChange/NodeTypeChangeExample.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { Connection, Edge, Elements, VueFlowStore } from '@braks/vue-flow'
-import { Position, VueFlow, addEdge, isEdge } from '@braks/vue-flow'
+import type { Connection, Edge, Elements, VueFlowStore } from '@vue-flow/renderer'
+import { Position, VueFlow, addEdge, isEdge } from '@vue-flow/renderer'
 
 const initialElements: Elements = [
   {

--- a/examples/vite/src/Overview/Overview.vue
+++ b/examples/vite/src/Overview/Overview.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { Connection, Edge, Elements, FlowEvents, VueFlowStore, FlowTransform, Node, SnapGrid } from '@braks/vue-flow'
-import { Background, Controls, MarkerType, MiniMap, VueFlow, addEdge } from '@braks/vue-flow'
+import type { Connection, Edge, Elements, FlowEvents, VueFlowStore, FlowTransform, Node, SnapGrid } from '@vue-flow/renderer'
+import { Background, Controls, MarkerType, MiniMap, VueFlow, addEdge } from '@vue-flow/renderer'
 
 const onNodeDragStart = (e: FlowEvents['nodeDragStart']) => console.log('drag start', e)
 const onNodeDrag = (e: FlowEvents['nodeDrag']) => console.log('drag', e)

--- a/examples/vite/src/Provider/ProviderExample.vue
+++ b/examples/vite/src/Provider/ProviderExample.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { Elements, VueFlowStore } from '@braks/vue-flow'
-import { ConnectionMode, Controls, VueFlow, useVueFlow } from '@braks/vue-flow'
+import type { Elements, VueFlowStore } from '@vue-flow/renderer'
+import { ConnectionMode, Controls, VueFlow, useVueFlow } from '@vue-flow/renderer'
 import Sidebar from './Sidebar.vue'
 
 const onLoad = (flowInstance: VueFlowStore) => console.log('flow loaded:', flowInstance)

--- a/examples/vite/src/Provider/Sidebar.vue
+++ b/examples/vite/src/Provider/Sidebar.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { useVueFlow } from '@braks/vue-flow'
+import { useVueFlow } from '@vue-flow/renderer'
 const { nodesSelectionActive, addSelectedNodes, getNodes, viewport } = useVueFlow()
 
 const selectAll = () => {

--- a/examples/vite/src/RGBFlow/RGBFlow.vue
+++ b/examples/vite/src/RGBFlow/RGBFlow.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { templateRef } from '@vueuse/core'
-import type { Elements, VueFlowStore } from '@braks/vue-flow'
-import { VueFlow } from '@braks/vue-flow'
+import type { Elements, VueFlowStore } from '@vue-flow/renderer'
+import { VueFlow } from '@vue-flow/renderer'
 import RGBNode from './RGBNode.vue'
 import RGBOutputNode from './RGBOutputNode.vue'
 

--- a/examples/vite/src/RGBFlow/RGBNode.vue
+++ b/examples/vite/src/RGBFlow/RGBNode.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import type { CSSProperties } from 'vue'
-import type { NodeProps } from '@braks/vue-flow'
-import { Handle, Position } from '@braks/vue-flow'
+import type { NodeProps } from '@vue-flow/renderer'
+import { Handle, Position } from '@vue-flow/renderer'
 
 interface RGBNodeProps extends NodeProps {
   data: {

--- a/examples/vite/src/RGBFlow/RGBOutputNode.vue
+++ b/examples/vite/src/RGBFlow/RGBOutputNode.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { NodeProps } from '@braks/vue-flow'
-import { Handle, Position } from '@braks/vue-flow'
+import type { NodeProps } from '@vue-flow/renderer'
+import { Handle, Position } from '@vue-flow/renderer'
 
 interface RBGOutputNodeProps extends NodeProps {
   rgb: string

--- a/examples/vite/src/SaveRestore/Controls.vue
+++ b/examples/vite/src/SaveRestore/Controls.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { FlowExportObject, Node } from '@braks/vue-flow'
-import { useVueFlow, useZoomPanHelper } from '@braks/vue-flow'
+import type { FlowExportObject, Node } from '@vue-flow/renderer'
+import { useVueFlow, useZoomPanHelper } from '@vue-flow/renderer'
 
 const flowKey = 'example-flow'
 const state = useStorage<FlowExportObject>(flowKey, {

--- a/examples/vite/src/SaveRestore/SaveRestoreExample.vue
+++ b/examples/vite/src/SaveRestore/SaveRestoreExample.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { Elements } from '@braks/vue-flow'
-import { VueFlow } from '@braks/vue-flow'
+import type { Elements } from '@vue-flow/renderer'
+import { VueFlow } from '@vue-flow/renderer'
 import Controls from './Controls.vue'
 
 const initialElements: Elements = [

--- a/examples/vite/src/Stress/StressExample.vue
+++ b/examples/vite/src/Stress/StressExample.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { VueFlow, useVueFlow } from '@braks/vue-flow'
+import { VueFlow, useVueFlow } from '@vue-flow/renderer'
 import { getElements } from './utils'
 
 const { nodes, edges } = getElements(10, 10)

--- a/examples/vite/src/Stress/utils.ts
+++ b/examples/vite/src/Stress/utils.ts
@@ -1,4 +1,4 @@
-import type { Edge, Node } from '@braks/vue-flow'
+import type { Edge, Node } from '@vue-flow/renderer'
 
 export function getElements(xElements = 10, yElements = 10) {
   const initialNodes: Node[] = []

--- a/examples/vite/src/Switch/SwitchExample.vue
+++ b/examples/vite/src/Switch/SwitchExample.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { Elements } from '@braks/vue-flow'
-import { VueFlow } from '@braks/vue-flow'
+import type { Elements } from '@vue-flow/renderer'
+import { VueFlow } from '@vue-flow/renderer'
 
 const elementsA: Elements = [
   { id: '1a', type: 'input', label: 'Node 1', position: { x: 250, y: 5 }, class: 'light' },

--- a/examples/vite/src/Unidirectional/CustomNode.vue
+++ b/examples/vite/src/Unidirectional/CustomNode.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import type { CSSProperties } from 'vue'
-import { Handle, Position } from '@braks/vue-flow'
+import { Handle, Position } from '@vue-flow/renderer'
 
 interface Props {
   id: string

--- a/examples/vite/src/Unidirectional/UnidirectionalExample.vue
+++ b/examples/vite/src/Unidirectional/UnidirectionalExample.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { Elements, Node } from '@braks/vue-flow'
-import { ConnectionLineType, ConnectionMode, MarkerType, VueFlow, useZoomPanHelper } from '@braks/vue-flow'
+import type { Elements, Node } from '@vue-flow/renderer'
+import { ConnectionLineType, ConnectionMode, MarkerType, VueFlow, useZoomPanHelper } from '@vue-flow/renderer'
 import CustomNode from './CustomNode.vue'
 
 const initialElements: Elements = [

--- a/examples/vite/src/UpdatableEdge/UpdatableEdgeExample.vue
+++ b/examples/vite/src/UpdatableEdge/UpdatableEdgeExample.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { Connection, Edge, Elements, FlowEvents, VueFlowStore } from '@braks/vue-flow'
-import { ConnectionMode, Controls, VueFlow, addEdge, updateEdge } from '@braks/vue-flow'
+import type { Connection, Edge, Elements, FlowEvents, VueFlowStore } from '@vue-flow/renderer'
+import { ConnectionMode, Controls, VueFlow, addEdge, updateEdge } from '@vue-flow/renderer'
 
 const initialElements: Elements = [
   {

--- a/examples/vite/src/UpdateNode/UpdateNodeExample.vue
+++ b/examples/vite/src/UpdateNode/UpdateNodeExample.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { Elements } from '@braks/vue-flow'
-import { VueFlow } from '@braks/vue-flow'
+import type { Elements } from '@vue-flow/renderer'
+import { VueFlow } from '@vue-flow/renderer'
 
 const initialElements: Elements = [
   { id: '1', label: '-', position: { x: 100, y: 100 } },

--- a/examples/vite/src/Validation/CustomInput.vue
+++ b/examples/vite/src/Validation/CustomInput.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { ValidConnectionFunc } from '@braks/vue-flow'
-import { Handle, Position } from '@braks/vue-flow'
+import type { ValidConnectionFunc } from '@vue-flow/renderer'
+import { Handle, Position } from '@vue-flow/renderer'
 
 interface CustomInputProps {
   isValidTargetPos: ValidConnectionFunc

--- a/examples/vite/src/Validation/CustomNode.vue
+++ b/examples/vite/src/Validation/CustomNode.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { NodeProps, ValidConnectionFunc } from '@braks/vue-flow'
-import { Handle, Position } from '@braks/vue-flow'
+import type { NodeProps, ValidConnectionFunc } from '@vue-flow/renderer'
+import { Handle, Position } from '@vue-flow/renderer'
 
 interface CustomNodeProps extends NodeProps {
   id: string

--- a/examples/vite/src/Validation/ValidationExample.vue
+++ b/examples/vite/src/Validation/ValidationExample.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { Connection, OnConnectStartParams, VueFlowStore } from '@braks/vue-flow'
-import { VueFlow, useVueFlow } from '@braks/vue-flow'
+import type { Connection, OnConnectStartParams, VueFlowStore } from '@vue-flow/renderer'
+import { VueFlow, useVueFlow } from '@vue-flow/renderer'
 import CustomInput from './CustomInput.vue'
 import CustomNode from './CustomNode.vue'
 

--- a/examples/vite/vite.config.ts
+++ b/examples/vite/vite.config.ts
@@ -24,6 +24,6 @@ export default defineConfig({
     }),
   ],
   optimizeDeps: {
-    exclude: ['@braks/vue-flow'],
+    exclude: ['@vue-flow/renderer'],
   },
 })

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@braks/vue-flow-monorepo",
+  "name": "@vue-flow/monorepo",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/packages/pathfinding-edge/example/App.vue
+++ b/packages/pathfinding-edge/example/App.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { Connection, Edge, Elements } from '@braks/vue-flow'
-import { Background, VueFlow, addEdge } from '@braks/vue-flow'
+import type { Connection, Edge, Elements } from '@vue-flow/renderer'
+import { Background, VueFlow, addEdge } from '@vue-flow/renderer'
 import { ref } from 'vue'
 import initialElements from './elements'
 import { PathFindingEdge, PerfectArrow } from '~/index'
@@ -31,8 +31,8 @@ const onConnect = (params: Edge | Connection) => (elements.value = addEdge(param
 </template>
 
 <style>
-@import '@braks/vue-flow/dist/style.css';
-@import '@braks/vue-flow/dist/theme-default.css';
+@import '@vue-flow/renderer/dist/style.css';
+@import '@vue-flow/renderer/dist/theme-default.css';
 
 html,
 body,

--- a/packages/pathfinding-edge/example/elements.ts
+++ b/packages/pathfinding-edge/example/elements.ts
@@ -1,5 +1,5 @@
-import type { EdgeMarkerType, Elements } from '@braks/vue-flow'
-import { MarkerType } from '@braks/vue-flow'
+import type { EdgeMarkerType, Elements } from '@vue-flow/renderer'
+import { MarkerType } from '@vue-flow/renderer'
 
 const markerEnd: EdgeMarkerType = MarkerType.Arrow
 

--- a/packages/pathfinding-edge/package.json
+++ b/packages/pathfinding-edge/package.json
@@ -34,7 +34,7 @@
     "perfect-arrows": "^0.3.7"
   },
   "devDependencies": {
-    "@braks/vue-flow": "workspace:*",
+    "@vue-flow/renderer": "workspace:*",
     "@types/pathfinding": "^0.0.5",
     "@vitejs/plugin-vue": "^2.3.3",
     "ts-patch": "^2.0.1",
@@ -45,7 +45,7 @@
     "vue-tsc": "^0.35.0"
   },
   "peerDependencies": {
-    "@braks/vue-flow": "^0.4.15",
+    "@vue-flow/renderer": "^0.4.15",
     "vue": "^3.2.25"
   },
   "publishConfig": {

--- a/packages/pathfinding-edge/package.json
+++ b/packages/pathfinding-edge/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@braks/vue-flow-pathfinding-edge",
+  "name": "@vue-flow/pathfinding-edge",
   "version": "0.2.2",
   "private": false,
   "repository": {

--- a/packages/pathfinding-edge/src/arrow/PerfectArrow.vue
+++ b/packages/pathfinding-edge/src/arrow/PerfectArrow.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { EdgeText, getEdgeCenter } from '@braks/vue-flow'
+import { EdgeText, getEdgeCenter } from '@vue-flow/renderer'
 import type { CSSProperties } from 'vue'
 import { getArrow } from 'perfect-arrows'
 import type { PerfectArrowProps } from '../types'

--- a/packages/pathfinding-edge/src/edge/PathFindingEdge.vue
+++ b/packages/pathfinding-edge/src/edge/PathFindingEdge.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { Position } from '@braks/vue-flow'
-import { BezierEdge, EdgeText, getEdgeCenter, useVueFlow } from '@braks/vue-flow'
+import type { Position } from '@vue-flow/renderer'
+import { BezierEdge, EdgeText, getEdgeCenter, useVueFlow } from '@vue-flow/renderer'
 import type { PathFindingEdgeProps } from '../types'
 import { createGrid, gridRatio } from './createGrid'
 import { drawSmoothLinePath } from './drawSvgPath'

--- a/packages/pathfinding-edge/src/edge/createGrid.ts
+++ b/packages/pathfinding-edge/src/edge/createGrid.ts
@@ -1,5 +1,5 @@
 import { Grid } from 'pathfinding'
-import type { Position } from '@braks/vue-flow'
+import type { Position } from '@vue-flow/renderer'
 import { getNextPointFromPosition, guaranteeWalkablePath } from './guaranteeWalkablePath'
 import { graphToGridPoint } from './pointConversion'
 import { round } from './utils'

--- a/packages/pathfinding-edge/src/edge/drawSvgPath.ts
+++ b/packages/pathfinding-edge/src/edge/drawSvgPath.ts
@@ -1,4 +1,4 @@
-import type { XYPosition } from '@braks/vue-flow'
+import type { XYPosition } from '@vue-flow/renderer'
 
 /**
  * Draws an SVG path from a list of points, using straight lines.

--- a/packages/pathfinding-edge/src/edge/generatePath.ts
+++ b/packages/pathfinding-edge/src/edge/generatePath.ts
@@ -1,6 +1,6 @@
 import { AStarFinder, DiagonalMovement, Util } from 'pathfinding'
 import type { Grid, Heuristic } from 'pathfinding'
-import type { XYPosition } from '@braks/vue-flow'
+import type { XYPosition } from '@vue-flow/renderer'
 
 // https://www.npmjs.com/package/pathfinding#advanced-usage
 declare module 'pathfinding' {

--- a/packages/pathfinding-edge/src/edge/getBoundingBoxes.ts
+++ b/packages/pathfinding-edge/src/edge/getBoundingBoxes.ts
@@ -1,4 +1,4 @@
-import type { GraphNode, XYPosition } from '@braks/vue-flow'
+import type { GraphNode, XYPosition } from '@vue-flow/renderer'
 import { roundDown, roundUp } from './utils'
 
 export interface NodeBoundingBox {

--- a/packages/pathfinding-edge/src/edge/guaranteeWalkablePath.ts
+++ b/packages/pathfinding-edge/src/edge/guaranteeWalkablePath.ts
@@ -1,5 +1,5 @@
 import type { Grid } from 'pathfinding'
-import type { Position, XYPosition } from '@braks/vue-flow'
+import type { Position, XYPosition } from '@vue-flow/renderer'
 
 type Direction = 'top' | 'bottom' | 'left' | 'right'
 

--- a/packages/pathfinding-edge/src/edge/pointConversion.ts
+++ b/packages/pathfinding-edge/src/edge/pointConversion.ts
@@ -1,4 +1,4 @@
-import type { XYPosition } from '@braks/vue-flow'
+import type { XYPosition } from '@vue-flow/renderer'
 
 const gridRatio = 10
 

--- a/packages/pathfinding-edge/src/types.ts
+++ b/packages/pathfinding-edge/src/types.ts
@@ -1,4 +1,4 @@
-import type { EdgeProps, Position } from '@braks/vue-flow'
+import type { EdgeProps, Position } from '@vue-flow/renderer'
 import type { CSSProperties } from 'vue'
 import type { ArrowOptions } from 'perfect-arrows'
 

--- a/packages/resize-rotate-node/example/App.vue
+++ b/packages/resize-rotate-node/example/App.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { Connection, Edge, Elements } from '@braks/vue-flow'
-import { Background, Controls, MiniMap, VueFlow, addEdge } from '@braks/vue-flow'
+import type { Connection, Edge, Elements } from '@vue-flow/renderer'
+import { Background, Controls, MiniMap, VueFlow, addEdge } from '@vue-flow/renderer'
 import { ref } from 'vue'
 import { ResizeRotateNode } from '../src'
 import initialElements from './elements'
@@ -23,8 +23,8 @@ const onConnect = (params: Edge | Connection) => (elements.value = addEdge(param
 </template>
 
 <style>
-@import '@braks/vue-flow/dist/style.css';
-@import '@braks/vue-flow/dist/theme-default.css';
+@import '@vue-flow/renderer/dist/style.css';
+@import '@vue-flow/renderer/dist/theme-default.css';
 
 html,
 body,

--- a/packages/resize-rotate-node/example/elements.ts
+++ b/packages/resize-rotate-node/example/elements.ts
@@ -1,4 +1,4 @@
-import type { Elements } from '@braks/vue-flow'
+import type { Elements } from '@vue-flow/renderer'
 
 export default [
   {

--- a/packages/resize-rotate-node/package.json
+++ b/packages/resize-rotate-node/package.json
@@ -34,7 +34,7 @@
     "vue3-moveable": "^0.4.8"
   },
   "devDependencies": {
-    "@braks/vue-flow": "workspace:*",
+    "@vue-flow/renderer": "workspace:*",
     "@vitejs/plugin-vue": "^2.3.3",
     "ts-patch": "^2.0.1",
     "typescript-transform-paths": "^3.3.1",

--- a/packages/resize-rotate-node/package.json
+++ b/packages/resize-rotate-node/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@braks/vue-flow-resize-rotate-node",
+  "name": "@vue-flow/resize-rotate-node",
   "version": "0.0.2",
   "private": false,
   "repository": {

--- a/packages/resize-rotate-node/src/node/ResizeRotateNode.vue
+++ b/packages/resize-rotate-node/src/node/ResizeRotateNode.vue
@@ -1,8 +1,8 @@
 <script lang="ts" setup>
 import type { MoveableEvents } from 'vue3-moveable'
 import Moveable from 'vue3-moveable'
-import type { Position } from '@braks/vue-flow'
-import { Handle, useVueFlow } from '@braks/vue-flow'
+import type { Position } from '@vue-flow/renderer'
+import { Handle, useVueFlow } from '@vue-flow/renderer'
 
 const props = defineProps<{
   id: string

--- a/packages/vue-flow/package.json
+++ b/packages/vue-flow/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@braks/vue-flow",
+  "name": "@vue-flow/renderer",
   "version": "0.4.23",
   "private": false,
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,11 +28,11 @@ importers:
     specifiers:
       '@animxyz/core': ^0.6.6
       '@animxyz/vue3': ^0.6.6
-      '@braks/vue-flow': workspace:*
       '@iconify/json': ^2.1.58
       '@stackblitz/sdk': ^1.6.0
       '@types/canvas-confetti': ^1.4.2
       '@types/node': ^17.0.41
+      '@vue-flow/renderer': workspace:*
       '@vue/repl': 1.1.2
       '@vuepress/bundler-vite': ^2.0.0-beta.46
       '@vuepress/plugin-docsearch': ^2.0.0-beta.46
@@ -53,8 +53,8 @@ importers:
     dependencies:
       '@animxyz/core': 0.6.6
       '@animxyz/vue3': 0.6.6_vue@3.2.37
-      '@braks/vue-flow': link:../packages/vue-flow
       '@stackblitz/sdk': 1.6.0
+      '@vue-flow/renderer': link:../packages/vue-flow
       '@vue/repl': 1.1.2_vue@3.2.37
       blobity: 0.1.7_react@18.1.0
       canvas-confetti: 1.5.1
@@ -79,13 +79,13 @@ importers:
 
   e2e:
     specifiers:
-      '@braks/vue-flow': workspace:*
       '@cypress/vite-dev-server': ^2.2.1
       '@cypress/vue': ^3.0.5
       '@vitejs/plugin-vue': ^2.2.0
+      '@vue-flow/renderer': workspace:*
       cypress: 8.5.0
     dependencies:
-      '@braks/vue-flow': link:../packages/vue-flow
+      '@vue-flow/renderer': link:../packages/vue-flow
     devDependencies:
       '@cypress/vite-dev-server': 2.2.3_vite@2.9.10
       '@cypress/vue': 3.1.2_cypress@8.5.0+vue@3.2.37
@@ -94,26 +94,26 @@ importers:
 
   examples/nuxt3:
     specifiers:
-      '@braks/vue-flow': workspace:*
+      '@vue-flow/renderer': workspace:*
       nuxt: 3.0.0-rc.3
     dependencies:
-      '@braks/vue-flow': link:../../packages/vue-flow
+      '@vue-flow/renderer': link:../../packages/vue-flow
     devDependencies:
       nuxt: 3.0.0-rc.3_rollup@2.75.6+vite@2.9.10
 
   examples/quasar:
     specifiers:
-      '@braks/vue-flow': workspace:*
       '@quasar/app-vite': ^1.0.0
       '@quasar/extras': ^1.0.0
       '@types/node': ^12.20.21
+      '@vue-flow/renderer': workspace:*
       autoprefixer: ^10.4.2
       quasar: ^2.6.0
       vue: ^3.2.15
       vue-router: ^4.0.0
     dependencies:
-      '@braks/vue-flow': link:../../packages/vue-flow
       '@quasar/extras': 1.14.0
+      '@vue-flow/renderer': link:../../packages/vue-flow
       quasar: 2.7.1
       vue: 3.2.37
       vue-router: 4.0.15_vue@3.2.37
@@ -124,9 +124,9 @@ importers:
 
   examples/vite:
     specifiers:
-      '@braks/vue-flow': workspace:*
       '@types/dagre': ^0.7.46
       '@vitejs/plugin-vue': ^2.2.0
+      '@vue-flow/renderer': workspace:*
       dagre: ^0.8.5
       unplugin-auto-import: ^0.6.8
       vite: 2.5.x
@@ -135,7 +135,7 @@ importers:
       vue: ^3.2.25
       vue-router: ^4.0.12
     dependencies:
-      '@braks/vue-flow': link:../../packages/vue-flow
+      '@vue-flow/renderer': link:../../packages/vue-flow
     devDependencies:
       '@types/dagre': 0.7.47
       '@vitejs/plugin-vue': 2.3.3_vite@2.5.10+vue@3.2.37
@@ -149,9 +149,9 @@ importers:
 
   packages/pathfinding-edge:
     specifiers:
-      '@braks/vue-flow': workspace:*
       '@types/pathfinding': ^0.0.5
       '@vitejs/plugin-vue': ^2.3.3
+      '@vue-flow/renderer': workspace:*
       pathfinding: ^0.4.18
       perfect-arrows: ^0.3.7
       ts-patch: ^2.0.1
@@ -164,9 +164,9 @@ importers:
       pathfinding: 0.4.18
       perfect-arrows: 0.3.7
     devDependencies:
-      '@braks/vue-flow': link:../vue-flow
       '@types/pathfinding': 0.0.5
       '@vitejs/plugin-vue': 2.3.3_vite@2.9.10+vue@3.2.37
+      '@vue-flow/renderer': link:../vue-flow
       ts-patch: 2.0.1_typescript@4.7.3
       typescript-transform-paths: 3.3.1_typescript@4.7.3
       unplugin-auto-import: 0.7.2_vite@2.9.10
@@ -176,8 +176,8 @@ importers:
 
   packages/resize-rotate-node:
     specifiers:
-      '@braks/vue-flow': workspace:*
       '@vitejs/plugin-vue': ^2.3.3
+      '@vue-flow/renderer': workspace:*
       '@vueuse/core': ^8.4.2
       ts-patch: ^2.0.1
       typescript-transform-paths: ^3.3.1
@@ -190,8 +190,8 @@ importers:
       '@vueuse/core': 8.6.0_vue@3.2.37
       vue3-moveable: 0.4.9_@types+react@16.9.56
     devDependencies:
-      '@braks/vue-flow': link:../vue-flow
       '@vitejs/plugin-vue': 2.3.3_vite@2.9.10+vue@3.2.37
+      '@vue-flow/renderer': link:../vue-flow
       ts-patch: 2.0.1_typescript@4.7.3
       typescript-transform-paths: 3.3.1_typescript@4.7.3
       unplugin-auto-import: 0.7.2_tci2uj2i5wdrrn53tzwatf6w64


### PR DESCRIPTION
# What's changed?

- [ ] split pkg into multiple pkgs (core, bg, minimap, controls)
- [ ] switch scope from `@braks` to `@vue-flow`
- [ ] Additional testing (Vitest[?])
- [ ] A11y
- [ ] Keyboard handler
- [ ] Generics for Types
- [ ] ...?