### PR TITLE
 refactor(core): use useOnInitHandler to emit paneReady event

### DIFF
--- a/.changeset/gorgeous-rules-relate.md
+++ b/.changeset/gorgeous-rules-relate.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Add `onInit` hook and deprecate `onPaneReady`

--- a/packages/core/src/composables/useOnInitHandler.ts
+++ b/packages/core/src/composables/useOnInitHandler.ts
@@ -7,6 +7,7 @@ export function useOnInitHandler() {
   watch(vfInstance.viewportInitialized, (isInitialized) => {
     if (isInitialized) {
       setTimeout(() => {
+        vfInstance.emits.init(vfInstance)
         vfInstance.emits.paneReady(vfInstance)
       }, 1)
     }

--- a/packages/core/src/composables/useOnInitHandler.ts
+++ b/packages/core/src/composables/useOnInitHandler.ts
@@ -4,12 +4,33 @@ import { useVueFlow } from './useVueFlow'
 export function useOnInitHandler() {
   const vfInstance = useVueFlow()
 
-  watch(vfInstance.viewportInitialized, (isInitialized) => {
-    if (isInitialized) {
-      setTimeout(() => {
-        vfInstance.emits.init(vfInstance)
-        vfInstance.emits.paneReady(vfInstance)
-      }, 1)
-    }
-  })
+  watch(
+    () => vfInstance.viewportHelper.value.viewportInitialized,
+    (isInitialized) => {
+      if (isInitialized) {
+        setTimeout(() => {
+          // todo: call these when *nodes* are initialized instead of the viewport
+          // currently doesn't work quite right because the viewport dimensions are not yet available when the nodes are initialized
+          if (!vfInstance.fitViewOnInitDone.value && vfInstance.fitViewOnInit.value) {
+            vfInstance.fitView()
+          }
+
+          vfInstance.fitViewOnInitDone.value = true
+
+          // Here, we are making all nodes visible once we have the dimensions.
+          if (!document.querySelector('#vue-flow__initialized-styles')) {
+            const style = document.createElement('style')
+            style.id = 'vue-flow__initialized-styles'
+            document.head.appendChild(style)
+
+            const css = `.vue-flow__node { visibility: visible !important; }`
+            style.appendChild(document.createTextNode(css))
+          }
+
+          vfInstance.emits.init(vfInstance)
+          vfInstance.emits.paneReady(vfInstance)
+        }, 1)
+      }
+    },
+  )
 }

--- a/packages/core/src/composables/useOnInitHandler.ts
+++ b/packages/core/src/composables/useOnInitHandler.ts
@@ -1,0 +1,14 @@
+import { watch } from 'vue'
+import { useVueFlow } from './useVueFlow'
+
+export function useOnInitHandler() {
+  const vfInstance = useVueFlow()
+
+  watch(vfInstance.viewportInitialized, (isInitialized) => {
+    if (isInitialized) {
+      setTimeout(() => {
+        vfInstance.emits.paneReady(vfInstance)
+      }, 1)
+    }
+  })
+}

--- a/packages/core/src/composables/useViewport.ts
+++ b/packages/core/src/composables/useViewport.ts
@@ -3,7 +3,7 @@ import { computed } from 'vue'
 import type { ComputedGetters, D3Selection, GraphNode, Project, State, ViewportFunctions } from '../types'
 import { clampPosition, getRectOfNodes, getTransformForBounds, pointToRendererPoint, rendererPointToPoint, warn } from '../utils'
 
-interface ExtendedViewport extends ViewportFunctions {
+export interface ViewportHelper extends ViewportFunctions {
   viewportInitialized: boolean
   screenToFlowCoordinate: Project
   flowToScreenCoordinate: Project
@@ -17,7 +17,7 @@ function noop() {
   return Promise.resolve(false)
 }
 
-const initialViewportHelper: ExtendedViewport = {
+const initialViewportHelper: ViewportHelper = {
   zoomIn: noop,
   zoomOut: noop,
   zoomTo: noop,
@@ -72,7 +72,7 @@ export function useViewport(state: State, getters: ComputedGetters) {
     })
   }
 
-  return computed<ExtendedViewport>(() => {
+  return computed<ViewportHelper>(() => {
     const isInitialized = state.d3Zoom && state.d3Selection && state.dimensions.width && state.dimensions.height
 
     if (!isInitialized) {

--- a/packages/core/src/composables/useVueFlow.ts
+++ b/packages/core/src/composables/useVueFlow.ts
@@ -56,7 +56,7 @@ export class Storage {
 
     const getters = useGetters(reactiveState, nodeIds, edgeIds)
 
-    const actions = useActions(id, emits, hooksOn, reactiveState, getters, nodeIds, edgeIds)
+    const actions = useActions(id, reactiveState, getters, nodeIds, edgeIds)
 
     actions.setState(reactiveState)
 

--- a/packages/core/src/container/VueFlow/VueFlow.vue
+++ b/packages/core/src/container/VueFlow/VueFlow.vue
@@ -4,9 +4,11 @@ import { onUnmounted, provide } from 'vue'
 import Viewport from '../Viewport/Viewport.vue'
 import A11yDescriptions from '../../components/A11y/A11yDescriptions.vue'
 import type { FlowEmits, FlowProps, FlowSlots, VueFlowStore } from '../../types'
-import { useVueFlow, useWatchProps } from '../../composables'
-import { useHooks } from '../../store'
 import { Slots } from '../../context'
+import { useOnInitHandler } from '../../composables/useOnInitHandler'
+import { useWatchProps } from '../../composables/useWatchProps'
+import { useVueFlow } from '../../composables/useVueFlow'
+import { useHooks } from '../../store/hooks'
 
 const props = withDefaults(defineProps<FlowProps>(), {
   snapToGrid: undefined,
@@ -63,6 +65,8 @@ const dispose = useWatchProps({ modelValue, nodes: modelNodes, edges: modelEdges
 })
 
 useHooks(emit, hooks)
+
+useOnInitHandler()
 
 // slots will be passed via provide
 // this is to avoid having to pass them down through all the components

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -54,8 +54,6 @@ import { useState } from './state'
 
 export function useActions(
   id: string,
-  emits: any,
-  hooksOn: any,
   state: State,
   getters: ComputedGetters,
   // todo: change to a Set
@@ -861,7 +859,7 @@ export function useActions(
         const y = viewport?.y || position[1]
         const nextZoom = viewport?.zoom || zoom || state.viewport.zoom
 
-        return until(() => viewportHelper.value.initialized)
+        return until(() => viewportHelper.value.viewportInitialized)
           .toBe(true)
           .then(() => {
             viewportHelper.value
@@ -906,7 +904,7 @@ export function useActions(
     setState(resetState)
   }
 
-  const actions: Actions = {
+  return {
     updateNodePositions,
     updateNodeDimensions,
     setElements,
@@ -959,20 +957,4 @@ export function useActions(
     $reset,
     $destroy: () => {},
   }
-
-  until(() => viewportHelper.value.initialized)
-    .toBe(true)
-    .then(() => {
-      state.hooks.paneReady.trigger({
-        id,
-        emits,
-        vueFlowVersion: typeof __VUE_FLOW_VERSION__ !== 'undefined' ? __VUE_FLOW_VERSION__ : 'UNKNOWN',
-        ...hooksOn,
-        ...state,
-        ...getters,
-        ...actions,
-      })
-    })
-
-  return actions
 }

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -180,22 +180,6 @@ export function useActions(
       return res
     }, [])
 
-    if (!state.fitViewOnInitDone && state.fitViewOnInit) {
-      viewportHelper.value.fitView()
-    }
-
-    state.fitViewOnInitDone = true
-
-    // Here, we are making all nodes visible once we have the dimensions.
-    if (!document.querySelector('#vue-flow__initialized-styles')) {
-      const style = document.createElement('style')
-      style.id = 'vue-flow__initialized-styles'
-      document.head.appendChild(style)
-
-      const css = `.vue-flow__node { visibility: visible !important; }`
-      style.appendChild(document.createTextNode(css))
-    }
-
     if (changes.length) {
       state.hooks.nodesChange.trigger(changes)
     }
@@ -954,6 +938,7 @@ export function useActions(
     toObject,
     fromObject,
     updateNodeInternals,
+    viewportHelper,
     $reset,
     $destroy: () => {},
   }

--- a/packages/core/src/store/hooks.ts
+++ b/packages/core/src/store/hooks.ts
@@ -30,6 +30,7 @@ export function createHooks(): FlowHooks {
     clickConnectStart: createExtendedEventHook(),
     clickConnectEnd: createExtendedEventHook(),
     paneReady: createExtendedEventHook(),
+    init: createExtendedEventHook(),
     move: createExtendedEventHook(),
     moveStart: createExtendedEventHook(),
     moveEnd: createExtendedEventHook(),

--- a/packages/core/src/store/state.ts
+++ b/packages/core/src/store/state.ts
@@ -50,6 +50,9 @@ function defaultState(): State {
     d3Zoom: null,
     d3Selection: null,
     d3ZoomHandler: null,
+
+    viewportInitialized: false,
+
     minZoom: 0.5,
     maxZoom: 2,
 

--- a/packages/core/src/store/state.ts
+++ b/packages/core/src/store/state.ts
@@ -51,8 +51,6 @@ function defaultState(): State {
     d3Selection: null,
     d3ZoomHandler: null,
 
-    viewportInitialized: false,
-
     minZoom: 0.5,
     maxZoom: 2,
 

--- a/packages/core/src/types/flow.ts
+++ b/packages/core/src/types/flow.ts
@@ -250,7 +250,9 @@ export interface FlowEmits {
   (event: 'viewportChangeStart', viewport: ViewportTransform): void
   (event: 'viewportChange', viewport: ViewportTransform): void
   (event: 'viewportChangeEnd', viewport: ViewportTransform): void
+  /** @deprecated use `init` instead */
   (event: 'paneReady', paneEvent: VueFlowStore): void
+  (event: 'init', paneEvent: VueFlowStore): void
   (event: 'paneScroll', paneEvent: WheelEvent | undefined): void
   (event: 'paneClick', paneEvent: MouseEvent): void
   (event: 'paneContextMenu', paneEvent: MouseEvent): void

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -63,7 +63,9 @@ export interface FlowEvents {
     event?: MouseEvent | TouchEvent
   } & OnConnectStartParams
   clickConnectEnd: MouseEvent | TouchEvent | undefined
+  /** @deprecated use `init` instead */
   paneReady: VueFlowStore
+  init: VueFlowStore
   move: { event: D3ZoomEvent<HTMLDivElement, any> | WheelEvent; flowTransform: ViewportTransform }
   moveStart: { event: D3ZoomEvent<HTMLDivElement, any> | WheelEvent; flowTransform: ViewportTransform }
   moveEnd: { event: D3ZoomEvent<HTMLDivElement, any> | WheelEvent; flowTransform: ViewportTransform }

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -1,5 +1,6 @@
 import type { CSSProperties, ComputedRef, ToRefs } from 'vue'
 import type { KeyFilter } from '@vueuse/core'
+import type { ViewportHelper } from '../composables'
 import type {
   Dimensions,
   ElementData,
@@ -56,8 +57,6 @@ export interface State extends Omit<FlowOptions, 'id' | 'modelValue'> {
   readonly d3Zoom: D3Zoom | null
   readonly d3Selection: D3Selection | null
   readonly d3ZoomHandler: D3ZoomHandler | null
-
-  viewportInitialized: boolean
 
   /** use setMinZoom action to change minZoom */
   minZoom: number
@@ -291,6 +290,8 @@ export interface Actions extends ViewportFunctions {
   getConnectedEdges: (nodesOrId: Node[] | string) => GraphEdge[]
   /** pan the viewport; return indicates if a transform has happened or not */
   panBy: (delta: XYPosition) => boolean
+  /** viewport helper instance */
+  viewportHelper: ComputedRef<ViewportHelper>
 
   /** reset state to defaults */
   $reset: () => void

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -57,6 +57,8 @@ export interface State extends Omit<FlowOptions, 'id' | 'modelValue'> {
   readonly d3Selection: D3Selection | null
   readonly d3ZoomHandler: D3ZoomHandler | null
 
+  viewportInitialized: boolean
+
   /** use setMinZoom action to change minZoom */
   minZoom: number
   /** use setMaxZoom action to change maxZoom */

--- a/tests/cypress/support/component.ts
+++ b/tests/cypress/support/component.ts
@@ -8,20 +8,19 @@ import { VueFlow } from '@vue-flow/core'
 import type { FlowProps } from '@vue-flow/core'
 
 function mountVueFlow(props?: FlowProps, attrs?: Record<string, any>, slots?: Record<string, any>) {
-  cy.mount(VueFlow as any, {
+  cy.mount(VueFlow, {
     props: {
       id: 'test',
       fitViewOnInit: true,
       ...props,
     } as FlowProps,
     attrs: {
-      key: 'flowy',
       style: {
         height: '100vh',
         width: '100vw',
-      },
+      } as CSSStyleDeclaration,
       ...attrs,
-    } as Record<string, any>,
+    },
     slots,
   })
 }


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- add `onInit` hook
- deprecate `onPaneReady`
- add `useOnInitHandler`
- emit pane ready from new composable
- add `viewportInitialized` state var
