### PR TITLE
fix(core): allow pan on drag when pan key is activated

### DIFF
--- a/.changeset/twenty-pears-act.md
+++ b/.changeset/twenty-pears-act.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Allow pan on drag when pan activation key is pressed and panOnDrag is set to false


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- When `panActivationKeyCode` is triggered, enable panning by dragging

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] #1152 
