### PR TITLE
fix: make @wheel and @touchstart event passive

### DIFF
--- a/packages/core/src/components/Handle/Handle.vue
+++ b/packages/core/src/components/Handle/Handle.vue
@@ -101,7 +101,7 @@ export default {
       },
     ]"
     @mousedown="handlePointerDown"
-    @touchstart="handlePointerDown"
+    @touchstart.passive="handlePointerDown"
     @click="handleClick"
   >
     <slot :id="id" />

--- a/packages/core/src/container/Pane/Pane.vue
+++ b/packages/core/src/container/Pane/Pane.vue
@@ -227,7 +227,7 @@ export default {
     :class="[{ selection: isSelecting }]"
     @click="onClick"
     @contextmenu="onContextMenu"
-    @wheel="onWheel"
+    @wheel.passive="onWheel"
     @mouseenter="onMouseEnter"
     @mousedown="onMouseDown"
     @mousemove="onMouseMove"


### PR DESCRIPTION
# 🚀 What's changed?

Make event touchstart & wheel passive, as they seem to reduce performance.

https://developer.chrome.com/en/docs/lighthouse/best-practices/uses-passive-event-listeners/

The warning is thrown very often when using VueFlow. In our case, where the graph is regenerated regularly, the performance of our application is impacted.

Example from https://vueflow.dev/examples/stress.html :

![image](https://user-images.githubusercontent.com/37600690/228303579-63169a13-31b2-408c-a9e5-bb88ce2ebf36.png)


# 🪴 To-Dos

- Build and test as I couldn't succeed in building it due to Turbo.