### PR TITLE
feat(core,composables): add useHandleConnections composable

### DIFF
--- a/.changeset/chilly-cameras-promise.md
+++ b/.changeset/chilly-cameras-promise.md
@@ -3,3 +3,11 @@
 ---
 
 Add `useNodeId` composable
+
+## 🧙 Example
+
+```ts
+const nodeId = useNodeId()
+
+console.log('nodeId', nodeId) // '1'
+```

--- a/.changeset/empty-moose-report.md
+++ b/.changeset/empty-moose-report.md
@@ -3,3 +3,36 @@
 ---
 
 Add `useHandleConnections` composable
+
+## 🧙 Example
+
+```ts
+const connections = useHandleConnections({
+  // type of the handle you are looking for - accepts a `MaybeRefOrGetter<string>`
+  type: 'source',
+
+  // the id of the handle you are looking for - accepts a `MaybeRefOrGetter<string | undefined> | undefined` [OPTIONAL]
+  id: 'a',
+
+  // if not provided, the node id from the NodeIdContext is used - accepts a `MaybeRefOrGetter<string | undefined> | undefined`
+  nodeId: '1',
+  
+  // a cb that is called when a new connection is added
+  onConnect: (params) => {
+    console.log('onConnect', params)
+  },
+
+  // a cb that is called when a connection is removed
+  onDisconnect: (params) => {
+    console.log('onDisconnect', params)
+  },
+})
+
+watch(
+  connections,
+  (next) => {
+    console.log('connections', next)
+  },
+  { immediate: true },
+)
+```

--- a/.changeset/empty-moose-report.md
+++ b/.changeset/empty-moose-report.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Add `useHandleConnections` composable

--- a/.changeset/giant-pants-speak.md
+++ b/.changeset/giant-pants-speak.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Add `connectionLookup` to state

--- a/packages/core/src/composables/useHandleConnections.ts
+++ b/packages/core/src/composables/useHandleConnections.ts
@@ -9,8 +9,8 @@ import { useVueFlow } from './useVueFlow'
 
 interface UseHandleConnectionsParams {
   type: MaybeRefOrGetter<HandleType>
-  id?: MaybeRefOrGetter<string | null>
-  nodeId?: MaybeRefOrGetter<string>
+  id?: MaybeRefOrGetter<string | undefined>
+  nodeId?: MaybeRefOrGetter<string | undefined>
   onConnect?: (connections: Connection[]) => void
   onDisconnect?: (connections: Connection[]) => void
 }
@@ -28,7 +28,7 @@ interface UseHandleConnectionsParams {
  */
 export function useHandleConnections({
   type,
-  id = null,
+  id,
   nodeId,
   onConnect,
   onDisconnect,

--- a/packages/core/src/composables/useHandleConnections.ts
+++ b/packages/core/src/composables/useHandleConnections.ts
@@ -1,0 +1,67 @@
+import type { ComputedRef } from 'vue'
+import { computed, ref, watch } from 'vue'
+import type { MaybeRefOrGetter } from '@vueuse/core'
+import { toRef, toValue } from '@vueuse/core'
+import type { Connection, HandleType } from '../types'
+import { areConnectionMapsEqual, handleConnectionChange } from '../utils'
+import { useNodeId } from './useNodeId'
+import { useVueFlow } from './useVueFlow'
+
+interface UseHandleConnectionsParams {
+  type: MaybeRefOrGetter<HandleType>
+  id?: MaybeRefOrGetter<string | null>
+  nodeId?: MaybeRefOrGetter<string>
+  onConnect?: (connections: Connection[]) => void
+  onDisconnect?: (connections: Connection[]) => void
+}
+
+/**
+ * Hook to check if a <Handle /> is connected to another <Handle /> and get the connections.
+ *
+ * @public
+ * @param param.type - handle type 'source' or 'target'
+ * @param param.nodeId - node id - if not provided, the node id from the NodeIdContext is used
+ * @param param.id - the handle id (this is only needed if the node has multiple handles of the same type)
+ * @param param.onConnect - gets called when a connection is established
+ * @param param.onDisconnect - gets called when a connection is removed
+ * @returns an array with connections
+ */
+export function useHandleConnections({
+  type,
+  id = null,
+  nodeId,
+  onConnect,
+  onDisconnect,
+}: UseHandleConnectionsParams): ComputedRef<Connection[]> {
+  const { connectionLookup } = useVueFlow()
+  const _nodeId = useNodeId()
+  const currentNodeId = toRef(() => toValue(nodeId) || _nodeId)
+
+  const connections = ref<Map<string, Connection>>()
+
+  watch(
+    () => connectionLookup.value.get(`${currentNodeId.value}-${toValue(type)}-${toValue(id)}`),
+    (nextConnections) => {
+      if (areConnectionMapsEqual(connections.value, nextConnections)) {
+        return
+      }
+
+      connections.value = nextConnections
+    },
+    { immediate: true },
+  )
+
+  watch(
+    [connections, () => typeof onConnect !== 'undefined', () => typeof onDisconnect !== 'undefined'],
+    ([currentConnections], [prevConnections]) => {
+      if (prevConnections && prevConnections !== currentConnections) {
+        const _connections = currentConnections ?? new Map()
+        handleConnectionChange(prevConnections, _connections, onDisconnect)
+        handleConnectionChange(_connections, prevConnections, onConnect)
+      }
+    },
+    { immediate: true },
+  )
+
+  return computed(() => Array.from(connections.value?.values() ?? []))
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -62,15 +62,15 @@ export { defaultEdgeTypes, defaultNodeTypes } from './store/state'
 
 export { VueFlow as VueFlowInjection, NodeId as NodeIdInjection } from './context'
 
-export {
-  useZoomPanHelper,
-  useVueFlow,
-  Storage as GlobalVueFlowStorage,
-  useHandle,
-  useNode,
-  useEdge,
-  useGetPointerPosition,
-} from './composables'
+export { useZoomPanHelper } from './composables/useZoomPanHelper'
+export { useVueFlow } from './composables/useVueFlow'
+export { useHandle } from './composables/useHandle'
+export { useNode } from './composables/useNode'
+export { useEdge } from './composables/useEdge'
+export { useGetPointerPosition } from './composables/useGetPointerPosition'
+export { useNodeId } from './composables/useNodeId'
+export { useConnection } from './composables/useConnection'
+export { useHandleConnections } from './composables/useHandleConnections'
 
 export { VueFlowError, ErrorCode } from './utils/errors'
 

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -47,6 +47,7 @@ import {
   isRect,
   nodeToRect,
   parseEdge,
+  updateConnectionLookup,
   updateEdgeAction,
 } from '../utils'
 import { useState } from './state'
@@ -376,6 +377,8 @@ export function useActions(
         )
       : nextEdges
 
+    updateConnectionLookup(state.connectionLookup, validEdges)
+
     state.edges = validEdges.reduce<GraphEdge[]>((res, edge) => {
       const sourceNode = findNode(edge.source)
       const targetNode = findNode(edge.target)
@@ -587,9 +590,17 @@ export function useActions(
   const updateEdge: Actions['updateEdge'] = (oldEdge, newConnection, shouldReplaceId = true) =>
     updateEdgeAction(oldEdge, newConnection, state.edges, findEdge, shouldReplaceId, state.hooks.error.trigger)
 
-  const applyNodeChanges: Actions['applyNodeChanges'] = (changes) => applyChanges(changes, state.nodes)
+  const applyNodeChanges: Actions['applyNodeChanges'] = (changes) => {
+    return applyChanges(changes, state.nodes)
+  }
 
-  const applyEdgeChanges: Actions['applyEdgeChanges'] = (changes) => applyChanges(changes, state.edges)
+  const applyEdgeChanges: Actions['applyEdgeChanges'] = (changes) => {
+    const changedEdges = applyChanges(changes, state.edges)
+
+    updateConnectionLookup(state.connectionLookup, changedEdges)
+
+    return changedEdges
+  }
 
   const startConnection: Actions['startConnection'] = (startHandle, position, event, isClick = false) => {
     if (isClick) {

--- a/packages/core/src/store/state.ts
+++ b/packages/core/src/store/state.ts
@@ -35,6 +35,7 @@ function defaultState(): State {
     nodes: [],
     // todo: change this to a Set
     edges: [],
+    connectionLookup: new Map(),
     nodeTypes: {},
     edgeTypes: {},
 

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -29,6 +29,8 @@ import type { CustomEvent, FlowHooks, FlowHooksEmit, FlowHooksOn } from './hooks
 import type { EdgeChange, NodeChange, NodeDragItem } from './changes'
 import type { ConnectingHandle, ValidConnectionFunc } from './handle'
 
+export type ConnectionLookup = Map<string, Map<string, Connection>>
+
 export interface UpdateNodeDimensionsParams {
   id: string
   nodeElement: HTMLDivElement
@@ -48,6 +50,8 @@ export interface State extends Omit<FlowOptions, 'id' | 'modelValue'> {
   nodes: GraphNode[]
   /** all stored edges */
   edges: GraphEdge[]
+
+  connectionLookup: ConnectionLookup
 
   readonly d3Zoom: D3Zoom | null
   readonly d3Selection: D3Selection | null


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Add `connectionLookup` to state
   - Maps handles to connections (edges) for quick lookups
- Add `useHandleConnections` composable
   - Returns a `ComputedRef<Connection[]>` based on the handle parameters passed into the composable

# 🧙 Example

```ts
const connections = useHandleConnections({
  // type of the handle you are looking for - accepts a `MaybeRefOrGetter<string>`
  type: 'source',

  // the id of the handle you are looking for - accepts a `MaybeRefOrGetter<string | undefined> | undefined` [OPTIONAL]
  id: 'a',

  // if not provided, the node id from the NodeIdContext is used - accepts a `MaybeRefOrGetter<string | undefined> | undefined`
  nodeId: '1',
  
  // a cb that is called when a new connection is added
  onConnect: (params) => {
    console.log('onConnect', params)
  },

  // a cb that is called when a connection is removed
  onDisconnect: (params) => {
    console.log('onDisconnect', params)
  },
})

watch(
  connections,
  (next) => {
    console.log('connections', next)
  },
  { immediate: true },
)
```