### PR TITLE
fix(core): improper check for selection key code in zoom-pan filter 

### DIFF
--- a/.changeset/pretty-cows-worry.md
+++ b/.changeset/pretty-cows-worry.md
@@ -1,0 +1,5 @@
+---
+'@vue-flow/core': patch
+---
+
+Fix improper if clause when checking for selection key code as bool

--- a/packages/core/src/container/Viewport/Viewport.vue
+++ b/packages/core/src/container/Viewport/Viewport.vue
@@ -196,7 +196,7 @@ onMounted(() => {
     if (!panOnDrag && !zoomScroll && !panOnScroll && !zoomOnDoubleClick && !zoomOnPinch) return false
 
     // during a selection we prevent all other interactions
-    if (selectionKeyPressed.value && !selectionKeyCode !== true) return false
+    if (selectionKeyPressed.value && selectionKeyCode !== true) return false
 
     // if zoom on double click is disabled, we prevent the double click event
     if (!zoomOnDoubleClick && event.type === 'dblclick') return false


### PR DESCRIPTION
# What's changed?

- for better visibility, switch drag hand to crosshair while connecting
