### PR TITLE
fix(core): use regexp to fetch imports in slots patch

### DIFF
--- a/.changeset/eleven-dryers-applaud.md
+++ b/.changeset/eleven-dryers-applaud.md
@@ -1,0 +1,5 @@
+---
+'@vue-flow/core': patch
+---
+
+Fix slots type regression

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
     "prepare": "ts-patch install -s",
     "build": "vite build",
     "types": "pnpm prepare && vue-tsc --declaration --emitDeclarationOnly && tsc -p tsconfig.build.json && shx rm -rf tmp && pnpm lint:dist && pnpm run patch",
-    "patch": "node patch/slots.js  && pnpm lint:dist",
+    "patch": "node patch/slots.js",
     "theme": "postcss src/style.css -o dist/style.css && postcss src/theme-default.css -o dist/theme-default.css",
     "lint": "eslint --ext \".js,.jsx,.ts,.tsx\" --fix --ignore-path ../../.gitignore .",
     "lint:dist": "eslint --ext \".ts,.tsx\" -c .eslintrc.js --fix ./dist",

--- a/packages/core/patch/slots.js
+++ b/packages/core/patch/slots.js
@@ -12,20 +12,7 @@ async function content(path) {
 
 const filePath = resolve(__dirname, '../dist/container/VueFlow/VueFlow.vue.d.ts')
 
-const typeImportsString = `import type {
-  Connection,
-  EdgeChange,
-  EdgeMouseEvent,
-  EdgeUpdateEvent,
-  GraphEdge,
-  GraphNode,
-  NodeChange,
-  NodeDragEvent,
-  NodeMouseEvent,
-  OnConnectStartParams,
-  ViewpaneTransform,
-  VueFlowStore,
-} from '../../types'`
+const typeImportsString = /import type {\n(.*\n)+} from '\.\.\/\.\.\/types'/
 
 const patchedTypeImports = `import type {
   Connection,
@@ -41,7 +28,7 @@ const patchedTypeImports = `import type {
   NodeMouseEvent,
   NodeProps,
   OnConnectStartParams,
-  ViewpaneTransform,
+  ViewportTransform,
   VueFlowStore,
 } from '../../types'`
 


### PR DESCRIPTION
Signed-off-by: braks <78412429+bcakmakoglu@users.noreply.github.com>
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Slots patch regression due to changed import names
