### PR TITLE
feat(core,composables): add `useNodesData`

### DIFF
--- a/.changeset/old-jokes-raise.md
+++ b/.changeset/old-jokes-raise.md
@@ -1,0 +1,46 @@
+---
+"@vue-flow/core": minor
+---
+
+Add `useNodesData` composable
+
+## 🧙 Example
+
+### Single node id
+
+```ts
+const nodeId = '1'
+
+const data = useNodesData(nodeId)
+
+console.log(data.value) // '[{ /* ... */ }]
+```
+
+### Array of node ids
+```ts
+const nodeIds = ['1', '2', '3']
+
+const data = useNodesData(nodeIds)
+
+console.log(data.value) // '[{ /* ... */ }]
+```
+
+### Asserting data type
+```ts
+import type { Node } from '@vue-flow/core'
+
+interface Data {
+	foo: string;
+	bar: string;
+}
+
+type MyNode = Node<CustomNodeData>
+
+const nodeId = '1'
+
+const data = useNodesData([nodeId], (node): node is MyNode => {
+  return 'foo' in node.data && 'bar' in node.data
+})
+
+console.log(data.value) // '[{ /* foo: string; bar: string */ }]
+```

--- a/packages/core/src/composables/useHandleConnections.ts
+++ b/packages/core/src/composables/useHandleConnections.ts
@@ -16,15 +16,16 @@ interface UseHandleConnectionsParams {
 }
 
 /**
- * Hook to check if a <Handle /> is connected to another <Handle /> and get the connections.
+ * Composable that returns existing connections of a handle
  *
  * @public
- * @param param.type - handle type 'source' or 'target'
- * @param param.nodeId - node id - if not provided, the node id from the NodeIdContext is used
- * @param param.id - the handle id (this is only needed if the node has multiple handles of the same type)
- * @param param.onConnect - gets called when a connection is established
- * @param param.onDisconnect - gets called when a connection is removed
- * @returns an array with connections
+ * @param UseHandleConnectionsParams
+ * @param UseHandleConnectionsParams.type - handle type `source` or `target`
+ * @param UseHandleConnectionsParams.nodeId - node id - if not provided, the node id from the `useNodeId` (meaning, the context-based injection) is used
+ * @param UseHandleConnectionsParams.id - the handle id (this is required if the node has multiple handles of the same type)
+ * @param UseHandleConnectionsParams.onConnect - gets called when a connection is created
+ * @param UseHandleConnectionsParams.onDisconnect - gets called when a connection is removed
+ * @returns An array of connections
  */
 export function useHandleConnections({
   type,

--- a/packages/core/src/composables/useNodesData.ts
+++ b/packages/core/src/composables/useNodesData.ts
@@ -1,0 +1,44 @@
+import { computed } from 'vue'
+import type { GraphNode, Node } from '../types'
+import { useVueFlow } from './useVueFlow'
+
+/**
+ * Composable for receiving data of one or multiple nodes
+ *
+ * @public
+ * @param nodeId - The id (or ids) of the node to get the data from
+ * @param guard - Optional guard function to narrow down the node type
+ * @returns An array of data objects
+ */
+export function useNodesData<NodeType extends Node = GraphNode>(nodeId: string): NodeType['data'] | null
+export function useNodesData<NodeType extends Node = GraphNode>(nodeIds: string[]): NodeType['data'][]
+export function useNodesData<NodeType extends Node = GraphNode>(
+  nodeIds: string[],
+  guard: (node: Node) => node is NodeType,
+): NodeType['data'][]
+export function useNodesData(nodeIds: any): any {
+  const { findNode } = useVueFlow()
+
+  return computed({
+    get() {
+      if (!Array.isArray(nodeIds)) {
+        return findNode(nodeIds)?.data || null
+      }
+
+      const data = []
+
+      for (const nodeId of nodeIds) {
+        const nodeData = findNode(nodeId)?.data
+
+        if (nodeData) {
+          data.push(nodeData)
+        }
+      }
+
+      return data
+    },
+    set() {
+      console.warn('You are trying to set node data via useNodesData. This is not supported.')
+    },
+  })
+}

--- a/packages/core/src/composables/useNodesData.ts
+++ b/packages/core/src/composables/useNodesData.ts
@@ -1,6 +1,9 @@
+import type { ComputedRef } from 'vue'
 import { computed } from 'vue'
 import type { GraphNode, Node } from '../types'
 import { useVueFlow } from './useVueFlow'
+
+type NodeData<NodeType extends Node = GraphNode> = NonNullable<NodeType['data']>
 
 /**
  * Composable for receiving data of one or multiple nodes
@@ -10,12 +13,12 @@ import { useVueFlow } from './useVueFlow'
  * @param guard - Optional guard function to narrow down the node type
  * @returns An array of data objects
  */
-export function useNodesData<NodeType extends Node = GraphNode>(nodeId: string): NodeType['data'] | null
-export function useNodesData<NodeType extends Node = GraphNode>(nodeIds: string[]): NodeType['data'][]
+export function useNodesData<NodeType extends Node = GraphNode>(nodeId: string): ComputedRef<NodeData<NodeType> | null>
+export function useNodesData<NodeType extends Node = GraphNode>(nodeIds: string[]): ComputedRef<NodeData<NodeType>[]>
 export function useNodesData<NodeType extends Node = GraphNode>(
   nodeIds: string[],
   guard: (node: Node) => node is NodeType,
-): NodeType['data'][]
+): ComputedRef<NodeData<NodeType>[]>
 export function useNodesData(nodeIds: any): any {
   const { findNode } = useVueFlow()
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -71,6 +71,7 @@ export { useGetPointerPosition } from './composables/useGetPointerPosition'
 export { useNodeId } from './composables/useNodeId'
 export { useConnection } from './composables/useConnection'
 export { useHandleConnections } from './composables/useHandleConnections'
+export { useNodesData } from './composables/useNodesData'
 
 export { VueFlowError, ErrorCode } from './utils/errors'
 

--- a/tests/cypress/component/4-composables/useNodesData.cy.ts
+++ b/tests/cypress/component/4-composables/useNodesData.cy.ts
@@ -1,0 +1,92 @@
+import type { Node } from '@vue-flow/core'
+import { useNodesData } from '@vue-flow/core'
+import { defineComponent, h } from 'vue'
+import { getElements } from '../../utils'
+
+const { nodes } = getElements()
+
+describe('Composable: `useNodesData`', () => {
+  describe('returns node data for a single node', () => {
+    let data: any = null
+
+    const node = nodes[0]
+
+    beforeEach(() => {
+      cy.vueFlow(
+        {
+          nodes: nodes.map((node) => ({ ...node, type: 'custom' })),
+        },
+        {},
+        {
+          'node-custom': defineComponent({
+            setup() {
+              data = useNodesData(nodes[0].id)
+
+              return () => h('div', 'Custom Node')
+            },
+          }),
+        },
+      )
+    })
+
+    it('should return the node data', () => {
+      expect(data.value).to.deep.equal(node.data)
+    })
+  })
+
+  describe('returns node data for multiple nodes', () => {
+    let data: any = null
+
+    const nodeIds = nodes.map((node) => node.id)
+
+    beforeEach(() => {
+      cy.vueFlow(
+        {
+          nodes: nodes.map((node) => ({ ...node, type: 'custom' })),
+        },
+        {},
+        {
+          'node-custom': defineComponent({
+            setup() {
+              data = useNodesData(nodeIds)
+
+              return () => h('div', 'Custom Node')
+            },
+          }),
+        },
+      )
+    })
+
+    it('should return the node data', () => {
+      expect(data.value).to.deep.equal(nodes.map((node) => node.data))
+    })
+  })
+
+  describe('returns node data for multiple nodes with a guard', () => {
+    let data: any = null
+
+    const nodeIds = nodes.map((node) => node.id)
+
+    beforeEach(() => {
+      cy.vueFlow(
+        {
+          nodes: nodes.map((node) => ({ ...node, type: 'custom' })),
+        },
+        {},
+        {
+          'node-custom': defineComponent({
+            setup() {
+              data = useNodesData(nodeIds, (node): node is Node<{ randomData: number }> => node.type === 'custom')
+
+              return () => h('div', 'Custom Node')
+            },
+          }),
+        },
+      )
+    })
+
+    it('should return the node data', () => {
+      expect(data.value).to.deep.equal(nodes.map((node) => node.data))
+    })
+  })
+})


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Add `useNodesData` composable

## 🧙 Example

### Single node id

```ts
const nodeId = '1'

const data = useNodesData(nodeId)

console.log(data.value) // '[{ /* ... */ }]
```

### Array of node ids
```ts
const nodeIds = ['1', '2', '3']

const data = useNodesData(nodeIds)

console.log(data.value) // '[{ /* ... */ }]
```

### Asserting data type
```ts
import type { Node } from '@vue-flow/core'

interface Data {
	foo: string;
	bar: string;
}

type MyNode = Node<CustomNodeData>

const nodeId = '1'

const data = useNodesData([nodeId], (node): node is MyNode => {
  return 'foo' in node.data && 'bar' in node.data
})

console.log(data.value) // '[{ /* foo: string; bar: string */ }]
```