### PR TITLE
fix(edges): edges not returned by getter when `paneReady` event is triggered

### DIFF
--- a/.changeset/violet-mugs-attend.md
+++ b/.changeset/violet-mugs-attend.md
@@ -1,0 +1,7 @@
+---
+'@vue-flow/core': patch
+---
+
+# Bugfixes
+
+- Edges not returned by getter when `paneReady` event is triggered

--- a/packages/core/src/container/EdgeRenderer/EdgeRenderer.vue
+++ b/packages/core/src/container/EdgeRenderer/EdgeRenderer.vue
@@ -89,9 +89,7 @@ onPaneReady(() => {
           ]
         }
       },
-      {
-        immediate: true,
-      },
+      { immediate: true },
     )
   })
 })

--- a/packages/core/src/store/getters.ts
+++ b/packages/core/src/store/getters.ts
@@ -65,17 +65,7 @@ export default (state: State): ComputedGetters => {
       return
     }
 
-    return (
-      !e.hidden &&
-      target &&
-      !target.hidden &&
-      source &&
-      !source.hidden &&
-      source.dimensions.width &&
-      source.dimensions.height &&
-      target.dimensions.width &&
-      target.dimensions.height
-    )
+    return !e.hidden && !target.hidden && !source.hidden
   }
 
   const getEdges = computed<GraphEdge[]>(() => {


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Fix edges not returned by getter when `paneReady` event is triggered