### PR TITLE
fix(core): remove erroneous window.stop in EdgeRenderer

### DIFF
--- a/packages/core/src/container/EdgeRenderer/EdgeRenderer.vue
+++ b/packages/core/src/container/EdgeRenderer/EdgeRenderer.vue
@@ -50,10 +50,6 @@ const groups = controlledComputed(
   () => groupEdgesByZLevel(getEdges, findNode, elevateEdgesOnSelect),
 )
 
-onBeforeUnmount(() => {
-  stop?.()
-})
-
 const selectable = (edgeSelectable?: boolean) => (typeof edgeSelectable === 'undefined' ? elementsSelectable : edgeSelectable)
 const updatable = (edgeUpdatable?: EdgeUpdatable) => (typeof edgeUpdatable === 'undefined' ? edgesUpdatable : edgeUpdatable)
 const focusable = (edgeFocusable?: boolean) => (typeof edgeFocusable === 'undefined' ? edgesFocusable : edgeFocusable)


### PR DESCRIPTION
# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

In https://github.com/bcakmakoglu/vue-flow/commit/c62c18a20d72db1591b69ba8e2cd3fdd7872af9b#diff-67a7ade8d1cb21ddf3888d44a38161a4aa06bebaf0ef24ac97387e4d67eb61f9L51, a usage of `watch` was removed. This usage of `watch` stored the unwatch function in a local variable called `stop`, which was called in `onBeforeUnmount()`. However, the removal of this `onBeforeUnmount` was missed, causing the `stop` call to start referring to [`window.stop`](https://developer.mozilla.org/en-US/docs/Web/API/Window/stop) (which I had no idea existed before today). 

The end result is that unmounting a `VueFlow` component causes all in-flight network requests to be immediately aborted. 
