### PR TITLE
fix(core,nodes): use object assign to parse node 

### DIFF
--- a/.changeset/clever-countries-hammer.md
+++ b/.changeset/clever-countries-hammer.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Use `Object.assign` when parsing node to avoid mutating the original object.

--- a/packages/core/src/utils/graph.ts
+++ b/packages/core/src/utils/graph.ts
@@ -99,11 +99,7 @@ export function parseNode(node: Node, defaults: Partial<GraphNode> = {}): GraphN
     }
   }
 
-  return {
-    ...initialState,
-    ...(node as GraphNode),
-    id: node.id.toString(),
-  }
+  return Object.assign({ id: node.id.toString() }, node, initialState) as GraphNode
 }
 
 export function parseEdge(edge: Edge, defaults: Partial<GraphEdge> = {}): GraphEdge {


### PR DESCRIPTION
Signed-off-by: braks <78412429+bcakmakoglu@users.noreply.github.com># 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Use `Object.assign` when parsing node to avoid mutating original object

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] #775 
