### PR TITLE
fix(core,key-press): check if key or code exists before matching

### DIFF
--- a/.changeset/brown-garlics-sin.md
+++ b/.changeset/brown-garlics-sin.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Check if `event.key` or `event.code` exists before trying to match keyfilter against keys

--- a/packages/core/src/composables/useKeyPress.ts
+++ b/packages/core/src/composables/useKeyPress.ts
@@ -39,7 +39,7 @@ function isKeyMatch(pressedKey: string, keyToMatch: string, pressedKeys: Set<str
 
 function createKeyPredicate(keyFilter: string | string[], pressedKeys: Set<string>): KeyPredicate {
   return (event: KeyboardEvent) => {
-    if (!event.code || !event.key) {
+    if (!event.code && !event.key) {
       return false
     }
 

--- a/packages/core/src/composables/useKeyPress.ts
+++ b/packages/core/src/composables/useKeyPress.ts
@@ -6,18 +6,12 @@ import { useWindow } from './useWindow'
 export function isInputDOMNode(event: KeyboardEvent): boolean {
   const target = (event.composedPath?.()?.[0] || event.target) as HTMLElement
 
-  const hasAttribute = typeof target.hasAttribute === 'function' ? target.hasAttribute('contenteditable') : false
+  const hasAttribute = typeof target?.hasAttribute === 'function' ? target.hasAttribute('contenteditable') : false
 
-  const closest = typeof target.closest === 'function' ? target.closest('.nokey') : null
+  const closest = typeof target?.closest === 'function' ? target.closest('.nokey') : null
 
   // when an input field is focused we don't want to trigger deletion or movement of nodes
-  return (
-    target instanceof HTMLInputElement ||
-    target instanceof HTMLTextAreaElement ||
-    target instanceof HTMLSelectElement ||
-    hasAttribute ||
-    !!closest
-  )
+  return ['INPUT', 'SELECT', 'TEXTAREA'].includes(target?.nodeName) || hasAttribute || !!closest
 }
 
 // we want to be able to do a multi selection event if we are in an input field
@@ -45,6 +39,10 @@ function isKeyMatch(pressedKey: string, keyToMatch: string, pressedKeys: Set<str
 
 function createKeyPredicate(keyFilter: string | string[], pressedKeys: Set<string>): KeyPredicate {
   return (event: KeyboardEvent) => {
+    if (!event.code || !event.key) {
+      return false
+    }
+
     const keyOrCode = useKeyOrCode(event.code, keyFilter)
 
     // if the keyFilter is an array of multiple keys, we need to check each possible key combination


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Check if `event.code` or `event.key` are defined before trying to match keyfilter against keys

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] #1255 
- [x] #1241 (I hope so at least 😄)
