### PR TITLE
fix(core): update node dimensions on next tick

### DIFF
--- a/.changeset/spotty-buckets-suffer.md
+++ b/.changeset/spotty-buckets-suffer.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Update node dimensions on next tick

--- a/packages/core/src/components/Nodes/NodeWrapper.ts
+++ b/packages/core/src/components/Nodes/NodeWrapper.ts
@@ -1,4 +1,4 @@
-import { computed, defineComponent, h, onBeforeUnmount, onMounted, provide, ref, watch } from 'vue'
+import { computed, defineComponent, h, nextTick, onBeforeUnmount, onMounted, provide, ref, watch } from 'vue'
 import { until, useVModel } from '@vueuse/core'
 import {
   ARIA_NODE_DESC_KEY,
@@ -121,13 +121,11 @@ const NodeWrapper = defineComponent({
       props.resizeObserver.unobserve(nodeElement.value as HTMLDivElement)
     })
 
-    watch(
-      [() => node.value.type, () => node.value.sourcePosition, () => node.value.targetPosition],
-      () => {
+    watch([() => node.value.type, () => node.value.sourcePosition, () => node.value.targetPosition], () => {
+      nextTick(() => {
         updateNodeDimensions([{ id: props.id, nodeElement: nodeElement.value as HTMLDivElement, forceUpdate: true }])
-      },
-      { flush: 'pre' },
-    )
+      })
+    })
 
     /** this watcher only updates XYZPosition (when dragging a parent etc) */
     watch(


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- When source/target handle position of a node changes, update it's dimensions on next tick

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] Edges using old handle bound values and being misaligned (during layouting for example)
