### PR TITLE
feat(nodes): add from position to position change event 

### DIFF
--- a/packages/vue-flow/src/store/actions.ts
+++ b/packages/vue-flow/src/store/actions.ts
@@ -67,6 +67,7 @@ export default (state: State, getters: ComputedGetters): Actions => {
         id: node.id,
         type: 'position',
         dragging,
+        from: node.from,
       }
 
       if (changed) {

--- a/packages/vue-flow/src/types/changes.ts
+++ b/packages/vue-flow/src/types/changes.ts
@@ -9,6 +9,7 @@ export interface NodeDragItem {
   // distance from the mouse cursor to the node when start dragging
   distance: XYPosition
   dimensions: Dimensions
+  from: XYPosition
   extent?: Node['extent']
   parentNode?: string
 }
@@ -25,6 +26,7 @@ export interface NodePositionChange {
   type: 'position'
   position: XYPosition
   computedPosition: XYPosition
+  from: XYPosition
   dragging: boolean
 }
 

--- a/packages/vue-flow/src/utils/drag.ts
+++ b/packages/vue-flow/src/utils/drag.ts
@@ -23,17 +23,20 @@ export function getDragItems(
 ): NodeDragItem[] {
   return nodes
     .filter((n) => (n.selected || n.id === nodeId) && (!n.parentNode || !isParentSelected(n, getNode)))
-    .map((n) => ({
-      id: n.id,
-      position: n.computedPosition || { x: 0, y: 0, z: 0 },
-      distance: {
-        x: mousePos.x - n.computedPosition?.x || 0,
-        y: mousePos.y - n.computedPosition?.y || 0,
-      },
-      extent: n.extent,
-      parentNode: n.parentNode,
-      dimensions: n.dimensions,
-    }))
+    .map((n) =>
+      markRaw({
+        id: n.id,
+        position: n.computedPosition || { x: 0, y: 0, z: 0 },
+        distance: {
+          x: mousePos.x - n.computedPosition?.x || 0,
+          y: mousePos.y - n.computedPosition?.y || 0,
+        },
+        from: n.computedPosition,
+        extent: n.extent,
+        parentNode: n.parentNode,
+        dimensions: n.dimensions,
+      }),
+    )
 }
 
 export function getEventHandlerParams({


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- add `from` position (starting position of the node when drag starts) to node position change events
	- can be used for position rollbacks
