### PR TITLE
fix(a11y): use correct vue flow aria names

### DIFF
--- a/packages/core/src/components/UserSelection/UserSelection.vue
+++ b/packages/core/src/components/UserSelection/UserSelection.vue
@@ -4,7 +4,7 @@ const { userSelectionRect } = useVueFlow()
 
 <template>
   <div
-    class="vue-flow__selection react-flow__container"
+    class="vue-flow__selection vue-flow__container"
     :style="{
       width: `${userSelectionRect?.width}px`,
       height: `${userSelectionRect?.height}px`,

--- a/packages/core/src/utils/a11y.ts
+++ b/packages/core/src/utils/a11y.ts
@@ -3,7 +3,7 @@ import type { XYPosition } from '~/types'
 export const ARIA_NODE_DESC_KEY = 'vue-flow__node-desc'
 export const ARIA_EDGE_DESC_KEY = 'vue-flow__edge-desc'
 
-export const ARIA_LIVE_MESSAGE = 'react-flow__aria-live'
+export const ARIA_LIVE_MESSAGE = 'vue-flow__aria-live'
 
 export const elementSelectionKeys = ['Enter', ' ', 'Escape']
 


### PR DESCRIPTION
Signed-off-by: braks <78412429+bcakmakoglu@users.noreply.github.com>

# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Change 1
- Change 2
- ...

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [ ] #Issue1
- [ ] #Issue2
- [ ] ...

# 🪴 To-Dos
<!--- Tell us if there are To-Dos left -->

- [ ] To-Do 1
- [ ] To-Do 2
- ...
