### PR TITLE
refactor(core): omit events when calling toObject

### DIFF
--- a/.changeset/curvy-spies-approve.md
+++ b/.changeset/curvy-spies-approve.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Omit `events` in nodes and edges when returning them from `toObject`

--- a/.changeset/slimy-cameras-pull.md
+++ b/.changeset/slimy-cameras-pull.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Deprecate `events` property on nodes and edges

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -810,6 +810,7 @@ export function useActions(
             resizing: ______,
             dragging: _______,
             initialized: ________,
+            events: _________,
             ...rest
           } = n
 
@@ -817,7 +818,7 @@ export function useActions(
         }),
         edges: state.edges.map((e) => {
           // omit internal properties when exporting
-          const { selected: _, sourceNode: __, targetNode: ___, ...rest } = e
+          const { selected: _, sourceNode: __, targetNode: ___, events: ____, ...rest } = e
 
           return rest
         }),

--- a/packages/core/src/types/edge.ts
+++ b/packages/core/src/types/edge.ts
@@ -103,7 +103,7 @@ export interface DefaultEdge<
   template?: EdgeComponent
   /** Additional data that is passed to your custom components */
   data?: Data
-  /** contextual and custom events of edge */
+  /** @deprecated will be removed in the next major version */
   events?: Partial<EdgeEventsHandler<CustomEvents>>
   /** Aria label for edge (a11y) */
   zIndex?: number
@@ -159,6 +159,7 @@ export type GraphEdge<
   sourceNode: GraphNode
   targetNode: GraphNode
   data: Data
+  /** @deprecated will be removed in the next major version */
   events: Partial<EdgeEventsHandler<CustomEvents>>
   type: Type
 } & EdgePositions

--- a/packages/core/src/types/node.ts
+++ b/packages/core/src/types/node.ts
@@ -114,6 +114,7 @@ export interface GraphNode<
   dragging: boolean
   initialized: boolean
   data: Data
+  /** @deprecated will be removed in the next major version */
   events: Partial<NodeEventsHandler<CustomEvents>>
   type: Type
 }


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Omit `events` property from nodes and edges returned by `toObject`