### PR TITLE
fix(core): use node rect for intersection check

### DIFF
--- a/.changeset/pink-hotels-laugh.md
+++ b/.changeset/pink-hotels-laugh.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Use nodeRect to check for intersections

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -670,7 +670,7 @@ export function useActions(
       const overlappingArea = getOverlappingArea(currNodeRect, nodeRect)
       const partiallyVisible = partially && overlappingArea > 0
 
-      return partiallyVisible || overlappingArea >= Number(nodeOrRect.width) * Number(nodeOrRect.height)
+      return partiallyVisible || overlappingArea >= Number(nodeRect.width) * Number(nodeRect.height)
     })
   }
 
@@ -684,7 +684,7 @@ export function useActions(
     const overlappingArea = getOverlappingArea(nodeRect, area)
     const partiallyVisible = partially && overlappingArea > 0
 
-    return partiallyVisible || overlappingArea >= Number(nodeOrRect.width) * Number(nodeOrRect.height)
+    return partiallyVisible || overlappingArea >= Number(nodeRect.width) * Number(nodeRect.height)
   }
 
   const panBy: Actions['panBy'] = (delta) => {


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- When checking for intersections use the resulting nodeRect and not the passed nodeOrRect
