### PR TITLE
refactor(core): find handle by id regardless of num of handles

### DIFF
--- a/.changeset/fresh-avocados-clap.md
+++ b/.changeset/fresh-avocados-clap.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Find handle by id regardless of number of handles that exist

--- a/packages/core/src/utils/edge.ts
+++ b/packages/core/src/utils/edge.ts
@@ -37,13 +37,7 @@ export function getHandle(bounds: HandleElement[] = [], handleId?: string | null
     return null
   }
 
-  if (!handleId || bounds.length === 1) {
-    return bounds[0]
-  } else if (handleId) {
-    return bounds.find((d) => d.id === handleId) || null
-  }
-
-  return null
+  return (!handleId ? bounds[0] : bounds.find((d) => d.id === handleId)) || null
 }
 
 export function getEdgePositions(


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Avoid falling back to first handle if handle length === 1
- Search for handle by id if a handle id was passed
