### PR TITLE
refactor(core): pass drag handle to useDrag

### DIFF
--- a/.changeset/bright-hornets-sell.md
+++ b/.changeset/bright-hornets-sell.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Fetch current node in drag handler, fixes drag handler using outdated node obj when it has been overwritten

--- a/packages/core/src/components/Nodes/NodeWrapper.ts
+++ b/packages/core/src/components/Nodes/NodeWrapper.ts
@@ -62,6 +62,7 @@ const NodeWrapper = defineComponent({
       el: nodeElement,
       disabled: () => !props.draggable,
       selectable: () => props.selectable,
+      dragHandle: () => node.value.dragHandle,
       onStart(args) {
         emit.dragStart({ ...args, intersections: getIntersectingNodes(node.value) })
       },

--- a/packages/core/src/composables/useDrag.ts
+++ b/packages/core/src/composables/useDrag.ts
@@ -15,6 +15,7 @@ interface UseDragParams {
   disabled?: MaybeComputedRef<boolean>
   selectable?: MaybeComputedRef<boolean>
   id?: string
+  dragHandle?: MaybeComputedRef<string | undefined>
 }
 
 function useDrag(params: UseDragParams) {
@@ -39,7 +40,7 @@ function useDrag(params: UseDragParams) {
     emits,
   } = $(useVueFlow())
 
-  const { onStart, onDrag, onStop, el, disabled, id, selectable } = params
+  const { onStart, onDrag, onStop, el, disabled, id, selectable, dragHandle } = params
 
   const dragging = ref(false)
 
@@ -209,11 +210,13 @@ function useDrag(params: UseDragParams) {
           })
           .filter((event: D3DragEvent<HTMLDivElement, null, SubjectPosition>['sourceEvent']) => {
             const target = event.target as HTMLDivElement
+            const unrefDragHandle = resolveUnref(dragHandle)
+
             return (
               !event.button &&
               (!noDragClassName ||
                 (!hasSelector(target, `.${noDragClassName}`, nodeEl) &&
-                  (!node?.dragHandle || hasSelector(target, node.dragHandle, nodeEl))))
+                  (!unrefDragHandle || hasSelector(target, unrefDragHandle, nodeEl))))
             )
           })
 


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Cleanup reactivity transform
- Cleanup unnecessary refs
- fetch node obj in drag handler to avoid possibly fetching outdated node obj (if it's been overwritten)

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] #942 
