### PR TITLE
feat(core): add source and target handle ids to edge removal change

### DIFF
--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -520,7 +520,15 @@ export function useActions(
       const connections = getConnectedEdges(nodes).filter((edge) => (isDef(edge.deletable) ? edge.deletable : true))
 
       edgeChanges.push(
-        ...connections.map((connection) => createEdgeRemoveChange(connection.id, connection.source, connection.target)),
+        ...connections.map((connection) =>
+          createEdgeRemoveChange(
+            connection.id,
+            connection.source,
+            connection.target,
+            connection.sourceHandle,
+            connection.targetHandle,
+          ),
+        ),
       )
     }
 
@@ -590,7 +598,15 @@ export function useActions(
         return
       }
 
-      changes.push(createEdgeRemoveChange(typeof item === 'string' ? item : item.id, currEdge.source, currEdge.target))
+      changes.push(
+        createEdgeRemoveChange(
+          typeof item === 'string' ? item : item.id,
+          currEdge.source,
+          currEdge.target,
+          currEdge.sourceHandle,
+          currEdge.targetHandle,
+        ),
+      )
     })
 
     state.hooks.edgesChange.trigger(changes)

--- a/packages/core/src/types/changes.ts
+++ b/packages/core/src/types/changes.ts
@@ -55,6 +55,8 @@ export type EdgeSelectionChange = NodeSelectionChange
 export interface EdgeRemoveChange extends NodeRemoveChange {
   source: string
   target: string
+  sourceHandle: string | null
+  targetHandle: string | null
 }
 
 export interface EdgeAddChange<Data = ElementData> {

--- a/packages/core/src/utils/changes.ts
+++ b/packages/core/src/utils/changes.ts
@@ -235,11 +235,19 @@ export function createNodeRemoveChange(id: string): NodeRemoveChange {
   }
 }
 
-export function createEdgeRemoveChange(id: string, source: string, target: string): EdgeRemoveChange {
+export function createEdgeRemoveChange(
+  id: string,
+  source: string,
+  target: string,
+  sourceHandle?: string | null,
+  targetHandle?: string | null,
+): EdgeRemoveChange {
   return {
     id,
     source,
     target,
+    sourceHandle: sourceHandle || null,
+    targetHandle: targetHandle || null,
     type: 'remove',
   }
 }


### PR DESCRIPTION
# 🚀 What's changed?

First, thank you for this awesome library, we love it and use it for one of our most important parts of our apps.

This PR adds the `sourceHandle` and `targetHandle` if available on the edge removal entry.

### Why?

Back in 1.21 you were able to look up the edge being removed before it actually got removed. Now after the upgrade you cannot do that as the edge is already removed so there is no way to know which handles were involved with that edge.

Also it feels arbitrary/harmless to include the handle ids since it is information readily available to all code paths creating the removal entry item.

## More context

In our complex flow builder, a node can have multiple outgoing edges originating from multiple handles. We were relying on the handle ids to differentiate between the different outgoing edges as the edge id itself is not enough.

## Alternative we considered

We considered encoding the information needed in the edge ID itself and not rely on the handles but if this PR is accepted it will make it much easier.

-----

LMK if there any pending tasks that need to be done, It passes local checks for me.