### PR TITLE
fix(core): use shallowReactive for node/edge data & events 

### DIFF
--- a/.changeset/stupid-bags-dance.md
+++ b/.changeset/stupid-bags-dance.md
@@ -1,0 +1,5 @@
+---
+'@vue-flow/core': patch
+---
+
+Use shallowRef for node/edge data and event objects so they trigger a re-render on custom nodes/edges

--- a/packages/core/src/utils/graph.ts
+++ b/packages/core/src/utils/graph.ts
@@ -1,3 +1,4 @@
+import { isString } from '@vueuse/core'
 import { warn } from './log'
 import type {
   Box,
@@ -76,8 +77,8 @@ export const parseNode = (node: Node, nodeExtent: CoordinateExtent, defaults?: P
       selectable: undefined,
       connectable: undefined,
       ...defaults,
-      data: node.data || {},
-      events: node.events || {},
+      data: shallowReactive(node.data || {}),
+      events: shallowReactive(node.events || {}),
     }
   }
 
@@ -103,8 +104,9 @@ export const parseEdge = (edge: Edge, defaults?: Partial<GraphEdge>): GraphEdge 
         targetY: 0,
         updatable: edge.updatable,
         selectable: edge.selectable,
-        data: edge.data || {},
-        events: edge.events || {},
+        data: shallowReactive(edge.data || {}),
+        events: shallowReactive(edge.events || {}),
+        label: edge.label && !isString(edge.label) ? markRaw(edge.label) : undefined,
         ...defaults,
       } as GraphEdge)
     : defaults


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- use `shallowRef` to wrap data and events objects
