### PR TITLE
fix(core): use nullish check when finding edge label renderer el

### DIFF
--- a/.changeset/tall-ligers-tan.md
+++ b/.changeset/tall-ligers-tan.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Add nullish check when looking up the edge label renderer el

--- a/packages/core/src/components/Edges/EdgeLabelRenderer.vue
+++ b/packages/core/src/components/Edges/EdgeLabelRenderer.vue
@@ -4,7 +4,7 @@ import { useVueFlow } from '../../composables'
 
 const { viewportRef } = useVueFlow()
 
-const teleportTarget = toRef(() => viewportRef.value!.getElementsByClassName('vue-flow__edge-labels')[0])
+const teleportTarget = toRef(() => viewportRef.value?.getElementsByClassName('vue-flow__edge-labels')[0] as undefined | unknown)
 </script>
 
 <script lang="ts">
@@ -17,7 +17,7 @@ export default {
 <template>
   <svg>
     <foreignObject height="0" width="0">
-      <Teleport :to="teleportTarget as any" :disabled="!teleportTarget">
+      <Teleport :to="teleportTarget" :disabled="!teleportTarget">
         <slot />
       </Teleport>
     </foreignObject>

--- a/packages/core/src/components/Edges/EdgeLabelRenderer.vue
+++ b/packages/core/src/components/Edges/EdgeLabelRenderer.vue
@@ -1,10 +1,11 @@
 <script lang="ts" setup>
 import { toRef } from '@vueuse/core'
+import type { TeleportProps } from 'vue'
 import { useVueFlow } from '../../composables'
 
 const { viewportRef } = useVueFlow()
 
-const teleportTarget = toRef(() => viewportRef.value?.getElementsByClassName('vue-flow__edge-labels')[0] as undefined | unknown)
+const teleportTarget = toRef(() => viewportRef.value?.getElementsByClassName('vue-flow__edge-labels')[0] as TeleportProps['to'])
 </script>
 
 <script lang="ts">

--- a/packages/pathfinding-edge/README.md
+++ b/packages/pathfinding-edge/README.md
@@ -1,5 +1,7 @@
 # Vue Flow Pathfinding Edge 🧲
 
+⚠️ DEPRECATED - WILL BE REMOVED WITH NEXT MAJOR RELEASE ⚠️
+
 __Custom edge that avoids crossing nodes__
 
 ## 🛠 Setup


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Use nullish check when looking up the edge label renderer el to avoid potential calls of `getElementsByClassname` on `null`