### PR TITLE
fix(core,edges): when connection mode is `Loose` use all handles as connection line source handle

### DIFF
--- a/.changeset/thick-pots-accept.md
+++ b/.changeset/thick-pots-accept.md
@@ -1,0 +1,5 @@
+---
+'@vue-flow/core': patch
+---
+
+When Connection Mode is `Loose`, use all handles as possible source handles for connection lines

--- a/packages/core/src/components/ConnectionLine/ConnectionLine.vue
+++ b/packages/core/src/components/ConnectionLine/ConnectionLine.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import type { GraphNode, HandleElement } from '../../types'
-import { ConnectionLineType, Position } from '../../types'
+import { ConnectionLineType, ConnectionMode, Position } from '../../types'
 import { getMarkerId } from '../../utils'
 
 const { sourceNode } = defineProps<{
@@ -9,6 +9,7 @@ const { sourceNode } = defineProps<{
 
 const {
   getNodes,
+  connectionMode,
   connectionStartHandle,
   connectionPosition,
   connectionLineType,
@@ -26,9 +27,11 @@ const nodeId = connectionStartHandle!.nodeId
 const type = connectionStartHandle!.type
 
 const sourceHandle =
-  handleId && type
+  (connectionMode === ConnectionMode.Strict
     ? sourceNode.handleBounds[type]?.find((d: HandleElement) => d.id === handleId)
-    : type && sourceNode.handleBounds[type ?? 'source']?.[0]
+    : [...(sourceNode.handleBounds.source || []), ...(sourceNode.handleBounds.target || [])]?.find(
+        (d: HandleElement) => d.id === handleId,
+      )) || sourceNode.handleBounds[type ?? 'source']?.[0]
 
 const sourceHandleX = sourceHandle ? sourceHandle.x + sourceHandle.width / 2 : sourceNode.dimensions.width / 2
 const sourceHandleY = sourceHandle ? sourceHandle.y + sourceHandle.height / 2 : sourceNode.dimensions.height

--- a/packages/core/src/components/ConnectionLine/ConnectionLine.vue
+++ b/packages/core/src/components/ConnectionLine/ConnectionLine.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import type { GraphNode, HandleElement } from '../../types'
+import type { GraphNode } from '../../types'
 import { ConnectionLineType, ConnectionMode, Position } from '../../types'
 import { getMarkerId } from '../../utils'
 
@@ -28,10 +28,9 @@ const type = connectionStartHandle!.type
 
 const sourceHandle =
   (connectionMode === ConnectionMode.Strict
-    ? sourceNode.handleBounds[type]?.find((d: HandleElement) => d.id === handleId)
-    : [...(sourceNode.handleBounds.source || []), ...(sourceNode.handleBounds.target || [])]?.find(
-        (d: HandleElement) => d.id === handleId,
-      )) || sourceNode.handleBounds[type ?? 'source']?.[0]
+    ? sourceNode.handleBounds[type]?.find((d) => d.id === handleId)
+    : [...(sourceNode.handleBounds.source || []), ...(sourceNode.handleBounds.target || [])]?.find((d) => d.id === handleId)) ||
+  sourceNode.handleBounds[type ?? 'source']?.[0]
 
 const sourceHandleX = sourceHandle ? sourceHandle.x + sourceHandle.width / 2 : sourceNode.dimensions.width / 2
 const sourceHandleY = sourceHandle ? sourceHandle.y + sourceHandle.height / 2 : sourceNode.dimensions.height

--- a/packages/core/src/components/Edges/utils/bezier.ts
+++ b/packages/core/src/components/Edges/utils/bezier.ts
@@ -20,7 +20,7 @@ interface GetControlWithCurvatureParams {
   c: number
 }
 
-function calculateControlOffset(distance: number, curvature: number): number {
+function calculateControlOffset(distance: number, curvature: number) {
   if (distance >= 0) {
     return 0.5 * distance
   } else {

--- a/packages/core/src/components/Edges/utils/smoothstep.ts
+++ b/packages/core/src/components/Edges/utils/smoothstep.ts
@@ -137,7 +137,7 @@ function getPoints({
   return [pathPoints, centerX, centerY, defaultOffsetX, defaultOffsetY]
 }
 
-function getBend(a: XYPosition, b: XYPosition, c: XYPosition, size: number): string {
+function getBend(a: XYPosition, b: XYPosition, c: XYPosition, size: number) {
   const bendSize = Math.min(distance(a, b) / 2, distance(b, c) / 2, size)
   const { x, y } = b
 
@@ -179,7 +179,7 @@ export function getSmoothStepPath({
     offset,
   })
 
-  const path = points.reduce<string>((res, p, i) => {
+  const path = points.reduce((res, p, i) => {
     let segment = ''
 
     if (i > 0 && i < points.length - 1) {


### PR DESCRIPTION
# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] Connection line jumping to different handles