### PR TITLE
docs: fix kestra showcase link

### DIFF
--- a/docs/components/home/Showcase.vue
+++ b/docs/components/home/Showcase.vue
@@ -42,7 +42,7 @@
             </div>
 
             <div class="px-1">
-              <a href="https://octai.com" target="_blank">
+              <a href="https://kestra.io" target="_blank">
                 <h2 class="text-3xl mt-6 font-semibold inline-block">Kestra</h2>
               </a>
 


### PR DESCRIPTION
Currently the showcase section of the homepage uses octai.com as the URL for both Octai and Kestra's showcase sections. This PR just updates it to use the correct URL.

# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Change Kestra's showcase section to point to the correct URL.

