### PR TITLE
release: 0.4.37

### DIFF
--- a/packages/vue-flow/src/components/Nodes/NodeWrapper.vue
+++ b/packages/vue-flow/src/components/Nodes/NodeWrapper.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
+import { useVModel } from '@vueuse/core'
 import { useDrag, useNodeHooks, useVueFlow } from '../../composables'
-import type { NodeComponent, SnapGrid, XYZPosition } from '../../types'
+import type { GraphNode, NodeComponent, SnapGrid, XYZPosition } from '../../types'
 import { NodeId } from '../../context'
 import { getConnectedEdges, getHandleBounds, getXYZPos, handleNodeClick } from '../../utils'
 
@@ -12,6 +13,7 @@ const { id, type, name, draggable, selectable, connectable, snapGrid, ...props }
   snapGrid?: SnapGrid
   type: NodeComponent | Function | Object | false
   name: string
+  node: GraphNode
 }>()
 
 provide(NodeId, id)
@@ -31,7 +33,8 @@ const {
   onUpdateNodeInternals,
 } = $(useVueFlow())
 
-const node = $computed(() => getNode(id)!)
+const node = $(useVModel(props, 'node'))
+
 const parentNode = $computed(() => (node.parentNode ? getNode(node.parentNode) : undefined))
 
 const nodeElement = ref()

--- a/packages/vue-flow/src/container/NodeRenderer/NodeRenderer.vue
+++ b/packages/vue-flow/src/container/NodeRenderer/NodeRenderer.vue
@@ -64,6 +64,7 @@ export default {
       :draggable="draggable(node.draggable)"
       :selectable="selectable(node.selectable)"
       :connectable="connectable(node.connectable)"
+      :node="node"
     />
   </div>
 </template>


### PR DESCRIPTION
# What's changed?

* instead of computed getter use prop to pass node
* avoids error when node gets deleting from custom node with `removeNodes`

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- Issue 1
- Issue 2
- ...

# 🪴 To-Dos
<!--- Tell us if there are To-Dos left -->

- [ ] To-Do 1
- [ ] To-Do 1
- ...
