### PR TITLE
fix(node-resizer): Use correct class name and style for handle controls

### DIFF
--- a/packages/node-resizer/src/NodeResizer.vue
+++ b/packages/node-resizer/src/NodeResizer.vue
@@ -52,8 +52,8 @@ export default {
     <ResizeControl
       v-for="c of handleControls"
       :key="c"
-      :class="lineClassName"
-      :style="lineStyle"
+      :class="handleClassName"
+      :style="handleStyle"
       :node-id="nodeId"
       :position="c"
       :color="color"


### PR DESCRIPTION
Hi! First of all, thank you for your efforts, the library makes a lot of things easier for us!

# 🐛 Fixes
- [x] When integrating a resize handler, I noticed that the line properties are incorrectly applied to the handles as well. This is now fixed.
