### PR TITLE
feat(edges): add `interactionWidth` prop to edges

### DIFF
--- a/.changeset/sharp-gifts-doubt.md
+++ b/.changeset/sharp-gifts-doubt.md
@@ -1,0 +1,5 @@
+---
+'@vue-flow/core': minor
+---
+
+Add `pointerRadius` prop to edges. Sets radius of pointer interactivity for edges

--- a/.changeset/sharp-gifts-doubt.md
+++ b/.changeset/sharp-gifts-doubt.md
@@ -2,4 +2,4 @@
 '@vue-flow/core': minor
 ---
 
-Add `pointerRadius` prop to edges. Sets radius of pointer interactivity for edges
+Add `interactionWidth` prop to edges. Sets radius of pointer interactivity for edges

--- a/packages/core/src/components/Edges/BaseEdge.ts
+++ b/packages/core/src/components/Edges/BaseEdge.ts
@@ -14,11 +14,12 @@ const BaseEdge: FunctionalComponent<BaseEdgeProps> = function ({
   labelBgBorderRadius,
   labelBgPadding,
   labelBgStyle,
-  labelShowBg,
+  labelShowBg = true,
   labelStyle,
   markerStart,
   markerEnd,
   style,
+  pointerRadius = 2,
 }) {
   return [
     h('path', {
@@ -28,6 +29,15 @@ const BaseEdge: FunctionalComponent<BaseEdgeProps> = function ({
       'marker-end': markerEnd,
       'marker-start': markerStart,
     }),
+    pointerRadius
+      ? h('path', {
+          'style': 'opacity: 0',
+          'd': path,
+          'class': 'vue-flow__edge-pointer',
+          'stroke': 'transparent',
+          'stroke-width': pointerRadius,
+        })
+      : null,
     label
       ? h(EdgeText, {
           x: labelX,
@@ -56,6 +66,7 @@ BaseEdge.props = [
   'markerStart',
   'markerEnd',
   'style',
+  'pointerRadius',
 ]
 BaseEdge.inheritAttrs = false
 

--- a/packages/core/src/components/Edges/BaseEdge.ts
+++ b/packages/core/src/components/Edges/BaseEdge.ts
@@ -19,7 +19,7 @@ const BaseEdge: FunctionalComponent<BaseEdgeProps> = function ({
   markerStart,
   markerEnd,
   style,
-  pointerRadius = 2,
+  interactionWidth = 20,
 }) {
   return [
     h('path', {
@@ -29,13 +29,12 @@ const BaseEdge: FunctionalComponent<BaseEdgeProps> = function ({
       'marker-end': markerEnd,
       'marker-start': markerStart,
     }),
-    pointerRadius
+    interactionWidth
       ? h('path', {
-          'style': 'opacity: 0',
           'd': path,
-          'class': 'vue-flow__edge-pointer',
-          'stroke': 'transparent',
-          'stroke-width': pointerRadius,
+          'fill': 'none',
+          'stroke-opacity': 0,
+          'stroke-width': interactionWidth,
         })
       : null,
     label
@@ -66,7 +65,7 @@ BaseEdge.props = [
   'markerStart',
   'markerEnd',
   'style',
-  'pointerRadius',
+  'interactionWidth',
 ]
 BaseEdge.inheritAttrs = false
 

--- a/packages/core/src/components/Edges/BezierEdge.ts
+++ b/packages/core/src/components/Edges/BezierEdge.ts
@@ -20,7 +20,7 @@ const BezierEdge: FunctionalComponent<EdgeProps> = function ({
   markerEnd,
   markerStart,
   style,
-  pointerRadius,
+  interactionWidth,
 }) {
   const [path, labelX, labelY] = getBezierPath({
     sourceX,
@@ -45,7 +45,7 @@ const BezierEdge: FunctionalComponent<EdgeProps> = function ({
     style,
     markerEnd,
     markerStart,
-    pointerRadius,
+    interactionWidth,
   })
 }
 
@@ -66,7 +66,7 @@ BezierEdge.props = [
   'markerEnd',
   'markerStart',
   'style',
-  'pointerRadius',
+  'interactionWidth',
 ]
 BezierEdge.inheritAttrs = false
 

--- a/packages/core/src/components/Edges/BezierEdge.ts
+++ b/packages/core/src/components/Edges/BezierEdge.ts
@@ -20,6 +20,7 @@ const BezierEdge: FunctionalComponent<EdgeProps> = function ({
   markerEnd,
   markerStart,
   style,
+  pointerRadius,
 }) {
   const [path, labelX, labelY] = getBezierPath({
     sourceX,
@@ -44,6 +45,7 @@ const BezierEdge: FunctionalComponent<EdgeProps> = function ({
     style,
     markerEnd,
     markerStart,
+    pointerRadius,
   })
 }
 
@@ -64,6 +66,7 @@ BezierEdge.props = [
   'markerEnd',
   'markerStart',
   'style',
+  'pointerRadius',
 ]
 BezierEdge.inheritAttrs = false
 

--- a/packages/core/src/components/Edges/SimpleBezierEdge.ts
+++ b/packages/core/src/components/Edges/SimpleBezierEdge.ts
@@ -19,6 +19,7 @@ const SimpleBezierEdge: FunctionalComponent<EdgeProps> = function ({
   markerEnd,
   markerStart,
   style,
+  pointerRadius,
 }) {
   const [path, labelX, labelY] = getSimpleBezierPath({
     sourceX,
@@ -42,6 +43,7 @@ const SimpleBezierEdge: FunctionalComponent<EdgeProps> = function ({
     style,
     markerEnd,
     markerStart,
+    pointerRadius,
   })
 }
 
@@ -61,6 +63,7 @@ SimpleBezierEdge.props = [
   'markerEnd',
   'markerStart',
   'style',
+  'pointerRadius',
 ]
 SimpleBezierEdge.inheritAttrs = false
 

--- a/packages/core/src/components/Edges/SimpleBezierEdge.ts
+++ b/packages/core/src/components/Edges/SimpleBezierEdge.ts
@@ -19,7 +19,7 @@ const SimpleBezierEdge: FunctionalComponent<EdgeProps> = function ({
   markerEnd,
   markerStart,
   style,
-  pointerRadius,
+  interactionWidth,
 }) {
   const [path, labelX, labelY] = getSimpleBezierPath({
     sourceX,
@@ -43,7 +43,7 @@ const SimpleBezierEdge: FunctionalComponent<EdgeProps> = function ({
     style,
     markerEnd,
     markerStart,
-    pointerRadius,
+    interactionWidth,
   })
 }
 
@@ -63,7 +63,7 @@ SimpleBezierEdge.props = [
   'markerEnd',
   'markerStart',
   'style',
-  'pointerRadius',
+  'interactionWidth',
 ]
 SimpleBezierEdge.inheritAttrs = false
 

--- a/packages/core/src/components/Edges/SmoothStepEdge.ts
+++ b/packages/core/src/components/Edges/SmoothStepEdge.ts
@@ -21,6 +21,7 @@ const SmoothStepEdge: FunctionalComponent<SmoothStepEdgeProps> = function ({
   borderRadius,
   offset,
   style,
+  pointerRadius,
 }) {
   const [path, labelX, labelY] = getSmoothStepPath({
     sourceX,
@@ -46,6 +47,7 @@ const SmoothStepEdge: FunctionalComponent<SmoothStepEdgeProps> = function ({
     style,
     markerEnd,
     markerStart,
+    pointerRadius,
   })
 }
 
@@ -67,6 +69,7 @@ SmoothStepEdge.props = [
   'markerEnd',
   'markerStart',
   'style',
+  'pointerRadius',
 ]
 SmoothStepEdge.inheritAttrs = false
 

--- a/packages/core/src/components/Edges/SmoothStepEdge.ts
+++ b/packages/core/src/components/Edges/SmoothStepEdge.ts
@@ -21,7 +21,7 @@ const SmoothStepEdge: FunctionalComponent<SmoothStepEdgeProps> = function ({
   borderRadius,
   offset,
   style,
-  pointerRadius,
+  interactionWidth,
 }) {
   const [path, labelX, labelY] = getSmoothStepPath({
     sourceX,
@@ -47,7 +47,7 @@ const SmoothStepEdge: FunctionalComponent<SmoothStepEdgeProps> = function ({
     style,
     markerEnd,
     markerStart,
-    pointerRadius,
+    interactionWidth,
   })
 }
 
@@ -69,7 +69,7 @@ SmoothStepEdge.props = [
   'markerEnd',
   'markerStart',
   'style',
-  'pointerRadius',
+  'interactionWidth',
 ]
 SmoothStepEdge.inheritAttrs = false
 

--- a/packages/core/src/components/Edges/StepEdge.ts
+++ b/packages/core/src/components/Edges/StepEdge.ts
@@ -22,6 +22,7 @@ StepEdge.props = [
   'markerEnd',
   'markerStart',
   'style',
+  'pointerRadius',
 ]
 StepEdge.inheritAttrs = false
 

--- a/packages/core/src/components/Edges/StepEdge.ts
+++ b/packages/core/src/components/Edges/StepEdge.ts
@@ -22,7 +22,7 @@ StepEdge.props = [
   'markerEnd',
   'markerStart',
   'style',
-  'pointerRadius',
+  'interactionWidth',
 ]
 StepEdge.inheritAttrs = false
 

--- a/packages/core/src/components/Edges/StraightEdge.ts
+++ b/packages/core/src/components/Edges/StraightEdge.ts
@@ -16,6 +16,7 @@ const StraightEdge: FunctionalComponent<EdgeProps> = function ({
   markerEnd,
   markerStart,
   style,
+  pointerRadius,
 }) {
   const [path, labelX, labelY] = getStraightPath({ sourceX, sourceY, targetX, targetY })
 
@@ -32,6 +33,7 @@ const StraightEdge: FunctionalComponent<EdgeProps> = function ({
     style,
     markerEnd,
     markerStart,
+    pointerRadius,
   })
 }
 
@@ -49,6 +51,7 @@ StraightEdge.props = [
   'markerEnd',
   'markerStart',
   'style',
+  'pointerRadius',
 ]
 StraightEdge.inheritAttrs = false
 

--- a/packages/core/src/components/Edges/StraightEdge.ts
+++ b/packages/core/src/components/Edges/StraightEdge.ts
@@ -16,7 +16,7 @@ const StraightEdge: FunctionalComponent<EdgeProps> = function ({
   markerEnd,
   markerStart,
   style,
-  pointerRadius,
+  interactionWidth,
 }) {
   const [path, labelX, labelY] = getStraightPath({ sourceX, sourceY, targetX, targetY })
 
@@ -33,7 +33,7 @@ const StraightEdge: FunctionalComponent<EdgeProps> = function ({
     style,
     markerEnd,
     markerStart,
-    pointerRadius,
+    interactionWidth,
   })
 }
 
@@ -51,7 +51,7 @@ StraightEdge.props = [
   'markerEnd',
   'markerStart',
   'style',
-  'pointerRadius',
+  'interactionWidth',
 ]
 StraightEdge.inheritAttrs = false
 

--- a/packages/core/src/components/Edges/Wrapper.ts
+++ b/packages/core/src/components/Edges/Wrapper.ts
@@ -190,7 +190,7 @@ const Wrapper = defineComponent({
                 targetY,
                 sourceHandleId: edge.sourceHandle,
                 targetHandleId: edge.targetHandle,
-                pointerRadius: edge.pointerRadius,
+                interactionWidth: edge.interactionWidth,
               }),
 
           [

--- a/packages/core/src/components/Edges/Wrapper.ts
+++ b/packages/core/src/components/Edges/Wrapper.ts
@@ -190,6 +190,7 @@ const Wrapper = defineComponent({
                 targetY,
                 sourceHandleId: edge.sourceHandle,
                 targetHandleId: edge.targetHandle,
+                pointerRadius: edge.pointerRadius,
               }),
 
           [

--- a/packages/core/src/types/edge.ts
+++ b/packages/core/src/types/edge.ts
@@ -87,7 +87,7 @@ export interface Edge<Data = ElementData, CustomEvents extends Record<string, Cu
   /** Is edge hidden */
   hidden?: boolean
   /** Radius of mouse event triggers (to ease selecting edges), defaults to 2 */
-  pointerRadius?: number
+  interactionWidth?: number
   /** Overwrites current edge type */
   template?: EdgeComponent
   /** Additional data that is passed to your custom components */
@@ -147,7 +147,7 @@ export interface EdgeProps<Data = ElementData, CustomEvents = {}> {
   markerStart?: string
   markerEnd?: string
   curvature?: number
-  pointerRadius?: number
+  interactionWidth?: number
   data: Data
   /** contextual and custom events of edge */
   events: EdgeEventsOn<CustomEvents>
@@ -183,7 +183,7 @@ export interface SmoothStepEdgeProps<Data = ElementData, CustomEvents = {}> exte
   markerEnd?: string
   borderRadius?: number
   offset?: number
-  pointerRadius?: number
+  interactionWidth?: number
   data: Data
   /** contextual and custom events of edge */
   events: EdgeEventsOn<CustomEvents>
@@ -202,5 +202,5 @@ export interface BaseEdgeProps {
   labelBgBorderRadius?: number
   markerStart?: string
   markerEnd?: string
-  pointerRadius?: number
+  interactionWidth?: number
 }

--- a/packages/core/src/types/edge.ts
+++ b/packages/core/src/types/edge.ts
@@ -86,6 +86,8 @@ export interface Edge<Data = ElementData, CustomEvents extends Record<string, Cu
   style?: Styles | StyleFunc<GraphEdge<Data, CustomEvents>>
   /** Is edge hidden */
   hidden?: boolean
+  /** Radius of mouse event triggers (to ease selecting edges), defaults to 2 */
+  pointerRadius?: number
   /** Overwrites current edge type */
   template?: EdgeComponent
   /** Additional data that is passed to your custom components */
@@ -145,6 +147,7 @@ export interface EdgeProps<Data = ElementData, CustomEvents = {}> {
   markerStart?: string
   markerEnd?: string
   curvature?: number
+  pointerRadius?: number
   data: Data
   /** contextual and custom events of edge */
   events: EdgeEventsOn<CustomEvents>
@@ -180,6 +183,7 @@ export interface SmoothStepEdgeProps<Data = ElementData, CustomEvents = {}> exte
   markerEnd?: string
   borderRadius?: number
   offset?: number
+  pointerRadius?: number
   data: Data
   /** contextual and custom events of edge */
   events: EdgeEventsOn<CustomEvents>
@@ -198,4 +202,5 @@ export interface BaseEdgeProps {
   labelBgBorderRadius?: number
   markerStart?: string
   markerEnd?: string
+  pointerRadius?: number
 }

--- a/packages/core/src/utils/graph.ts
+++ b/packages/core/src/utils/graph.ts
@@ -122,7 +122,7 @@ export const parseEdge = (edge: Edge, defaults?: Partial<GraphEdge>): GraphEdge 
         data: shallowReactive(edge.data || defaults?.data || {}),
         events: shallowReactive(edge.events || defaults?.events || {}),
         label: (edge.label && !isString(edge.label) ? markRaw(edge.label) : edge.label) || defaults?.label,
-        interactionWidth: edge.interactionWidth || defaults?.interactionWidth || 2,
+        interactionWidth: edge.interactionWidth || defaults?.interactionWidth,
       } as GraphEdge)
     : defaults
 

--- a/packages/core/src/utils/graph.ts
+++ b/packages/core/src/utils/graph.ts
@@ -122,6 +122,7 @@ export const parseEdge = (edge: Edge, defaults?: Partial<GraphEdge>): GraphEdge 
         data: shallowReactive(edge.data || defaults?.data || {}),
         events: shallowReactive(edge.events || defaults?.events || {}),
         label: (edge.label && !isString(edge.label) ? markRaw(edge.label) : edge.label) || defaults?.label,
+        pointerRadius: edge.pointerRadius || defaults?.pointerRadius || 2,
       } as GraphEdge)
     : defaults
 

--- a/packages/core/src/utils/graph.ts
+++ b/packages/core/src/utils/graph.ts
@@ -122,7 +122,7 @@ export const parseEdge = (edge: Edge, defaults?: Partial<GraphEdge>): GraphEdge 
         data: shallowReactive(edge.data || defaults?.data || {}),
         events: shallowReactive(edge.events || defaults?.events || {}),
         label: (edge.label && !isString(edge.label) ? markRaw(edge.label) : edge.label) || defaults?.label,
-        pointerRadius: edge.pointerRadius || defaults?.pointerRadius || 2,
+        interactionWidth: edge.interactionWidth || defaults?.interactionWidth || 2,
       } as GraphEdge)
     : defaults
 


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- add `interactionWidth` prop to edge
- add a second (invisible) edge path that increases pointer interactivity radius

# To-Do's

- [x] change prop name to `interactionWidth`