### PR TITLE
fix(core): use connectable prop or global connectable in Handle

### DIFF
--- a/.changeset/purple-mice-cry.md
+++ b/.changeset/purple-mice-cry.md
@@ -1,0 +1,5 @@
+---
+'@vue-flow/core': patch
+---
+
+Fix handle prop connectable always falling back to true, even when explicitly set to false

--- a/packages/core/src/components/Handle/Handle.vue
+++ b/packages/core/src/components/Handle/Handle.vue
@@ -3,7 +3,7 @@ import { isFunction, isString } from '@vueuse/core'
 import type { Position } from '../../types'
 import type { HandleProps } from '../../types/handle'
 
-const { position = 'top' as Position, connectable, id, isValidConnection, ...props } = defineProps<HandleProps>()
+const { position = 'top' as Position, connectable = true, id, isValidConnection, ...props } = defineProps<HandleProps>()
 
 const type = toRef(props, 'type', 'source')
 
@@ -35,7 +35,7 @@ const isConnectable = computed(() => {
     return connectable(node, connectedEdges.value)
   }
 
-  return connectable || true
+  return isDef(connectable) ? connectable : nodesConnectable
 })
 
 onMounted(() => {


### PR DESCRIPTION
Signed-off-by: braks <78412429+bcakmakoglu@users.noreply.github.com>
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- If defined, use connectable prop, otherwise fall back to global connectable value

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] #508 
