### PR TITLE
fix(core): add immediate flag to prop watchers

### DIFF
--- a/.changeset/neat-pumpkins-yawn.md
+++ b/.changeset/neat-pumpkins-yawn.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Add immediate flag to prop watchers. Fixes default viewport values not being available when viewport is mounted

--- a/.changeset/seven-walls-argue.md
+++ b/.changeset/seven-walls-argue.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Do not wait for d3zoom to be available when setting min/max zoom

--- a/packages/core/src/composables/useWatchProps.ts
+++ b/packages/core/src/composables/useWatchProps.ts
@@ -160,6 +160,9 @@ export function useWatchProps(
               store.setMaxZoom(props.maxZoom)
             }
           },
+          {
+            immediate: true,
+          },
         )
       })
     }
@@ -173,6 +176,7 @@ export function useWatchProps(
               store.setMinZoom(props.minZoom)
             }
           },
+          { immediate: true },
         )
       })
     }
@@ -185,6 +189,9 @@ export function useWatchProps(
             if (props.translateExtent && isDef(props.translateExtent)) {
               store.setTranslateExtent(props.translateExtent)
             }
+          },
+          {
+            immediate: true,
           },
         )
       })
@@ -199,6 +206,9 @@ export function useWatchProps(
               store.setNodeExtent(props.nodeExtent)
             }
           },
+          {
+            immediate: true,
+          },
         )
       })
     }
@@ -211,6 +221,9 @@ export function useWatchProps(
             if (isDef(props.applyDefault)) {
               store.applyDefault.value = props.applyDefault
             }
+          },
+          {
+            immediate: true,
           },
         )
       })
@@ -237,6 +250,7 @@ export function useWatchProps(
               store.autoConnect.value = props.autoConnect
             }
           },
+          { immediate: true },
         )
 
         watch(

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -784,13 +784,7 @@ export function useActions(
       }
     })
 
-    if (!state.d3Zoom) {
-      until(() => state.d3Zoom)
-        .not.toBeNull()
-        .then(setSkippedOptions)
-    } else {
-      setSkippedOptions()
-    }
+    setSkippedOptions()
 
     if (!state.initialized) {
       state.initialized = true


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Add immediate flag to prop watchers so we properly assign initial prop values to the store state
- Remove waiting for d3zoom to be available before setting min/max zoom etc. as these values should be available when d3zoom is initialized making waiting redundant here and causing multiple calls of `setState` to queue the execution of this watcher
