### PR TITLE
Sync Node position after Resizing

### DIFF
--- a/packages/resize-rotate-node/src/node/ResizeRotateNode.vue
+++ b/packages/resize-rotate-node/src/node/ResizeRotateNode.vue
@@ -25,7 +25,7 @@ const el = ref()
 
 const visible = ref(false)
 
-const { onRotateStart, onRotate, onResizeStart, onResize } = useMoveable(props.id, emits)
+const { onRotateStart, onRotate, onResizeStart, onResize, onResizeEnd } = useMoveable(props.id, emits)
 
 const toggleVisibility = (val?: boolean) => {
   visible.value = val ?? !visible.value
@@ -110,6 +110,7 @@ export default {
     :zoom="1"
     @resize-start="onResizeStart"
     @resize="onResize"
+    @resize-end="onResizeEnd"
     @rotate-start="onRotateStart"
     @rotate="onRotate"
   />

--- a/packages/resize-rotate-node/src/node/utils.ts
+++ b/packages/resize-rotate-node/src/node/utils.ts
@@ -40,6 +40,15 @@ export function useMoveable(id: string, emits: ResizeRotateNodeEmits) {
     emits('resize', { width: e.width, height: e.height })
   }
 
+  const onResizeEnd = (e: MoveableEvents['resizeEnd']) => {
+    const oldPosition = node.computedPosition
+    e.target.style.transform = `rotate(${node.data!.rotate}deg)`
+    node.position = { x: oldPosition.x + node.data!.translate[0]!, y: oldPosition.y + node.data!.translate[1]! }
+    node.data!.translate = [0, 0]
+
+    emits('updateNodeInternals')
+  }
+
   const onRotateStart = (e: MoveableEvents['rotateStart']) => {
     e.set(node.data!.rotate)
   }
@@ -57,6 +66,7 @@ export function useMoveable(id: string, emits: ResizeRotateNodeEmits) {
   return {
     onResizeStart,
     onResize,
+    onResizeEnd,
     onRotateStart,
     onRotate,
   }


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->
- Update node position and clear transform translate of node on `resizeEnd`

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->
#468

# 🪴 To-Dos
<!--- Tell us if there are To-Dos left -->

- [ ] Perhaps update node position on the fly using `onResize` event instead of `onResizeEnd`, which could make the position update smoother.
