### PR TITLE
refactor(nodes): apply node specific snapGrid on drag 

### DIFF
--- a/packages/vue-flow/src/components/Nodes/NodeWrapper.vue
+++ b/packages/vue-flow/src/components/Nodes/NodeWrapper.vue
@@ -19,16 +19,14 @@ provide(NodeId, id)
 const {
   edges,
   viewport,
-  noDragClassName,
   noPanClassName,
   selectNodesOnDrag,
-  setState,
-  updateNodeDimensions,
-  getNode,
-  addSelectedNodes,
+  nodesSelectionActive,
   multiSelectionActive,
+  getNode,
   removeSelectedElements,
-  getSelectedNodes,
+  addSelectedNodes,
+  updateNodeDimensions,
   onUpdateNodeInternals,
 } = $(useVueFlow())
 
@@ -43,8 +41,6 @@ const dragging = useDrag({
   id,
   el: nodeElement,
   disabled: computed(() => !draggable),
-  noDragClassName: $$(noDragClassName) as any,
-  handleSelector: node.dragHandle,
   onStart(event, node, nodes) {
     emit.dragStart({ event, node, nodes })
   },
@@ -154,7 +150,7 @@ const onDoubleClick = (event: MouseEvent) => {
 
 const onSelectNode = (event: MouseEvent) => {
   if (selectable && (!selectNodesOnDrag || !draggable)) {
-    handleNodeClick(node, multiSelectionActive, addSelectedNodes, removeSelectedElements, setState)
+    handleNodeClick(node, multiSelectionActive, addSelectedNodes, removeSelectedElements, $$(nodesSelectionActive))
   }
   emit.click({ event, node, connectedEdges: getConnectedEdges([node], edges) })
 }

--- a/packages/vue-flow/src/container/NodeRenderer/NodeRenderer.vue
+++ b/packages/vue-flow/src/container/NodeRenderer/NodeRenderer.vue
@@ -21,7 +21,6 @@ const {
 const draggable = (d?: boolean) => (typeof d === 'undefined' ? nodesDraggable : d)
 const selectable = (s?: boolean) => (typeof s === 'undefined' ? elementsSelectable : s)
 const connectable = (c?: boolean) => (typeof c === 'undefined' ? nodesConnectable : c)
-const hasSnapGrid = (sg?: SnapGrid) => (sg ?? snapToGrid ? snapGrid : undefined)
 
 const getType = (type?: string, template?: GraphNode['template']) => {
   const name = type || 'default'
@@ -65,7 +64,6 @@ export default {
       :draggable="draggable(node.draggable)"
       :selectable="selectable(node.selectable)"
       :connectable="connectable(node.connectable)"
-      :snap-grid="hasSnapGrid(node.snapGrid)"
     />
   </div>
 </template>

--- a/packages/vue-flow/src/utils/node.ts
+++ b/packages/vue-flow/src/utils/node.ts
@@ -1,5 +1,6 @@
 import { getDimensions } from './graph'
 import type { Actions, GraphNode, HandleElement, Position } from '~/types'
+import { Ref } from "vue";
 
 export const getHandleBoundsByHandleType = (
   selector: string,
@@ -43,9 +44,9 @@ export const handleNodeClick = (
   multiSelectionActive: boolean,
   addSelectedNodes: Actions['addSelectedNodes'],
   removeSelectedElements: Actions['removeSelectedElements'],
-  setState: Actions['setState'],
+  nodesSelectionActive: Ref<boolean>,
 ) => {
-  setState({ nodesSelectionActive: false })
+  nodesSelectionActive.value = false
 
   if (!node.selected) {
     addSelectedNodes([node])


### PR DESCRIPTION
# What's changed?

* remove params `noDragClassName` and `handleSelector` and access while dragging from store or current node
* apply snap grid if present on node