### PR TITLE
fix(applyDefault): ensure that events introduced by the watcher are properly released when no longer needed

### DIFF
--- a/packages/core/src/composables/useVueFlow.ts
+++ b/packages/core/src/composables/useVueFlow.ts
@@ -134,7 +134,7 @@ export function useVueFlow(options?: FlowProps): VueFlowStore {
     detachedScope.run(() => {
       watch(
         state.applyDefault,
-        (shouldApplyDefault) => {
+        (shouldApplyDefault, __, onCleanup) => {
           const nodesChangeHandler = (changes: NodeChange[]) => {
             state.applyNodeChanges(changes)
           }
@@ -150,6 +150,11 @@ export function useVueFlow(options?: FlowProps): VueFlowStore {
             state.hooks.value.nodesChange.off(nodesChangeHandler)
             state.hooks.value.edgesChange.off(edgesChangeHandler)
           }
+
+          onCleanup(() => {
+            state.hooks.value.nodesChange.off(nodesChangeHandler)
+            state.hooks.value.edgesChange.off(edgesChangeHandler)
+          })
         },
         { immediate: true },
       )


### PR DESCRIPTION
# 🐛 Fixes
Passing the `applyDefault` option doesn't work properly. Added the missing onCleanup to ensure that events introduced by the watcher are properly released when no longer needed.