### PR TITLE
feat(core): make loopback edges appear nicely

### DIFF
--- a/packages/core/src/components/Edges/BezierEdge.ts
+++ b/packages/core/src/components/Edges/BezierEdge.ts
@@ -2,16 +2,37 @@ import type { FunctionalComponent } from 'vue'
 import { h } from 'vue'
 import BaseEdge from './BaseEdge'
 import { getBezierPath } from './utils'
-import type { BezierEdgeProps } from '~/types'
+import type { BezierEdgeProps, GraphNode } from '~/types'
 import { Position } from '~/types'
 
 const BezierEdge: FunctionalComponent<BezierEdgeProps> = function (
   { sourcePosition = Position.Bottom, targetPosition = Position.Top, ...props },
   { attrs },
 ) {
+  let controlOffsetX = 0
+  let controlOffsetY = 0
+  if (attrs.sourceNode === attrs.targetNode) {
+    if (
+      (sourcePosition === Position.Bottom && targetPosition === Position.Top) ||
+      (sourcePosition === Position.Top && targetPosition === Position.Bottom)
+    ) {
+      const source = attrs.sourceNode as GraphNode
+      controlOffsetX = ((-40 - source.dimensions.width / 2) * 4) / 3
+      controlOffsetY = 0
+    } else if (
+      (sourcePosition === Position.Left && targetPosition === Position.Right) ||
+      (sourcePosition === Position.Right && targetPosition === Position.Left)
+    ) {
+      const source = attrs.sourceNode as GraphNode
+      controlOffsetX = 0
+      controlOffsetY = ((20 + source.dimensions.height / 2) * 4) / 3
+    }
+  }
   const [path, labelX, labelY] = getBezierPath({
     sourcePosition,
     targetPosition,
+    controlOffsetX,
+    controlOffsetY,
     ...props,
   })
 

--- a/packages/core/src/components/Edges/SimpleBezierEdge.ts
+++ b/packages/core/src/components/Edges/SimpleBezierEdge.ts
@@ -2,16 +2,37 @@ import type { FunctionalComponent } from 'vue'
 import { h } from 'vue'
 import BaseEdge from './BaseEdge'
 import { getSimpleBezierPath } from './utils'
-import type { SimpleBezierEdgeProps } from '~/types'
+import type { GraphNode, SimpleBezierEdgeProps } from '~/types'
 import { Position } from '~/types'
 
 const SimpleBezierEdge: FunctionalComponent<SimpleBezierEdgeProps> = function (
   { sourcePosition = Position.Bottom, targetPosition = Position.Top, ...props },
   { attrs },
 ) {
+  let controlOffsetX = 0
+  let controlOffsetY = 0
+  if (attrs.sourceNode === attrs.targetNode) {
+    if (
+      (sourcePosition === Position.Bottom && targetPosition === Position.Top) ||
+      (sourcePosition === Position.Top && targetPosition === Position.Bottom)
+    ) {
+      const source = attrs.sourceNode as GraphNode
+      controlOffsetX = ((-40 - source.dimensions.width / 2) * 4) / 3
+      controlOffsetY = 0
+    } else if (
+      (sourcePosition === Position.Left && targetPosition === Position.Right) ||
+      (sourcePosition === Position.Right && targetPosition === Position.Left)
+    ) {
+      const source = attrs.sourceNode as GraphNode
+      controlOffsetX = 0
+      controlOffsetY = ((20 + source.dimensions.height / 2) * 4) / 3
+    }
+  }
   const [path, labelX, labelY] = getSimpleBezierPath({
     sourcePosition,
     targetPosition,
+    controlOffsetX,
+    controlOffsetY,
     ...props,
   })
 

--- a/packages/core/src/components/Edges/SmoothStepEdge.ts
+++ b/packages/core/src/components/Edges/SmoothStepEdge.ts
@@ -2,19 +2,29 @@ import type { FunctionalComponent } from 'vue'
 import { h } from 'vue'
 import BaseEdge from './BaseEdge'
 import { getSmoothStepPath } from './utils'
-import type { SmoothStepEdgeProps, GraphNode } from '~/types'
+import type { GraphNode, SmoothStepEdgeProps } from '~/types'
 import { Position } from '~/types'
 
 const SmoothStepEdge: FunctionalComponent<SmoothStepEdgeProps> = function (
   { sourcePosition = Position.Bottom, targetPosition = Position.Top, ...props },
   { attrs },
 ) {
-  let centerX, centerY;
-  if (attrs.sourceNode == attrs.targetNode) {
-    if (sourcePosition == Position.Bottom && targetPosition == Position.Top) {
-      let source = attrs.sourceNode as GraphNode;
-      centerX = props.sourceX - (props.offset ?? 40) - source.dimensions.width / 2;
-      centerY = (props.sourceY + props.targetY) / 2;
+  let centerX, centerY
+  if (attrs.sourceNode === attrs.targetNode) {
+    if (
+      (sourcePosition === Position.Bottom && targetPosition === Position.Top) ||
+      (sourcePosition === Position.Top && targetPosition === Position.Bottom)
+    ) {
+      const source = attrs.sourceNode as GraphNode
+      centerX = props.sourceX - (props.offset ?? 40) - source.dimensions.width / 2
+      centerY = (props.sourceY + props.targetY) / 2
+    } else if (
+      (sourcePosition === Position.Left && targetPosition === Position.Right) ||
+      (sourcePosition === Position.Right && targetPosition === Position.Left)
+    ) {
+      const source = attrs.sourceNode as GraphNode
+      centerX = (props.sourceX + props.targetX) / 2
+      centerY = props.sourceY + (props.offset ?? 20) + source.dimensions.height / 2
     }
   }
   const [path, labelX, labelY] = getSmoothStepPath({
@@ -22,7 +32,7 @@ const SmoothStepEdge: FunctionalComponent<SmoothStepEdgeProps> = function (
     targetPosition,
     centerX,
     centerY,
-    ...props, 
+    ...props,
   })
 
   return h(BaseEdge, {

--- a/packages/core/src/components/Edges/SmoothStepEdge.ts
+++ b/packages/core/src/components/Edges/SmoothStepEdge.ts
@@ -2,17 +2,27 @@ import type { FunctionalComponent } from 'vue'
 import { h } from 'vue'
 import BaseEdge from './BaseEdge'
 import { getSmoothStepPath } from './utils'
-import type { SmoothStepEdgeProps } from '~/types'
+import type { SmoothStepEdgeProps, GraphNode } from '~/types'
 import { Position } from '~/types'
 
 const SmoothStepEdge: FunctionalComponent<SmoothStepEdgeProps> = function (
   { sourcePosition = Position.Bottom, targetPosition = Position.Top, ...props },
   { attrs },
 ) {
+  let centerX, centerY;
+  if (attrs.sourceNode == attrs.targetNode) {
+    if (sourcePosition == Position.Bottom && targetPosition == Position.Top) {
+      let source = attrs.sourceNode as GraphNode;
+      centerX = props.sourceX - (props.offset ?? 40) - source.dimensions.width / 2;
+      centerY = (props.sourceY + props.targetY) / 2;
+    }
+  }
   const [path, labelX, labelY] = getSmoothStepPath({
     sourcePosition,
     targetPosition,
-    ...props,
+    centerX,
+    centerY,
+    ...props, 
   })
 
   return h(BaseEdge, {

--- a/packages/core/src/components/Edges/utils/bezier.ts
+++ b/packages/core/src/components/Edges/utils/bezier.ts
@@ -9,6 +9,8 @@ export interface GetBezierPathParams {
   targetY: number
   targetPosition?: Position
   curvature?: number
+  controlOffsetX?: number
+  controlOffsetY?: number
 }
 
 interface GetControlWithCurvatureParams {
@@ -59,8 +61,10 @@ export function getBezierPath({
   targetY,
   targetPosition = Position.Top,
   curvature = 0.25,
+  controlOffsetX = 0,
+  controlOffsetY = 0,
 }: GetBezierPathParams): [path: string, labelX: number, labelY: number, offsetX: number, offsetY: number] {
-  const [sourceControlX, sourceControlY] = getControlWithCurvature({
+  let [sourceControlX, sourceControlY] = getControlWithCurvature({
     pos: sourcePosition,
     x1: sourceX,
     y1: sourceY,
@@ -68,7 +72,7 @@ export function getBezierPath({
     y2: targetY,
     c: curvature,
   })
-  const [targetControlX, targetControlY] = getControlWithCurvature({
+  let [targetControlX, targetControlY] = getControlWithCurvature({
     pos: targetPosition,
     x1: targetX,
     y1: targetY,
@@ -76,6 +80,11 @@ export function getBezierPath({
     y2: sourceY,
     c: curvature,
   })
+
+  sourceControlX += controlOffsetX
+  sourceControlY += controlOffsetY
+  targetControlX += controlOffsetX
+  targetControlY += controlOffsetY
 
   const [centerX, centerY, offsetX, offsetY] = getBezierEdgeCenter({
     sourceX,

--- a/packages/core/src/components/Edges/utils/simple-bezier.ts
+++ b/packages/core/src/components/Edges/utils/simple-bezier.ts
@@ -8,6 +8,8 @@ export interface GetSimpleBezierPathParams {
   targetX: number
   targetY: number
   targetPosition?: Position
+  controlOffsetX?: number
+  controlOffsetY?: number
 }
 
 interface GetControlParams {
@@ -42,21 +44,28 @@ export function getSimpleBezierPath({
   targetX,
   targetY,
   targetPosition = Position.Top,
+  controlOffsetX = 0,
+  controlOffsetY = 0,
 }: GetSimpleBezierPathParams): [path: string, labelX: number, labelY: number, offsetX: number, offsetY: number] {
-  const [sourceControlX, sourceControlY] = getControl({
+  let [sourceControlX, sourceControlY] = getControl({
     pos: sourcePosition,
     x1: sourceX,
     y1: sourceY,
     x2: targetX,
     y2: targetY,
   })
-  const [targetControlX, targetControlY] = getControl({
+  let [targetControlX, targetControlY] = getControl({
     pos: targetPosition,
     x1: targetX,
     y1: targetY,
     x2: sourceX,
     y2: sourceY,
   })
+
+  sourceControlX += controlOffsetX
+  sourceControlY += controlOffsetY
+  targetControlX += controlOffsetX
+  targetControlY += controlOffsetY
 
   const [centerX, centerY, offsetX, offsetY] = getBezierEdgeCenter({
     sourceX,


### PR DESCRIPTION
# 🚀 What's changed?
- Loopback edges (same source and destination) now render nicely
Original:
<img width="371" alt="Screen Shot 2023-06-19 at 12 07 03 PM" src="https://github.com/bcakmakoglu/vue-flow/assets/19317207/03f000df-b669-4834-8bfe-813eaa53ba1c">

New:
<img width="437" alt="Screen Shot 2023-06-19 at 12 04 03 PM" src="https://github.com/bcakmakoglu/vue-flow/assets/19317207/eed43ab9-8a5e-422e-ae40-063f2d1ce026">


# 🐛 Fixes
- Loopback edges previously were invisible as they rendered behind the node. This routes the edge around the left side.

# 🪴 To-Dos

- This currently only works for default handle positions. I don't know if you're willing to merge this without generic support for all nodes, but IMO it's better than the current default behavior.
