### PR TITLE
fix(core): disable user selection if `elementsSelectable` is false 

### DIFF
--- a/.changeset/fast-shoes-beam.md
+++ b/.changeset/fast-shoes-beam.md
@@ -1,0 +1,5 @@
+---
+'@vue-flow/core': patch
+---
+
+Disable user selection if `elementsSelectable` is false

--- a/.changeset/nice-lobsters-develop.md
+++ b/.changeset/nice-lobsters-develop.md
@@ -1,0 +1,5 @@
+---
+'@vue-flow/core': patch
+---
+
+Prevent node selection box from appearing before mouseup

--- a/packages/core/src/components/UserSelection/UserSelection.vue
+++ b/packages/core/src/components/UserSelection/UserSelection.vue
@@ -46,7 +46,6 @@ const onMouseDown = (event: MouseEvent) => {
   }
 
   userSelectionActive.value = true
-  nodesSelectionActive.value = true
 }
 
 const onMouseMove = (event: MouseEvent) => {

--- a/packages/core/src/container/SelectionPane/SelectionPane.vue
+++ b/packages/core/src/container/SelectionPane/SelectionPane.vue
@@ -84,8 +84,8 @@ export default {
 </script>
 
 <template>
-  <UserSelection v-if="selectionKeyPressed" :key="`user-selection-${id}`" />
-  <NodesSelection v-if="nodesSelectionActive" :key="`nodes-selection-${id}`" />
+  <UserSelection v-if="selectionKeyPressed && userSelectionActive" />
+  <NodesSelection v-if="nodesSelectionActive" />
   <div
     :key="`pane-${id}`"
     v-bind="$attrs"


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- disable user selection when `elementsSelectable` is false
- prevent node selection box from appearing before mouseup event