### PR TITLE
feat(edges): add `connectionLineOptions` prop

### DIFF
--- a/docs/src/guide/vue-flow/config.md
+++ b/docs/src/guide/vue-flow/config.md
@@ -305,7 +305,17 @@ const edges = ref([
 
   If set to `loose` all handles are treated as source handles (thus allowing for connections on target handles as well.)
 
-### connection-line-type <Badge class="text-white" style="line-height: inherit" text="optional" vertical="top" />
+### connection-line-options
+
+- Type: [`ConnectionLineOptions`](/typedocs/interfaces/ConnectionLineOptions.html/)
+
+- Details:
+
+  Options for the connection line.
+  
+  The options include the connection line type, style and possible marker types (marker-end/marker-start).
+
+### connection-line-type <Badge class="text-white" style="line-height: inherit" text="optional" vertical="top" /> <Badge type="warning" class="text-white" style="line-height: inherit" text="deprecated" vertical="top" />
 
 - Type: [`ConnectionLineType`](/typedocs/enums/ConnectionLineType.html/)
 
@@ -317,7 +327,7 @@ const edges = ref([
 
   When using a custom connection line this prop does nothing.
 
-### connection-line-style <Badge class="text-white" style="line-height: inherit" text="optional" vertical="top" />
+### connection-line-style <Badge class="text-white" style="line-height: inherit" text="optional" vertical="top" /> <Badge type="warning" class="text-white" style="line-height: inherit" text="deprecated" vertical="top" />
 
 - Type: `CSSProperties` | `null`
 

--- a/packages/vue-flow/src/components/ConnectionLine/ConnectionLine.vue
+++ b/packages/vue-flow/src/components/ConnectionLine/ConnectionLine.vue
@@ -4,6 +4,7 @@ import type { GraphNode, HandleElement, HandleType } from '../../types'
 import { ConnectionLineType, Position } from '../../types'
 import { useVueFlow } from '../../composables'
 import { Slots } from '../../context'
+import { getMarkerId } from '../../utils'
 
 const { sourceNode } = defineProps<{
   sourceNode: GraphNode
@@ -17,6 +18,7 @@ const {
   connectionLineType,
   connectionLineStyle,
   connectionNodeId,
+  connectionLineOptions,
   viewport,
 } = $(useVueFlow())
 
@@ -44,7 +46,7 @@ const targetY = $computed(() => (connectionPosition.y - viewport.y) / viewport.z
 
 const dAttr = computed(() => {
   let path = `M${sourceX},${sourceY} ${targetX},${targetY}`
-  switch (connectionLineType) {
+  switch (connectionLineType || connectionLineOptions.type) {
     case ConnectionLineType.Bezier:
       path = getBezierPath({
         sourceX,
@@ -99,13 +101,21 @@ export default {
         targetX,
         targetY,
         targetPosition,
-        connectionLineType,
-        connectionLineStyle,
         nodes: getNodes,
         sourceNode,
         sourceHandle,
+        markerEnd: `url(#${getMarkerId(connectionLineOptions.markerEnd)})`,
+        markerStart: `url(#${getMarkerId(connectionLineOptions.markerStart)})`,
       }"
     />
-    <path v-else :d="dAttr" class="vue-flow__connection-path" :style="connectionLineStyle || {}" />
+    <path
+      v-else
+      :d="dAttr"
+      class="vue-flow__connection-path"
+      :class="connectionLineOptions.class"
+      :style="connectionLineStyle || connectionLineOptions.style || {}"
+      :marker-end="`url(#${getMarkerId(connectionLineOptions.markerEnd)})`"
+      :marker-start="`url(#${getMarkerId(connectionLineOptions.markerStart)})`"
+    />
   </g>
 </template>

--- a/packages/vue-flow/src/container/EdgeRenderer/EdgeRenderer.vue
+++ b/packages/vue-flow/src/container/EdgeRenderer/EdgeRenderer.vue
@@ -18,7 +18,6 @@ const {
   connectionNodeId,
   nodesConnectable,
   connectionHandleType,
-  defaultMarkerColor,
   edgesUpdatable,
   elementsSelectable,
   getSelectedNodes,
@@ -181,7 +180,7 @@ export default {
 
 <template>
   <svg v-for="group of groups" :key="group.level" class="vue-flow__edges vue-flow__container" :style="`z-index: ${group.level}`">
-    <MarkerDefinitions v-if="group.isMaxLevel" :default-color="defaultMarkerColor" />
+    <MarkerDefinitions v-if="group.isMaxLevel" />
     <g>
       <EdgeWrapper
         v-for="edge of group.edges"

--- a/packages/vue-flow/src/container/EdgeRenderer/Marker.vue
+++ b/packages/vue-flow/src/container/EdgeRenderer/Marker.vue
@@ -15,7 +15,7 @@ const {
 
 <script lang="ts">
 export default {
-  name: 'Marker',
+  name: 'MarkerType',
 }
 </script>
 

--- a/packages/vue-flow/src/container/EdgeRenderer/MarkerDefinitions.vue
+++ b/packages/vue-flow/src/container/EdgeRenderer/MarkerDefinitions.vue
@@ -1,31 +1,34 @@
 <script lang="ts" setup>
 import { useVueFlow } from '../../composables'
-import type { MarkerProps, MarkerType } from '../../types/edge'
+import type { EdgeMarkerType, MarkerProps, MarkerType } from '../../types/edge'
 import { getMarkerId } from '../../utils'
 import Marker from './Marker.vue'
 
-const { defaultColor = '' } = defineProps<{
-  defaultColor: string
-}>()
-
-const { edges } = $(useVueFlow())
+const { edges, connectionLineOptions, defaultMarkerColor: defaultColor } = $(useVueFlow())
 
 const markers = computed(() => {
   const ids: string[] = []
+  const markers: MarkerProps[] = []
 
-  return edges.reduce<MarkerProps[]>((markers, edge) => {
-    ;[edge.markerStart, edge.markerEnd].forEach((marker) => {
-      if (marker) {
-        const markerId = getMarkerId(marker)
-        if (!ids.includes(markerId)) {
-          if (typeof marker === 'object') markers.push({ ...marker, id: markerId, color: marker.color || defaultColor })
-          else markers.push({ id: markerId, color: defaultColor, type: marker as MarkerType })
-          ids.push(markerId)
-        }
+  const createMarkers = (marker?: EdgeMarkerType) => {
+    if (marker) {
+      const markerId = getMarkerId(marker)
+      if (!ids.includes(markerId)) {
+        if (typeof marker === 'object') markers.push({ ...marker, id: markerId, color: marker.color || defaultColor })
+        else markers.push({ id: markerId, color: defaultColor, type: marker as MarkerType })
+        ids.push(markerId)
       }
-    })
+    }
+  }
+
+  ;[connectionLineOptions.markerEnd, connectionLineOptions.markerStart].forEach(createMarkers)
+
+  edges.reduce<MarkerProps[]>((markers, edge) => {
+    ;[edge.markerStart, edge.markerEnd].forEach(createMarkers)
     return markers.sort((a, b) => a.id.localeCompare(b.id))
-  }, [])
+  }, markers)
+
+  return markers
 })
 </script>
 

--- a/packages/vue-flow/src/store/state.ts
+++ b/packages/vue-flow/src/store/state.ts
@@ -76,6 +76,10 @@ const defaultState = (): State => ({
   defaultMarkerColor: '#b1b1b7',
   connectionLineStyle: {},
   connectionLineType: ConnectionLineType.Bezier,
+  connectionLineOptions: {
+    type: ConnectionLineType.Bezier,
+    style: {},
+  },
   connectionNodeId: null,
   connectionHandleId: null,
   connectionHandleType: null,

--- a/packages/vue-flow/src/types/connection.ts
+++ b/packages/vue-flow/src/types/connection.ts
@@ -2,7 +2,7 @@ import type { CSSProperties } from 'vue'
 import type { Position } from './flow'
 import type { GraphNode } from './node'
 import type { HandleElement, HandleType } from './handle'
-import type { Edge } from './edge'
+import type { Edge, EdgeMarkerType } from './edge'
 
 /** Connection line types (same as default edge types */
 export enum ConnectionLineType {
@@ -10,6 +10,14 @@ export enum ConnectionLineType {
   Straight = 'straight',
   Step = 'step',
   SmoothStep = 'smoothstep',
+}
+
+export interface ConnectionLineOptions {
+  type?: ConnectionLineType
+  style?: CSSProperties
+  class?: string
+  markerEnd?: EdgeMarkerType
+  markerStart?: EdgeMarkerType
 }
 
 /** Connection params that are passed when onConnect is called */
@@ -67,4 +75,8 @@ export interface ConnectionLineProps {
   sourceNode: GraphNode
   /** The source handle element of the connection line */
   sourceHandle: HandleElement
+  /** marker url */
+  markerStart: string
+  /** marker url */
+  markerEnd: string
 }

--- a/packages/vue-flow/src/types/flow.ts
+++ b/packages/vue-flow/src/types/flow.ts
@@ -1,7 +1,7 @@
 import type { CSSProperties } from 'vue'
 import type { DefaultEdgeOptions, Edge, GraphEdge } from './edge'
 import type { CoordinateExtent, GraphNode, Node } from './node'
-import type { ConnectionLineType, ConnectionMode, Connector } from './connection'
+import type { ConnectionLineOptions, ConnectionLineType, ConnectionMode, Connector } from './connection'
 import type { KeyCode, PanOnScrollMode } from './zoom'
 import type { DefaultEdgeTypes, DefaultNodeTypes, EdgeComponent, NodeComponent } from './components'
 
@@ -85,8 +85,11 @@ export interface FlowProps {
   /** either use the nodeTypes prop to define your node-types or use slots (<template #node-mySpecialType="props">) */
   nodeTypes?: { [key in keyof DefaultNodeTypes]?: NodeComponent } & Record<string, NodeComponent>
   connectionMode?: ConnectionMode
+  /** @deprecated use {@link ConnectionLineOptions.type} */
   connectionLineType?: ConnectionLineType
+  /** @deprecated use {@link ConnectionLineOptions.style} */
   connectionLineStyle?: CSSProperties | null
+  connectionLineOptions?: ConnectionLineOptions
   deleteKeyCode?: KeyCode
   selectionKeyCode?: KeyCode
   multiSelectionKeyCode?: KeyCode

--- a/packages/vue-flow/src/types/store.ts
+++ b/packages/vue-flow/src/types/store.ts
@@ -1,7 +1,7 @@
 import type { CSSProperties, ComputedRef, ToRefs } from 'vue'
 import type { Dimensions, ElementData, Elements, FlowElements, FlowExportObject, FlowOptions, SnapGrid, XYPosition } from './flow'
 import type { DefaultEdgeTypes, DefaultNodeTypes, EdgeComponent, NodeComponent } from './components'
-import type { Connection, ConnectionLineType, ConnectionMode, Connector } from './connection'
+import type { Connection, ConnectionLineOptions, ConnectionLineType, ConnectionMode, Connector } from './connection'
 import type { DefaultEdgeOptions, Edge, GraphEdge } from './edge'
 import type { CoordinateExtent, GraphNode, Node } from './node'
 import type { D3Selection, D3Zoom, D3ZoomHandler, KeyCode, PanOnScrollMode, Viewport, ViewportFunctions } from './zoom'
@@ -59,7 +59,10 @@ export interface State extends Omit<FlowOptions, 'id' | 'modelValue'> {
   connectionHandleType: HandleType | null
   connectionPosition: XYPosition
   connectionMode: ConnectionMode
+  connectionLineOptions: ConnectionLineOptions
+  /** @deprecated use {@link ConnectionLineOptions.type} */
   connectionLineType: ConnectionLineType
+  /** @deprecated use {@link ConnectionLineOptions.style} */
   connectionLineStyle: CSSProperties | null
   connectionStartHandle: StartHandle | null
 


### PR DESCRIPTION
# What's changed?

* allow defining markers on connection lines
* deprecate `connectionLineType`
* deprecate `connectionLineStyle`

# 🪴 To-Dos
<!--- Tell us if there are To-Dos left -->

- [x] add documentation for new option
