### PR TITLE
refactor: move watch flush timing to pre 

### DIFF
--- a/packages/vue-flow/src/components/Nodes/NodeWrapper.vue
+++ b/packages/vue-flow/src/components/Nodes/NodeWrapper.vue
@@ -127,7 +127,7 @@ onMounted(() => {
           target: getHandleBounds('.target', nodeElement.value, viewport.zoom),
         }
       },
-      { immediate: true, flush: 'post' },
+      { immediate: true },
     )
   })
 })

--- a/packages/vue-flow/src/container/EdgeRenderer/EdgeRenderer.vue
+++ b/packages/vue-flow/src/container/EdgeRenderer/EdgeRenderer.vue
@@ -87,7 +87,6 @@ onPaneReady(() => {
         }
       },
       {
-        flush: 'post',
         immediate: true,
       },
     )

--- a/packages/vue-flow/src/container/VueFlow/watch.ts
+++ b/packages/vue-flow/src/container/VueFlow/watch.ts
@@ -34,7 +34,7 @@ export default (models: ToRefs<Pick<FlowProps, 'nodes' | 'edges' | 'modelValue'>
                     if (pauseModel) pauseModel.resume()
                   })
                 },
-                { immediate: true, flush: 'post' },
+                { immediate: true },
               )
 
               nextTick(() => {
@@ -43,7 +43,7 @@ export default (models: ToRefs<Pick<FlowProps, 'nodes' | 'edges' | 'modelValue'>
               })
             }
           },
-          { immediate: !!(models.modelValue && models.modelValue.value), flush: 'post' },
+          { immediate: !!(models.modelValue && models.modelValue.value) },
         )
       })
     }
@@ -77,7 +77,7 @@ export default (models: ToRefs<Pick<FlowProps, 'nodes' | 'edges' | 'modelValue'>
               })
             }
           },
-          { immediate: !!(models.nodes && models.nodes.value), flush: 'post' },
+          { immediate: !!(models.nodes && models.nodes.value) },
         )
       })
     }
@@ -111,7 +111,7 @@ export default (models: ToRefs<Pick<FlowProps, 'nodes' | 'edges' | 'modelValue'>
               })
             }
           },
-          { immediate: !!(models.edges && models.edges.value), flush: 'post' },
+          { immediate: !!(models.edges && models.edges.value) },
         )
       })
     }


### PR DESCRIPTION
# What's changed?

* revert keypress listener on input elements (except button)
* skip keypress events on elements with `.nokey` classname
