### PR TITLE
fix(handles): connectOnClick reset before connections can be made

### DIFF
--- a/.changeset/green-dragons-explain.md
+++ b/.changeset/green-dragons-explain.md
@@ -1,0 +1,9 @@
+---
+'@vue-flow/core': patch
+---
+
+`connectOnClick`: mouseup handler resets startHandle before connections can be made
+
+## Bugfixes
+
+- Prevent `mouseup` handler from resetting `startHandle` before connections can be made when using `connectOnClick`

--- a/e2e/cypress/component/2-vue-flow/connect.cy.ts
+++ b/e2e/cypress/component/2-vue-flow/connect.cy.ts
@@ -22,17 +22,18 @@ describe('Check if nodes are connectable', () => {
     })
   })
 
-  it('creates connection', () => {
+  it('creates connection by dragging', () => {
     cy.window().then((win) => {
       const sourceHandle = cy.get(`[data-nodeid="1"].source`)
       const targetHandle = cy.get(`[data-nodeid="2"].target`)
+
       targetHandle.then((handle) => {
         const target = handle[0]
         const { x, y } = target.getBoundingClientRect()
 
         sourceHandle
           .trigger('mousedown', {
-            which: 1,
+            button: 0,
             force: true,
             view: win,
           })
@@ -48,10 +49,20 @@ describe('Check if nodes are connectable', () => {
             view: win,
           })
 
-        cy.wait(100).then(() => {
-          expect(store.edges.value).to.have.length(1)
-        })
+        cy.get('.vue-flow__edge').should('have.length', 1)
       })
     })
+  })
+
+  it('creates connection by clicking', () => {
+    store.connectOnClick.value = true
+
+    const sourceHandle = cy.get(`[data-nodeid="1"].source`)
+    const targetHandle = cy.get(`[data-nodeid="2"].target`)
+
+    sourceHandle.click()
+    targetHandle.click()
+
+    cy.get('.vue-flow__edge').should('have.length', 1)
   })
 })

--- a/e2e/cypress/component/2-vue-flow/updateEdge.cy.ts
+++ b/e2e/cypress/component/2-vue-flow/updateEdge.cy.ts
@@ -45,7 +45,7 @@ describe('Check if edges are updatable', () => {
 
         edgeAnchor
           .trigger('mousedown', {
-            which: 1,
+            button: 0,
             force: true,
             view: win,
           })

--- a/packages/core/src/composables/useHandle.ts
+++ b/packages/core/src/composables/useHandle.ts
@@ -106,7 +106,7 @@ export default function useHandle({
     edges,
     connectOnClick,
     nodesConnectable,
-    connectionStartHandle,
+    connectionClickStartHandle,
     connectionMode,
     emits,
     startConnection,
@@ -121,6 +121,8 @@ export default function useHandle({
   let recentHoveredHandle: Element
 
   const onMouseDown = (event: MouseEvent) => {
+    if (event.button !== 0) return
+
     const doc = getHostForElement(event.target as HTMLElement)
     if (!doc) return
 
@@ -222,8 +224,9 @@ export default function useHandle({
 
   const onClick = (event: MouseEvent) => {
     if (!connectOnClick) return
-    if (!connectionStartHandle) {
-      startConnection({ nodeId: unref(nodeId), type: unref(type), handleId: unref(handleId) }, undefined, event)
+
+    if (!connectionClickStartHandle) {
+      startConnection({ nodeId: unref(nodeId), type: unref(type), handleId: unref(handleId) }, undefined, event, true)
     } else {
       let validConnectFunc: ValidConnectionFunc = isValidConnection ?? (() => true)
 
@@ -240,9 +243,9 @@ export default function useHandle({
       const { connection, isValid } = checkElementBelowIsValid(
         event as MouseEvent,
         connectionMode,
-        connectionStartHandle.type === 'target',
-        connectionStartHandle.nodeId,
-        connectionStartHandle.handleId || null,
+        connectionClickStartHandle.type === 'target',
+        connectionClickStartHandle.nodeId,
+        connectionClickStartHandle.handleId || null,
         validConnectFunc,
         doc,
         edges,
@@ -253,7 +256,7 @@ export default function useHandle({
 
       if (isValid && !isOwnHandle) emits.connect(connection)
 
-      endConnection(event)
+      endConnection(event, true)
     }
   }
 

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -370,8 +370,12 @@ export default (state: State, getters: ComputedGetters): Actions => {
 
   const applyEdgeChanges: Actions['applyEdgeChanges'] = (changes) => applyChanges(changes, state.edges)
 
-  const startConnection: Actions['startConnection'] = (startHandle, position, event) => {
-    state.connectionStartHandle = startHandle
+  const startConnection: Actions['startConnection'] = (startHandle, position, event, isClick = false) => {
+    if (isClick) {
+      state.connectionClickStartHandle = startHandle
+    } else {
+      state.connectionStartHandle = startHandle
+    }
 
     if (position) state.connectionPosition = position
 
@@ -387,9 +391,15 @@ export default (state: State, getters: ComputedGetters): Actions => {
     state.connectionPosition = position
   }
 
-  const endConnection: Actions['endConnection'] = (event) => {
+  const endConnection: Actions['endConnection'] = (event, isClick) => {
     state.connectionPosition = { x: NaN, y: NaN }
-    state.connectionStartHandle = null
+
+    if (isClick) {
+      state.connectionClickStartHandle = null
+    } else {
+      state.connectionStartHandle = null
+    }
+
     state.hooks.connectEnd.trigger(event)
   }
 

--- a/packages/core/src/store/state.ts
+++ b/packages/core/src/store/state.ts
@@ -84,6 +84,7 @@ const defaultState = (): State => ({
   },
   connectionMode: ConnectionMode.Loose,
   connectionStartHandle: null,
+  connectionClickStartHandle: null,
   connectionPosition: { x: NaN, y: NaN },
   connectOnClick: true,
 

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -67,6 +67,7 @@ export interface State extends Omit<FlowOptions, 'id' | 'modelValue'> {
   /** @deprecated use {@link ConnectionLineOptions.style} */
   connectionLineStyle: CSSProperties | null
   connectionStartHandle: StartHandle | null
+  connectionClickStartHandle: StartHandle | null
   connectionPosition: XYPosition
 
   connectOnClick: boolean
@@ -188,11 +189,11 @@ export interface Actions extends ViewportFunctions {
   /** force update node internal data, if handle bounds are incorrect, you might want to use this */
   updateNodeInternals: UpdateNodeInternals
   /** start a connection */
-  startConnection: (startHandle: StartHandle, position?: XYPosition, event?: MouseEvent) => void
+  startConnection: (startHandle: StartHandle, position?: XYPosition, event?: MouseEvent, isClick?: boolean) => void
   /** update connection position */
   updateConnection: (position: XYPosition) => void
   /** end (or cancel) a connection */
-  endConnection: (event?: MouseEvent) => void
+  endConnection: (event?: MouseEvent, isClick?: boolean) => void
 
   /** internal position updater, you probably don't want to use this */
   updateNodePositions: UpdateNodePosition


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- prevent `mouseup` handler resetting the click startHandle
- add click startHandle

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] #324 