### PR TITLE
feat(core): resolve promise from viewport actions on transition end

### DIFF
--- a/.changeset/dry-boxes-raise.md
+++ b/.changeset/dry-boxes-raise.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Return promises from viewport actions that are resolved when the transition of the action has ended

--- a/examples/vite/src/Basic/BasicOptionsAPI.vue
+++ b/examples/vite/src/Basic/BasicOptionsAPI.vue
@@ -64,6 +64,7 @@ export default defineComponent({
     :min-zoom="0.2"
     :max-zoom="4"
     :zoom-on-scroll="false"
+    fit-view-on-init
     @connect="onConnect"
     @pane-ready="onPaneReady"
     @node-drag-stop="onNodeDragStop"

--- a/packages/core/src/composables/useViewport.ts
+++ b/packages/core/src/composables/useViewport.ts
@@ -1,5 +1,5 @@
 import { zoomIdentity } from 'd3-zoom'
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 import type { ComputedGetters, D3Selection, GraphNode, State, ViewportFunctions } from '~/types'
 import { clampPosition, getRectOfNodes, getTransformForBounds, pointToRendererPoint } from '~/utils'
 
@@ -9,7 +9,9 @@ interface ExtendedViewport extends ViewportFunctions {
 
 const DEFAULT_PADDING = 0.1
 
-function noop() {}
+function noop() {
+  return Promise.resolve(false)
+}
 
 const initialViewportHelper: ExtendedViewport = {
   zoomIn: noop,
@@ -25,59 +27,89 @@ const initialViewportHelper: ExtendedViewport = {
 }
 
 export function useViewport(state: State, getters: ComputedGetters) {
-  const { nodes, d3Zoom, d3Selection, dimensions, translateExtent, minZoom, maxZoom, viewport, snapToGrid, snapGrid, hooks } =
-    $(state)
+  const { nodes, d3Zoom, d3Selection, dimensions, translateExtent, minZoom, maxZoom, viewport, snapToGrid, snapGrid } = $(state)
 
-  const { getNodes } = getters
+  const { getNodes, getNodesInitialized } = getters
 
-  const nodesInitialized = ref(false)
-
-  hooks.nodesInitialized.on(() => {
-    nodesInitialized.value = true
-  })
-
-  const isReady = computed(() => !!d3Zoom && !!d3Selection && !!dimensions.width && !!dimensions.height && nodesInitialized.value)
+  const isReady = computed(
+    () =>
+      !!d3Zoom &&
+      !!d3Selection &&
+      !!dimensions.width &&
+      !!dimensions.height &&
+      getNodesInitialized.value.length === getNodes.value.length,
+  )
 
   function zoom(scale: number, duration?: number) {
-    if (d3Selection && d3Zoom) {
-      d3Zoom.scaleBy(transition(d3Selection, duration), scale)
-    }
+    return new Promise<boolean>((resolve) => {
+      if (d3Selection && d3Zoom) {
+        d3Zoom.scaleBy(
+          transition(d3Selection, duration, () => {
+            resolve(true)
+          }),
+          scale,
+        )
+      } else {
+        resolve(false)
+      }
+    })
   }
 
   function transformViewport(x: number, y: number, zoom: number, duration?: number) {
-    // enforce translate extent
-    const { x: clampedX, y: clampedY } = clampPosition({ x: -x, y: -y }, translateExtent)
+    return new Promise<boolean>((resolve) => {
+      // enforce translate extent
+      const { x: clampedX, y: clampedY } = clampPosition({ x: -x, y: -y }, translateExtent)
 
-    const nextTransform = zoomIdentity.translate(-clampedX, -clampedY).scale(zoom)
+      const nextTransform = zoomIdentity.translate(-clampedX, -clampedY).scale(zoom)
 
-    if (d3Selection && d3Zoom) {
-      d3Zoom.transform(transition(d3Selection, duration), nextTransform)
-    }
+      if (d3Selection && d3Zoom) {
+        d3Zoom.transform(
+          transition(d3Selection, duration, () => {
+            resolve(true)
+          }),
+          nextTransform,
+        )
+      } else {
+        resolve(false)
+      }
+    })
   }
 
   return computed<ExtendedViewport>(() => {
     if (isReady.value) {
       return {
         initialized: true,
+        // todo: allow passing scale as option
         zoomIn: (options) => {
-          zoom(1.2, options?.duration)
+          return zoom(1.2, options?.duration)
         },
         zoomOut: (options) => {
-          zoom(1 / 1.2, options?.duration)
+          return zoom(1 / 1.2, options?.duration)
         },
         zoomTo: (zoomLevel, options) => {
-          if (d3Selection && d3Zoom) {
-            d3Zoom.scaleTo(transition(d3Selection, options?.duration), zoomLevel)
-          }
+          return new Promise<boolean>((resolve) => {
+            if (d3Selection && d3Zoom) {
+              d3Zoom.scaleTo(
+                transition(d3Selection, options?.duration, () => {
+                  resolve(true)
+                }),
+                zoomLevel,
+              )
+            } else {
+              resolve(false)
+            }
+          })
         },
         setTransform: (transform, options) => {
-          transformViewport(transform.x, transform.y, transform.zoom, options?.duration)
+          return transformViewport(transform.x, transform.y, transform.zoom, options?.duration)
         },
-        getTransform: () => ({
-          x: viewport.x,
-          y: viewport.y,
-          zoom: viewport.zoom,
-        }),
+        getTransform: () => {
+          return {
+            x: viewport.x,
+            y: viewport.y,
+            zoom: viewport.zoom,
+          }
+        },
         fitView: (
           options = {
             padding: DEFAULT_PADDING,
@@ -86,7 +118,7 @@ export function useViewport(state: State, getters: ComputedGetters) {
           },
         ) => {
           if (!nodes.length) {
-            return
+            return Promise.resolve(false)
           }
 
           const nodesToFit: GraphNode[] = (options.includeHiddenNodes ? nodes : getNodes.value).filter((node) => {
@@ -112,14 +144,14 @@ export function useViewport(state: State, getters: ComputedGetters) {
             options.offset,
           )
 
-          transformViewport(x, y, zoom, options?.duration)
+          return transformViewport(x, y, zoom, options?.duration)
         },
         setCenter: (x, y, options) => {
           const nextZoom = typeof options?.zoom !== 'undefined' ? options.zoom : maxZoom
           const centerX = dimensions.width / 2 - x * nextZoom
           const centerY = dimensions.height / 2 - y * nextZoom
 
-          transformViewport(centerX, centerY, nextZoom, options?.duration)
+          return transformViewport(centerX, centerY, nextZoom, options?.duration)
         },
         fitBounds: (bounds, options = { padding: DEFAULT_PADDING }) => {
           const { x, y, zoom } = getTransformForBounds(
@@ -131,7 +163,7 @@ export function useViewport(state: State, getters: ComputedGetters) {
             options.padding,
           )
 
-          transformViewport(x, y, zoom, options?.duration)
+          return transformViewport(x, y, zoom, options?.duration)
         },
         project: (position) => pointToRendererPoint(position, viewport, snapToGrid, snapGrid),
       }
@@ -141,6 +173,6 @@ export function useViewport(state: State, getters: ComputedGetters) {
   })
 }
 
-function transition(selection: D3Selection, ms = 0) {
-  return selection.transition().duration(ms)
+function transition(selection: D3Selection, ms = 0, onEnd: () => void) {
+  return selection.transition().duration(ms).on('end', onEnd)
 }

--- a/packages/core/src/composables/useZoomPanHelper.ts
+++ b/packages/core/src/composables/useZoomPanHelper.ts
@@ -1,106 +1,24 @@
-import { zoomIdentity } from 'd3-zoom'
 import { useVueFlow } from './useVueFlow'
-import type { D3Selection, GraphNode, ViewportFunctions } from '~/types'
-import { clampPosition, getRectOfNodes, getTransformForBounds, pointToRendererPoint } from '~/utils'
-
-const DEFAULT_PADDING = 0.1
+import { useViewport } from './useViewport'
+import type { ComputedGetters, State, ViewportFunctions } from '~/types'
 
 /**
  * @deprecated use {@link useVueFlow} instead (all viewport functions are also available in {@link useVueFlow})
  */
 export function useZoomPanHelper(vueFlowId?: string): ViewportFunctions {
-  const { nodes, d3Zoom, d3Selection, dimensions, translateExtent, minZoom, maxZoom, viewport, snapToGrid, snapGrid, getNodes } =
-    $(useVueFlow({ id: vueFlowId }))
+  const state = $(useVueFlow({ id: vueFlowId }))
+
+  const viewportHelper = useViewport(state as State, state as unknown as ComputedGetters)
 
   return {
-    zoomIn: (options) => {
-      zoom(1.2, options?.duration)
-    },
-    zoomOut: (options) => {
-      zoom(1 / 1.2, options?.duration)
-    },
-    zoomTo: (zoomLevel, options) => {
-      if (d3Selection && d3Zoom) {
-        d3Zoom.scaleTo(transition(d3Selection, options?.duration), zoomLevel)
-      }
-    },
-    setTransform: (transform, options) => {
-      transformViewport(transform.x, transform.y, transform.zoom, options?.duration)
-    },
-    getTransform: () => ({
-      x: viewport.x,
-      y: viewport.y,
-      zoom: viewport.zoom,
-    }),
-    fitView: (
-      options = {
-        padding: DEFAULT_PADDING,
-        includeHiddenNodes: false,
-        duration: 0,
-      },
-    ) => {
-      if (!nodes.length) {
-        return
-      }
-
-      const nodesToFit: GraphNode[] = (options.includeHiddenNodes ? nodes : getNodes).filter((node) => {
-        const initialized = node.initialized && node.dimensions.width && node.dimensions.height
-        let shouldInclude = true
-
-        if (options.nodes?.length) {
-          shouldInclude = options.nodes.includes(node.id)
-        }
-
-        return initialized && shouldInclude
-      })
-
-      const bounds = getRectOfNodes(nodesToFit)
-
-      const { x, y, zoom } = getTransformForBounds(
-        bounds,
-        dimensions.width,
-        dimensions.height,
-        options.minZoom ?? minZoom,
-        options.maxZoom ?? maxZoom,
-        options.padding ?? DEFAULT_PADDING,
-        options.offset,
-      )
-
-      transformViewport(x, y, zoom, options?.duration)
-    },
-    setCenter: (x, y, options) => {
-      const nextZoom = typeof options?.zoom !== 'undefined' ? options.zoom : maxZoom
-      const centerX = dimensions.width / 2 - x * nextZoom
-      const centerY = dimensions.height / 2 - y * nextZoom
-
-      transformViewport(centerX, centerY, nextZoom, options?.duration)
-    },
-    fitBounds: (bounds, options = { padding: DEFAULT_PADDING }) => {
-      const { x, y, zoom } = getTransformForBounds(bounds, dimensions.width, dimensions.height, minZoom, maxZoom, options.padding)
-
-      transformViewport(x, y, zoom, options?.duration)
-    },
-    project: (position) => pointToRendererPoint(position, viewport, snapToGrid, snapGrid),
+    fitView: (params) => viewportHelper.value.fitView(params),
+    zoomIn: (transitionOpts) => viewportHelper.value.zoomIn(transitionOpts),
+    zoomOut: (transitionOpts) => viewportHelper.value.zoomOut(transitionOpts),
+    zoomTo: (zoomLevel, transitionOpts) => viewportHelper.value.zoomTo(zoomLevel, transitionOpts),
+    setTransform: (params, transitionOpts) => viewportHelper.value.setTransform(params, transitionOpts),
+    getTransform: () => viewportHelper.value.getTransform(),
+    setCenter: (x, y, opts) => viewportHelper.value.setCenter(x, y, opts),
+    fitBounds: (params, opts) => viewportHelper.value.fitBounds(params, opts),
+    project: (params) => viewportHelper.value.project(params),
   }
-
-  function zoom(scale: number, duration?: number) {
-    if (d3Selection && d3Zoom) {
-      d3Zoom.scaleBy(transition(d3Selection, duration), scale)
-    }
-  }
-
-  function transformViewport(x: number, y: number, zoom: number, duration?: number) {
-    // enforce translate extent
-    const { x: clampedX, y: clampedY } = clampPosition({ x: -x, y: -y }, translateExtent)
-
-    const nextTransform = zoomIdentity.translate(-clampedX, -clampedY).scale(zoom)
-
-    if (d3Selection && d3Zoom) {
-      d3Zoom.transform(transition(d3Selection, duration), nextTransform)
-    }
-  }
-}
-
-function transition(selection: D3Selection, ms = 0) {
-  return selection.transition().duration(ms)
 }

--- a/packages/core/src/types/zoom.ts
+++ b/packages/core/src/types/zoom.ts
@@ -42,28 +42,28 @@ export type FitBoundsOptions = TransitionOptions & {
 }
 
 /** Fit the viewport around visible nodes */
-export type FitView = (fitViewOptions?: FitViewParams) => void
+export type FitView = (fitViewOptions?: FitViewParams) => Promise<boolean>
 
 /** project a position onto the viewport, i.e. a mouse event clientX/clientY onto graph coordinates */
 export type Project = (position: XYPosition) => XYPosition
 
 /** set center of viewport */
-export type SetCenter = (x: number, y: number, options?: SetCenterOptions) => void
+export type SetCenter = (x: number, y: number, options?: SetCenterOptions) => Promise<boolean>
 
 /** fit the viewport around bounds */
-export type FitBounds = (bounds: Rect, options?: FitBoundsOptions) => void
+export type FitBounds = (bounds: Rect, options?: FitBoundsOptions) => Promise<boolean>
 
 /** zoom in/out */
-export type ZoomInOut = (options?: TransitionOptions) => void
+export type ZoomInOut = (options?: TransitionOptions) => Promise<boolean>
 
 /** zoom to a specific level */
-export type ZoomTo = (zoomLevel: number, options?: TransitionOptions) => void
+export type ZoomTo = (zoomLevel: number, options?: TransitionOptions) => Promise<boolean>
 
 /** get current viewport transform */
 export type GetTransform = () => ViewportTransform
 
 /** set current viewport transform */
-export type SetTransform = (transform: ViewportTransform, options?: TransitionOptions) => void
+export type SetTransform = (transform: ViewportTransform, options?: TransitionOptions) => Promise<boolean>
 
 export interface ViewportFunctions {
   zoomIn: ZoomInOut


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Return promises from viewport actions, which are resolved when the viewport transitions end
