### PR TITLE
fix(additional-components): render mini map nodes regardless of `only…

### DIFF
--- a/.changeset/early-bears-stare.md
+++ b/.changeset/early-bears-stare.md
@@ -1,0 +1,5 @@
+---
+'@vue-flow/additional-components': patch
+---
+
+Render mini map nodes regardless of `onlyRenderVisibleElements`

--- a/.changeset/stale-maps-doubt.md
+++ b/.changeset/stale-maps-doubt.md
@@ -1,0 +1,5 @@
+---
+'@vue-flow/additional-components': patch
+---
+
+Inject minimap slots to avoid performance drops when using template slots

--- a/packages/additional-components/src/minimap/MiniMap.vue
+++ b/packages/additional-components/src/minimap/MiniMap.vue
@@ -8,6 +8,7 @@ import type { PanelPosition } from '../panel'
 import { Panel } from '../panel'
 import type { MiniMapNodeFunc, MiniMapProps, ShapeRendering } from './types'
 import MiniMapNode from './MiniMapNode'
+import { MiniMapSlots } from './types'
 
 const {
   width,
@@ -34,14 +35,7 @@ const { id, edges, viewport, dimensions, emits, nodes, d3Selection, d3Zoom } = u
 
 const el = ref<SVGElement>()
 
-const slots = useSlots()
-
-const hasSlot = (type: string) => {
-  const slotType = slots[type]
-
-  console.log(slotType && slotType().length > 0)
-  return !!(slotType && slotType().length > 0)
-}
+provide(MiniMapSlots, useSlots())
 
 const elementWidth = computed(() => width ?? attrs.style?.width ?? defaultWidth)
 
@@ -219,29 +213,13 @@ export default {
         :stroke-color="nodeStrokeColorFunc(node)"
         :stroke-width="nodeStrokeWidth"
         :shape-rendering="shapeRendering"
+        :type="node.type"
         @click="onNodeClick($event, node)"
         @dblclick="onNodeDblClick($event, node)"
         @mouseenter="onNodeMouseEnter($event, node)"
         @mousemove="onNodeMouseMove($event, node)"
         @mouseleave="onNodeMouseLeave($event, node)"
-      >
-        <!-- todo: slot causes some lag spikes with FF when a lot of nodes are rendered -->
-        <slot
-          :id="node.id"
-          :name="`node-${node.type}`"
-          :parent-node="node.parentNode"
-          :selected="node.selected"
-          :position="node.computedPosition"
-          :dimensions="node.dimensions"
-          :style="node.style"
-          :class="nodeClassNameFunc(node)"
-          :color="nodeColorFunc(node)"
-          :border-radius="nodeBorderRadius"
-          :stroke-color="nodeStrokeColorFunc(node)"
-          :stroke-width="nodeStrokeWidth"
-          :shape-rendering="shapeRendering"
-        />
-      </MiniMapNode>
+      />
 
       <path class="vue-flow__minimap-mask" :style="pannable ? 'cursor: grab' : ''" :d="d" :fill="maskColor" fill-rule="evenodd" />
     </svg>

--- a/packages/additional-components/src/minimap/MiniMap.vue
+++ b/packages/additional-components/src/minimap/MiniMap.vue
@@ -30,7 +30,7 @@ const attrs: Record<string, any> = useAttrs()
 const defaultWidth = 200
 const defaultHeight = 150
 
-const { id, edges, viewport, dimensions, emits, getNodes, d3Selection, d3Zoom } = useVueFlow()
+const { id, edges, viewport, dimensions, emits, nodes, d3Selection, d3Zoom } = useVueFlow()
 
 const el = ref<SVGElement>()
 
@@ -59,7 +59,7 @@ const nodeClassNameFunc = computed<MiniMapNodeFunc>(() =>
   nodeClassName instanceof Function ? nodeClassName : ((() => nodeClassName) as MiniMapNodeFunc),
 )
 
-const bb = computed(() => getRectOfNodes(getNodes.value))
+const bb = computed(() => getRectOfNodes(nodes.value))
 
 const viewBB = computed(() => ({
   x: -viewport.value.x / viewport.value.zoom,
@@ -68,7 +68,7 @@ const viewBB = computed(() => ({
   height: dimensions.value.height / viewport.value.zoom,
 }))
 
-const boundingRect = computed(() => (getNodes && getNodes.value.length ? getBoundsofRects(bb.value, viewBB.value) : viewBB.value))
+const boundingRect = computed(() => (nodes.value && nodes.value.length ? getBoundsofRects(bb.value, viewBB.value) : viewBB.value))
 
 const viewScale = computed(() => {
   const scaledWidth = boundingRect.value.width / elementWidth.value
@@ -207,7 +207,7 @@ export default {
       <title :id="`vue-flow__minimap-${id}`">Vue Flow mini map {{ id }}</title>
 
       <MiniMapNode
-        v-for="node of getNodes"
+        v-for="node of nodes"
         :id="node.id"
         :key="node.id"
         :position="node.computedPosition"

--- a/packages/additional-components/src/minimap/MiniMapNode.ts
+++ b/packages/additional-components/src/minimap/MiniMapNode.ts
@@ -1,12 +1,14 @@
-import type { CSSProperties } from 'vue'
+import type { CSSProperties, Slots } from 'vue'
 import type { MiniMapNodeProps } from './types'
+import { MiniMapSlots } from './types'
 
 export default defineComponent({
   name: 'MiniMapNode',
-  props: ['id', 'position', 'dimensions', 'strokeWidth', 'strokeColor', 'borderRadius', 'color', 'shapeRendering'],
+  props: ['id', 'position', 'dimensions', 'strokeWidth', 'strokeColor', 'borderRadius', 'color', 'shapeRendering', 'type'],
   emits: ['click', 'dblclick', 'mouseenter', 'mousemove', 'mouseleave'],
-  setup(props: MiniMapNodeProps, { attrs, emit, slots }) {
+  setup(props: MiniMapNodeProps, { attrs, emit }) {
     const style = (attrs.style ?? {}) as CSSProperties
+    const miniMapSlots: Slots = inject(MiniMapSlots)!
 
     return () => [
       h('rect', {
@@ -29,7 +31,7 @@ export default defineComponent({
         onMousemove: (e: MouseEvent) => emit('mousemove', e),
         onMouseleave: (e: MouseEvent) => emit('mouseleave', e),
       }),
-      slots?.default?.(),
+      miniMapSlots[props.type] && miniMapSlots[props.type]!(props),
     ]
   },
 })

--- a/packages/additional-components/src/minimap/types.ts
+++ b/packages/additional-components/src/minimap/types.ts
@@ -1,5 +1,5 @@
 import type { Dimensions, GraphNode, XYPosition } from '@vue-flow/core'
-import type { CSSProperties } from 'vue'
+import type { CSSProperties, InjectionKey, Slots } from 'vue'
 import type { PanelPosition } from '../panel'
 
 /** expects a node and returns a color value */
@@ -38,6 +38,7 @@ export interface MiniMapProps {
 /** these props are passed to mini map node slots */
 export interface MiniMapNodeProps {
   id: string
+  type: string
   parentNode?: string
   selected?: boolean
   dragging?: boolean
@@ -49,3 +50,5 @@ export interface MiniMapNodeProps {
   strokeColor?: string
   strokeWidth?: number
 }
+
+export const MiniMapSlots: InjectionKey<Slots> = Symbol('MiniMapSlots')


### PR DESCRIPTION
…RenderVisibleElements`

# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Change 1
- Change 2
- ...

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [ ] #Issue1
- [ ] #Issue2
- [ ] ...

# 🪴 To-Dos
<!--- Tell us if there are To-Dos left -->

- [ ] To-Do 1
- [ ] To-Do 2
- ...
