### PR TITLE
fix(graph): getIncomers always returning itself

### DIFF
--- a/packages/vue-flow/src/container/VueFlow/watch.ts
+++ b/packages/vue-flow/src/container/VueFlow/watch.ts
@@ -174,6 +174,17 @@ export default (models: ToRefs<Pick<FlowProps, 'nodes' | 'edges' | 'modelValue'>
 
     const watchAutoConnect = () => {
       scope.run(() => {
+        const autoConnector = async (params: Connection) => {
+          let connect: boolean | Connection = true
+          if (isFunction(props.autoConnect)) {
+            connect = await props.autoConnect(params)
+          }
+
+          if (connect) {
+            store.addEdges([params])
+          }
+        }
+
         watch(
           () => props.autoConnect,
           () => {
@@ -186,19 +197,8 @@ export default (models: ToRefs<Pick<FlowProps, 'nodes' | 'edges' | 'modelValue'>
 
         watch(
           store.autoConnect,
-          () => {
-            const autoConnector = async (params: Connection) => {
-              let connect: boolean | Connection = true
-              if (isFunction(props.autoConnect)) {
-                connect = await props.autoConnect(params)
-              }
-
-              if (connect) {
-                store.addEdges([params])
-              }
-            }
-
-            if (store.autoConnect) {
+          (autoConnectEnabled) => {
+            if (autoConnectEnabled) {
               store.onConnect(autoConnector)
             } else {
               store.hooks.value.connect.off(autoConnector)


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- only trigger auto-connect if actually set to `true` or `Connector` function.

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- #227 
