### PR TITLE
Fix styling for animated edges

### DIFF
--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -73,7 +73,7 @@
   pointer-events: visibleStroke;
   cursor: pointer;
 
-  &.animated path {
+  &.animated .vue-flow__edge-path {
      stroke-dasharray: 5;
      animation: dashdraw 0.5s linear infinite;
    }


### PR DESCRIPTION
# 🚀 What's changed?
- Minor CSS Fixes

# 🐛 Fixes
- This fixes buggy behavior with animated edges. The current CSS applies animated dash-strokearray to the visible edge path as well as the invisible buffer zone around the path. The means that if you hover over an animated path, it will flash in and out of hover state. This PR fixes that and only applies the effect to the visible stroke.
# 🪴 To-Dos
Nothing
