### PR TITLE
refactor(core): fit view initially when node dimensions are updated

### DIFF
--- a/.changeset/fresh-seas-admire.md
+++ b/.changeset/fresh-seas-admire.md
@@ -1,0 +1,5 @@
+---
+'@vue-flow/core': patch
+---
+
+Fit view on init is now triggered as soon as node dimensions are updated for the first time

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -21,6 +21,8 @@ import type {
 } from '~/types'
 
 export function useActions(state: State, getters: ComputedGetters): Actions {
+  let fitViewOnInitDone = false
+
   const updateNodeInternals: Actions['updateNodeInternals'] = (ids) => {
     state.hooks.updateNodeInternals.trigger(ids)
   }
@@ -150,6 +152,13 @@ export function useActions(state: State, getters: ComputedGetters): Actions {
 
       return res
     }, [])
+
+    if (state.fitViewOnInit && !fitViewOnInitDone) {
+      paneReady().then((helper) => {
+        helper.fitView()
+        fitViewOnInitDone = true
+      })
+    }
 
     if (changes.length) state.hooks.nodesChange.trigger(changes)
   }

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -141,6 +141,7 @@ export function useActions(state: State, getters: ComputedGetters): Actions {
         if (doUpdate) {
           node.handleBounds.source = getHandleBounds('.source', update.nodeElement, zoom)
           node.handleBounds.target = getHandleBounds('.target', update.nodeElement, zoom)
+          node.dimensions = dimensions
 
           res.push({
             id: node.id,


### PR DESCRIPTION
Signed-off-by: braks <78412429+bcakmakoglu@users.noreply.github.com>