### PR TITLE
refactor(core): change `shallowReactive` properties in elements to `reactive`

### DIFF
--- a/.changeset/plenty-turkeys-remain.md
+++ b/.changeset/plenty-turkeys-remain.md
@@ -1,0 +1,5 @@
+---
+'@vue-flow/core': patch
+---
+
+use `reactive` instead of `shallowReactive` for nested node/edge properties

--- a/packages/core/src/utils/graph.ts
+++ b/packages/core/src/utils/graph.ts
@@ -78,7 +78,7 @@ export const parseNode = (node: Node, nodeExtent: CoordinateExtent, defaults?: P
         width: 0,
         height: 0,
       }),
-      handleBounds: shallowReactive({
+      handleBounds: reactive({
         source: [],
         target: [],
       }),
@@ -90,7 +90,7 @@ export const parseNode = (node: Node, nodeExtent: CoordinateExtent, defaults?: P
       selectable: undefined,
       connectable: undefined,
       ...defaults,
-      data: shallowReactive(node.data || {}),
+      data: reactive(node.data || {}),
       events: shallowReactive(node.events || {}),
     }
   }
@@ -118,7 +118,7 @@ export const parseEdge = (edge: Edge, defaults?: Partial<GraphEdge>): GraphEdge 
         targetY: 0 || defaults?.targetY,
         updatable: edge.updatable ?? defaults?.updatable,
         selectable: edge.selectable ?? defaults?.selectable,
-        data: shallowReactive(edge.data || defaults?.data || {}),
+        data: reactive(edge.data || defaults?.data || {}),
         events: shallowReactive(edge.events || defaults?.events || {}),
         label: (edge.label && !isString(edge.label) ? markRaw(edge.label) : edge.label) || defaults?.label,
         interactionWidth: edge.interactionWidth || defaults?.interactionWidth,


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Replace `shallowReactive` with `reactive` in nested node/edge properties

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] Re-rendering when nested data properties change, i.e. `data.property.nestedProperty`
