### PR TITLE
fix(core): reset nodes and edges before state

### DIFF
--- a/.changeset/metal-parrots-allow.md
+++ b/.changeset/metal-parrots-allow.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Reset node and edge state before the rest of the state when calling `$reset` to avoid throwing error

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -719,6 +719,9 @@ export function useActions(state: State, getters: ComputedGetters): Actions {
     toObject,
     updateNodeInternals,
     $reset: () => {
+      state.edges = []
+      state.nodes = []
+
       setState(useState())
     },
     $destroy: () => {},


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Reset node and edge state before resetting the rest of the state

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] #834 
