### PR TITLE
refactor(nodes): use `content-box` for resize observer

### DIFF
--- a/packages/vue-flow/src/components/Nodes/NodeWrapper.vue
+++ b/packages/vue-flow/src/components/Nodes/NodeWrapper.vue
@@ -52,9 +52,13 @@ const dragging = useDrag({
   },
 })
 
-const observer = useResizeObserver(nodeElement, () => {
-  updateNodeDimensions([{ id, nodeElement: nodeElement.value, forceUpdate: true }])
-})
+const observer = useResizeObserver(
+  nodeElement,
+  () => {
+    updateNodeDimensions([{ id, nodeElement: nodeElement.value, forceUpdate: true }])
+  },
+  { box: 'content-box' },
+)
 
 watch(
   [() => node.width, () => node.height, () => node.type, () => node.sourcePosition, () => node.targetPosition],

--- a/packages/vue-flow/src/components/Nodes/NodeWrapper.vue
+++ b/packages/vue-flow/src/components/Nodes/NodeWrapper.vue
@@ -111,7 +111,7 @@ onMounted(() => {
       const xyzPos = {
         x: newX,
         y: newY,
-        z: node.computedPosition.z ? node.computedPosition.z : node.selected ? 1000 : 0,
+        z: node.selected ? 1000 : 0,
       }
 
       updatePosition(xyzPos, parentX && parentY ? { x: parentX, y: parentY, z: parentZ! } : undefined)


### PR DESCRIPTION
# What's changed?

* connection lines should be above nodes
* selected node should be above edges
