### PR TITLE
fix(core): respect zoom key when hovering nopan elements

### DIFF
--- a/.changeset/nasty-planes-prove.md
+++ b/.changeset/nasty-planes-prove.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Respect zoom activation key code when hovering an element with `nopan` on it

--- a/packages/core/src/container/Viewport/Viewport.vue
+++ b/packages/core/src/container/Viewport/Viewport.vue
@@ -190,7 +190,7 @@ onMounted(() => {
     // if the target element is inside an element with the nopan class, we prevent panning
     if (
       isWrappedWithClass(event, noPanClassName.value) &&
-      (event.type !== 'wheel' || (panOnScroll.value && event.type === 'wheel'))
+      (event.type !== 'wheel' || (panOnScroll.value && event.type === 'wheel' && !zoomKeyPressed.value))
     ) {
       return false
     }


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Allow zooming when zoom key is pressed and user hovers a nopan element
