### PR TITLE
feat(core): add updateNode & updateNodeData actions to store

### DIFF
--- a/.changeset/cuddly-flies-change.md
+++ b/.changeset/cuddly-flies-change.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Add `updateNode` action

--- a/.changeset/cuddly-flies-change.md
+++ b/.changeset/cuddly-flies-change.md
@@ -3,3 +3,17 @@
 ---
 
 Add `updateNode` action
+
+## 🧙 Example
+
+```ts
+const { updateNode } = useVueFlow()
+
+updateNode('1', { position: { x: 100, y: 100 } })
+
+// or using a function to update the node
+updateNode('1', (node) => ({ ...node, position: { x: 100, y: 100 } }))
+
+// passing options - `replace` will replace the node instead of merging it
+updateNode('1', { id: '1', label: 'Node 1', position: { x: 100, y: 100 } }, { replace: true })
+```

--- a/.changeset/nice-suits-pull.md
+++ b/.changeset/nice-suits-pull.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Add `updateNodeData` action

--- a/.changeset/nice-suits-pull.md
+++ b/.changeset/nice-suits-pull.md
@@ -3,3 +3,17 @@
 ---
 
 Add `updateNodeData` action
+
+## 🧙 Example
+
+```ts
+const { updateNodeData } = useVueFlow()
+
+updateNodeData('1', { foo: 'bar' })
+
+// or using a function to update the data
+updateNodeData('1', (data) => ({ ...data, foo: 'bar' }))
+
+// passing options - `replace` will replace the data instead of merging it
+updateNodeData('1', { foo: 'bar' }, { replace: true })
+```

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -619,7 +619,7 @@ export function useActions(
   }
 
   // todo: maybe we should use a more immutable approach, this is a bit too much mutation and hard to maintain
-  const updateNode: Actions['updateNode'] = (id, nodeUpdate, options = { replace: true }) => {
+  const updateNode: Actions['updateNode'] = (id, nodeUpdate, options = { replace: false }) => {
     const node = findNode(id)
 
     if (!node) {

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -618,6 +618,34 @@ export function useActions(
     return changedEdges
   }
 
+  // todo: maybe we should use a more immutable approach, this is a bit too much mutation and hard to maintain
+  const updateNode: Actions['updateNode'] = (id, nodeUpdate, options = { replace: true }) => {
+    const node = findNode(id)
+
+    if (!node) {
+      return
+    }
+
+    const nextNode = typeof nodeUpdate === 'function' ? nodeUpdate(node) : nodeUpdate
+
+    if (options.replace) {
+      state.nodes.splice(state.nodes.indexOf(node), 1, nextNode as GraphNode)
+    } else {
+      Object.assign(node, nextNode)
+    }
+  }
+
+  const updateNodeData: Actions['updateNodeData'] = (id, dataUpdate, options = { replace: false }) => {
+    updateNode(
+      id,
+      (node) => {
+        const nextData = typeof dataUpdate === 'function' ? dataUpdate(node) : dataUpdate
+        return options.replace ? { ...node, data: nextData } : { ...node, data: { ...node.data, ...nextData } }
+      },
+      options,
+    )
+  }
+
   const startConnection: Actions['startConnection'] = (startHandle, position, event, isClick = false) => {
     if (isClick) {
       state.connectionClickStartHandle = startHandle
@@ -919,6 +947,8 @@ export function useActions(
     findNode,
     findEdge,
     updateEdge,
+    updateNode,
+    updateNodeData,
     applyEdgeChanges,
     applyNodeChanges,
     addSelectedElements,

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -203,6 +203,18 @@ export type GetIntersectingNodes = (
   nodes?: GraphNode[],
 ) => GraphNode[]
 
+export type UpdateNode = <Data = ElementData, CustomEvents extends Record<string, CustomEvent> = any>(
+  id: string,
+  nodeUpdate: Partial<Node<Data, CustomEvents>> | ((node: GraphNode<Data, CustomEvents>) => Partial<Node<Data, CustomEvents>>),
+  options?: { replace: boolean },
+) => void
+
+export type UpdateNodeData = <Data = ElementData, CustomEvents extends Record<string, CustomEvent> = any>(
+  id: string,
+  dataUpdate: Partial<Data> | ((node: GraphNode<Data, CustomEvents>) => Partial<Data>),
+  options?: { replace: boolean },
+) => void
+
 export type IsNodeIntersecting = (node: (Partial<Node> & { id: Node['id'] }) | Rect, area: Rect, partially?: boolean) => boolean
 
 export interface Actions extends ViewportFunctions {
@@ -226,6 +238,10 @@ export interface Actions extends ViewportFunctions {
   findEdge: FindEdge
   /** updates an edge */
   updateEdge: UpdateEdge
+  /** updates a node */
+  updateNode: UpdateNode
+  /** updates the data of a node */
+  updateNodeData: UpdateNodeData
   /** applies default edge change handler */
   applyEdgeChanges: (changes: EdgeChange[]) => GraphEdge[]
   /** applies default node change handler */

--- a/tests/cypress/component/1-store/nodes/updateNode.cy.ts
+++ b/tests/cypress/component/1-store/nodes/updateNode.cy.ts
@@ -1,0 +1,96 @@
+import { useVueFlow } from '@vue-flow/core'
+import { getElements } from '../../../utils'
+
+const { nodes, edges } = getElements()
+
+describe('Store Action: `updateNode`', () => {
+  const store = useVueFlow({ id: 'test' })
+  let randomIndex: number
+
+  beforeEach(() => {
+    cy.vueFlow({
+      nodes,
+      edges,
+    })
+  })
+
+  beforeEach(() => {
+    randomIndex = Math.floor(Math.random() * nodes.length)
+  })
+
+  it('updates node from object', () => {
+    const nodeId = nodes[randomIndex].id
+
+    const newPosition = {
+      x: Math.random() * 100,
+      y: Math.random() * 100,
+    }
+
+    store.updateNode(nodeId, { position: newPosition })
+
+    const updatedNode = store.findNode(nodeId)
+
+    if (!updatedNode) {
+      throw new Error('Node not found in store')
+    }
+
+    expect(updatedNode.id).to.equal(nodeId)
+    expect(updatedNode.position.x).to.equal(newPosition.x)
+    expect(updatedNode.position.y).to.equal(newPosition.y)
+  })
+
+  it('updates node from function', () => {
+    const nodeId = nodes[randomIndex].id
+
+    let newPosition = {
+      x: 0,
+      y: 0,
+    }
+
+    store.updateNode(nodeId, (node) => {
+      newPosition = {
+        x: node.position.x + 10,
+        y: node.position.y + 10,
+      }
+
+      return { position: newPosition }
+    })
+
+    const updatedNode = store.findNode(nodeId)
+
+    if (!updatedNode) {
+      throw new Error('Node not found in store')
+    }
+
+    expect(updatedNode.id).to.equal(nodeId)
+    expect(updatedNode.position.x).to.equal(newPosition.x)
+    expect(updatedNode.position.y).to.equal(newPosition.y)
+  })
+
+  it('replaces node when `options.replace` is true', () => {
+    const nodeId = nodes[randomIndex].id
+    const testLabel = Date.now().toString()
+
+    const newNode = {
+      id: nodeId,
+      label: testLabel,
+      position: {
+        x: Math.random() * 100,
+        y: Math.random() * 100,
+      },
+    }
+
+    store.updateNode(nodeId, newNode, { replace: true })
+
+    const updatedNode = store.findNode(nodeId)
+
+    if (!updatedNode) {
+      throw new Error('Node not found in store')
+    }
+
+    expect(updatedNode.id).to.equal(nodeId)
+    expect(updatedNode.position.x).to.equal(newNode.position.x)
+    expect(updatedNode.position.y).to.equal(newNode.position.y)
+    expect(updatedNode.data).to.equal(undefined)
+  })
+})

--- a/tests/cypress/component/1-store/nodes/updateNodeData.cy.ts
+++ b/tests/cypress/component/1-store/nodes/updateNodeData.cy.ts
@@ -1,0 +1,74 @@
+import { useVueFlow } from '@vue-flow/core'
+import { getElements } from '../../../utils'
+
+const { nodes, edges } = getElements()
+
+describe('Store Action: `updateNodeData`', () => {
+  const store = useVueFlow({ id: 'test' })
+  let randomIndex: number
+
+  beforeEach(() => {
+    cy.vueFlow({
+      nodes,
+      edges,
+    })
+  })
+
+  beforeEach(() => {
+    randomIndex = Math.floor(Math.random() * nodes.length)
+  })
+
+  it('updates node data from object', () => {
+    const nodeId = nodes[randomIndex].id
+    const testData = Date.now().toString()
+
+    store.updateNodeData(nodeId, { randomData: testData })
+
+    const updatedNode = store.findNode(nodeId)
+
+    if (!updatedNode) {
+      throw new Error('Node not found in store')
+    }
+
+    expect(updatedNode.id).to.equal(nodeId)
+    expect(updatedNode.data.randomData).to.equal(testData)
+  })
+
+  it('updates node data from function', () => {
+    const nodeId = nodes[randomIndex].id
+
+    let testData = ''
+
+    store.updateNodeData(nodeId, (node) => {
+      testData = node.data.randomData + Date.now().toString()
+
+      return { randomData: testData }
+    })
+
+    const updatedNode = store.findNode(nodeId)
+
+    if (!updatedNode) {
+      throw new Error('Node not found in store')
+    }
+
+    expect(updatedNode.id).to.equal(nodeId)
+    expect(updatedNode.data.randomData).to.equal(testData)
+  })
+
+  it('replaces node data when `replace` option is true', () => {
+    const nodeId = nodes[randomIndex].id
+    const testData = Date.now().toString()
+
+    store.updateNodeData(nodeId, { testData }, { replace: true })
+
+    const updatedNode = store.findNode(nodeId)
+
+    if (!updatedNode) {
+      throw new Error('Node not found in store')
+    }
+
+    expect(updatedNode.id).to.equal(nodeId)
+    expect(updatedNode.data.testData).to.equal(testData)
+    expect(updatedNode.data.randomData).to.not.exist
+  })
+})


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Add `updateNodeData` action
- Add `updateNode` action

## 🧙 Example

### `updateNode`
```ts
const { updateNode } = useVueFlow()

updateNode('1', { position: { x: 100, y: 100 } })
```

### `updateNodeData`
```ts
const { updateNodeData } = useVueFlow()

updateNodeData('1', { foo: 'bar' })
```