### PR TITLE
fix: use `elementFromPoint`

### DIFF
--- a/packages/vue-flow/src/utils/graph.ts
+++ b/packages/vue-flow/src/utils/graph.ts
@@ -35,7 +35,7 @@ export const getHostForElement = (element: HTMLElement): Document => {
   const doc = element.getRootNode() as Document
   const window = useWindow()
 
-  if ('getElementFromPoint' in doc) return doc
+  if ('elementFromPoint' in doc) return doc
   else return window.document
 }
 


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Replace `getElementFromPoint` with `elementFromPoint`

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- #280 
