### PR TITLE
fix(core): use `overflow: clip` for viewport element

### DIFF
--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -38,6 +38,7 @@
 
 .vue-flow__viewport {
   z-index: 4;
+  overflow: clip;
 }
 
 .vue-flow__selection {


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Fix the issue of pushing out the panel when copying a large amount of text to the textarea

https://github.com/bcakmakoglu/vue-flow/assets/14084550/3611da11-63ee-4e59-a14f-4a58fc0e2d7f