### PR TITLE
feat(core): add flag to removeNodes to remove children of a node

### DIFF
--- a/.changeset/mean-peaches-develop.md
+++ b/.changeset/mean-peaches-develop.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Add flag to `removeNodes` which allows recursively removing all child nodes of a parent

--- a/.changeset/soft-icons-marry.md
+++ b/.changeset/soft-icons-marry.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Allow passing string or `{ id }` type object to `getIncomers` and `getOutgoers`

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -155,6 +155,7 @@ export type AddNodes = (nodes: Node | Node[] | ((nodes: GraphNode[]) => Node | N
 export type RemoveNodes = (
   nodes: (string | Node) | (Node | string)[] | ((nodes: GraphNode[]) => (string | Node) | (Node | string)[]),
   removeConnectedEdges?: boolean,
+  removeChildren?: boolean,
 ) => void
 
 export type RemoveEdges = (
@@ -209,7 +210,7 @@ export interface Actions extends ViewportFunctions {
   addNodes: AddNodes
   /** parses edges and adds to state */
   addEdges: AddEdges
-  /** remove nodes (and possibly connected edges) from state */
+  /** remove nodes (and possibly connected edges and children) from state */
   removeNodes: RemoveNodes
   /** remove edges from state */
   removeEdges: RemoveEdges

--- a/packages/core/src/utils/graph.ts
+++ b/packages/core/src/utils/graph.ts
@@ -152,23 +152,23 @@ export function parseEdge(edge: Edge, defaults: Partial<GraphEdge> = {}): GraphE
 }
 
 function getConnectedElements<T extends Elements = FlowElements>(
-  node: Node,
+  nodeOrId: Node | { id: string } | string,
   elements: T,
   dir: 'source' | 'target',
 ): T extends FlowElements ? GraphNode[] : Node[] {
-  if (!isNode(node)) {
-    return []
-  }
+  const id = isString(nodeOrId) ? nodeOrId : nodeOrId.id
+
   const origin = dir === 'source' ? 'target' : 'source'
-  const ids = elements.filter((e) => isEdge(e) && e[origin] === node.id).map((e) => isEdge(e) && e[dir])
+  const ids = elements.filter((e) => isEdge(e) && e[origin] === id).map((e) => isEdge(e) && e[dir])
+
   return elements.filter((e) => ids.includes(e.id)) as T extends FlowElements ? GraphNode[] : Node[]
 }
-export function getOutgoers<T extends Elements = FlowElements>(node: Node, elements: T) {
-  return getConnectedElements(node, elements, 'target')
+export function getOutgoers<T extends Elements = FlowElements>(nodeOrId: Node | { id: string } | string, elements: T) {
+  return getConnectedElements(nodeOrId, elements, 'target')
 }
 
-export function getIncomers<T extends Elements = FlowElements>(node: Node, elements: T) {
-  return getConnectedElements(node, elements, 'source')
+export function getIncomers<T extends Elements = FlowElements>(nodeOrId: Node | { id: string } | string, elements: T) {
+  return getConnectedElements(nodeOrId, elements, 'source')
 }
 
 export function getEdgeId({ source, sourceHandle, target, targetHandle }: Connection) {


### PR DESCRIPTION
# What's Changed?

- Allow passing `string` | `Node` | `{ id }` to `getIncomers` / `getOutgoers` utils
- Add `removeChildren` arg to `removeNodes`
   - Allows recursively removing child nodes of a parent
 