### PR TITLE
feat(edges): move connection lines to separate container

### DIFF
--- a/docs/src/guide/theming.md
+++ b/docs/src/guide/theming.md
@@ -132,6 +132,7 @@ const elements = ref<Elements>([
 | .vue-flow__edge-path          | Edge element svg path                                    |
 | .vue-flow__edge-text          | Edge label wrapper                                       |
 | .vue-flow__edge-textbg        | Edge label wrapper background                            |
+| .vue-flow__connectionline     | Connection line container element                        |
 | .vue-flow__connection         | Connection line element                                  |
 | .vue-flow__connection-path    | Connection line svg path                                 |
 | .vue-flow__nodes              | Nodes renderer wrapper                                   |

--- a/packages/vue-flow/src/container/EdgeRenderer/EdgeRenderer.vue
+++ b/packages/vue-flow/src/container/EdgeRenderer/EdgeRenderer.vue
@@ -197,7 +197,9 @@ export default {
         @source-mousedown="(e: MouseEvent) => onEdgeUpdaterSourceMouseDown(e, edge)"
         @target-mousedown="(e: MouseEvent) => onEdgeUpdaterTargetMouseDown(e, edge)"
       />
-      <ConnectionLine v-if="connectionLineVisible && !!sourceNode" :source-node="sourceNode" />
     </g>
+  </svg>
+  <svg v-if="connectionLineVisible && !!sourceNode" class="vue-flow__edges vue-flow__connectionline vue-flow__container">
+    <ConnectionLine :source-node="sourceNode" />
   </svg>
 </template>

--- a/packages/vue-flow/src/container/Viewport/Transform.vue
+++ b/packages/vue-flow/src/container/Viewport/Transform.vue
@@ -58,8 +58,8 @@ export default {
     class="vue-flow__transformationpane vue-flow__container"
     :style="{ transform: `translate(${viewport.x}px,${viewport.y}px) scale(${viewport.zoom})`, opacity: ready ? undefined : 0 }"
   >
-    <NodeRenderer />
     <EdgeRenderer />
+    <NodeRenderer />
     <slot />
   </div>
 </template>

--- a/packages/vue-flow/src/style.css
+++ b/packages/vue-flow/src/style.css
@@ -69,6 +69,10 @@
   user-select: none;
 }
 
+.vue-flow .vue-flow__connectionline {
+  z-index: 1001;
+}
+
 .vue-flow__connection {
   pointer-events: none;
 


### PR DESCRIPTION
# What's changed?

* connection lines should be above nodes
* selected node should be above edges