### PR TITLE
refactor(pathfinding-edge): deprecate pkg

### DIFF
--- a/packages/pathfinding-edge/README.md
+++ b/packages/pathfinding-edge/README.md
@@ -1,5 +1,7 @@
 # Vue Flow Pathfinding Edge 🧲
 
+⚠️ DEPRECATED - WILL BE REMOVED WITH NEXT MAJOR RELEASE ⚠️
+
 __Custom edge that avoids crossing nodes__
 
 ## 🛠 Setup


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Deprecate pathfinding pkg, will be removed with next major release
   - Hasn't been maintained for a long time
   - No usage requests
