### PR TITLE
fix(core): queue node dimension update outside of resize observer to avoid exceeding loop limit depth

### DIFF
--- a/packages/core/src/container/NodeRenderer/NodeRenderer.vue
+++ b/packages/core/src/container/NodeRenderer/NodeRenderer.vue
@@ -43,7 +43,7 @@ onMounted(() => {
       }
     })
 
-    updateNodeDimensions(updates)
+    setTimeout(() => updateNodeDimensions(updates));
   })
 })
 


### PR DESCRIPTION
# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

In my project, I recently started seeing a major uptick in errors of the form "ResizeObserver loop limit exceeded." I know when this happened - I added some code which does the following:

* when certain types of nodes get rendered, their custom component creates another node adds it to the graph, and parents it to itself (a sort of managed sub-node)

Now, it's a mystery to me why that causes this problem - I don't have `expandParent` or anything to that effect set, so it doesn't seem like this should cause dimension updates in practice. I also can't reproduce this issue consistently anywhere except my Cypress test suite - and I really have no idea what it is about that test suite which consistently reproduces this issue, either. I had planned to just chalk it up to Cypress being Cypress and leave it alone (+ ignore it in the tests), but it actually happens pretty frequently in production as well - just not consistently, never to me personally, and not for any discernable reason.

However, if I add a setTimeout inside the NodeWrapper ResizeObserver, the test suite passes without issue and no loop limit error is raised. My hypothesis is that something that's happening synchronously inside the ResizeObserver is causing a change to one of the elements being observed (perhaps in the form of a viewport transform change?) but I wasn't able to identify anything specific. I'm also not sure if there's any reason why using a setTimeout to do the actual work outside of the observer itself is a bad idea. the `updateNodeDimensions` function does do quite a bit of work and invoke quite a bit of other code and I don't think it's out of the realm of possibility that it's doing something that technically shouldn't be done inside a ResizeObserver, either directly or transitively (and there's no real guarantee something like that doesn't start happening in the future either). 

Thoughts? Any harm that could come from this? Any idea why this might be happening? 