### PR TITLE
feat(core,composables): add `useNodesInitialized` composable

### DIFF
--- a/packages/core/src/composables/useNodesInitialized.ts
+++ b/packages/core/src/composables/useNodesInitialized.ts
@@ -1,0 +1,26 @@
+import { computed } from 'vue'
+import { useVueFlow } from './useVueFlow'
+
+export interface UseNodesInitializedOptions {
+  includeHiddenNodes?: boolean
+}
+
+export function useNodesInitialized(options: UseNodesInitializedOptions = { includeHiddenNodes: false }) {
+  const { nodes } = useVueFlow()
+
+  return computed(() => {
+    if (nodes.value.length === 0) {
+      return false
+    }
+
+    for (const node of nodes.value) {
+      if (options.includeHiddenNodes || !node.hidden) {
+        if (node?.handleBounds === undefined) {
+          return false
+        }
+      }
+    }
+
+    return true
+  })
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -71,6 +71,7 @@ export { useNodeId } from './composables/useNodeId'
 export { useConnection } from './composables/useConnection'
 export { useHandleConnections } from './composables/useHandleConnections'
 export { useNodesData } from './composables/useNodesData'
+export { useNodesInitialized } from './composables/useNodesInitialized'
 
 export { VueFlowError, ErrorCode, isErrorOfType } from './utils/errors'
 

--- a/packages/core/src/store/getters.ts
+++ b/packages/core/src/store/getters.ts
@@ -125,10 +125,16 @@ export function useGetters(state: State, nodeIds: ComputedRef<string[]>, edgeIds
     ...(getSelectedEdges.value ?? []),
   ])
 
+  /**
+   * @deprecated will be removed in next major version; use `useNodesInitialized` instead
+   */
   const getNodesInitialized: ComputedGetters['getNodesInitialized'] = computed(() =>
     getNodes.value.filter((n) => n.initialized && n.handleBounds !== undefined),
   )
 
+  /**
+   * @deprecated will be removed in next major version; use `useNodesInitialized` instead
+   */
   const areNodesInitialized: ComputedGetters['areNodesInitialized'] = computed(
     () => getNodes.value.length > 0 && getNodesInitialized.value.length === getNodes.value.length,
   )

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -321,11 +321,20 @@ export interface Getters {
   getEdgeTypes: Record<keyof DefaultEdgeTypes | string, EdgeComponent>
   /** returns object containing current node types */
   getNodeTypes: Record<keyof DefaultNodeTypes | string, NodeComponent>
-  /** get all elements (filters hidden elements) */
+  /**
+   * @deprecated - will be removed in next major version
+   * get all elements (filters hidden elements)
+   */
   getElements: FlowElements
-  /** filters hidden nodes */
+  /**
+   * @deprecated - will be removed in next major version; use `useVisibleNodes` instead
+   * all visible nodes
+   */
   getNodes: GraphNode[]
-  /** filters hidden edges */
+  /**
+   * @deprecated - will be removed in next major version; use `useVisibleEdges` instead
+   * all visible edges
+   */
   getEdges: GraphEdge[]
   /** @deprecated use {@link Actions.findNode} instead; returns a node by id */
   getNode: (id: string) => GraphNode | undefined
@@ -337,9 +346,15 @@ export interface Getters {
   getSelectedNodes: GraphNode[]
   /** returns all currently selected edges */
   getSelectedEdges: GraphEdge[]
-  /** returns all nodes that are initialized, i.e. they have actual dimensions */
+  /**
+   * @deprecated - will be removed in next major version; use `useNodesInitialized` instead
+   * returns all nodes that are initialized, i.e. they have actual dimensions
+   */
   getNodesInitialized: GraphNode[]
-  /** returns a boolean flag whether all current nodes are initialized */
+  /**
+   * @deprecated - will be removed in next major version; use `useNodesInitialized` instead
+   * returns a boolean flag whether all current nodes are initialized
+   */
   areNodesInitialized: boolean
 }
 

--- a/tests/cypress/component/4-composables/useNodesInitialized.cy.ts
+++ b/tests/cypress/component/4-composables/useNodesInitialized.cy.ts
@@ -1,0 +1,56 @@
+import { defineComponent, h, watch } from 'vue'
+import { useNodesInitialized } from '@vue-flow/core'
+import { getElements } from '../../utils'
+
+const { nodes } = getElements()
+
+const ComposableTester = defineComponent({
+  emits: ['change'],
+  setup(_, { emit }) {
+    const nodesInitialized = useNodesInitialized()
+
+    watch(
+      nodesInitialized,
+      (value) => {
+        emit('change', value)
+      },
+      { immediate: true },
+    )
+
+    return 'Composable Tester'
+  },
+})
+
+describe('Composable: `useNodesInitialized`', () => {
+  it('should return that nodes are initialized', () => {
+    const onChangeSpy = cy.spy().as('onChangeSpy')
+
+    cy.vueFlow(
+      {
+        nodes,
+      },
+      {},
+      {
+        default: () => h(ComposableTester, { onChange: onChangeSpy }),
+      },
+    )
+
+    cy.get('@onChangeSpy').should('have.been.calledWith', true)
+  })
+
+  it('should return that nodes are not initialized', () => {
+    const onChangeSpy = cy.spy().as('onChangeSpy')
+
+    cy.vueFlow(
+      {
+        nodes: [],
+      },
+      {},
+      {
+        default: () => h(ComposableTester, { onChange: onChangeSpy }),
+      },
+    )
+
+    cy.get('@onChangeSpy').should('have.been.calledWith', false)
+  })
+})


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Add `useNodesInitialized` composable
- Deprecate getters for nodes initialized
