### PR TITLE
refactor(core): call nodes initialized whenever areNodesInitialized is true

### DIFF
--- a/.changeset/curvy-needles-enjoy.md
+++ b/.changeset/curvy-needles-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Call `onNodesInitialized` whenever `areNodesInitialized` is true instead of only once

--- a/packages/core/src/container/NodeRenderer/NodeRenderer.vue
+++ b/packages/core/src/container/NodeRenderer/NodeRenderer.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { getCurrentInstance, inject, nextTick, onBeforeUnmount, onMounted, ref, resolveComponent } from 'vue'
-import { until } from '@vueuse/core'
+import { whenever } from '@vueuse/core'
 import { NodeWrapper } from '../../components'
 import type { GraphNode, HandleConnectable, NodeComponent } from '../../types'
 import { Slots } from '../../context'
@@ -26,13 +26,14 @@ const resizeObserver = ref<ResizeObserver>()
 
 const instance = getCurrentInstance()
 
-until(() => areNodesInitialized.value)
-  .toBe(true)
-  .then(() => {
+whenever(
+  () => areNodesInitialized.value,
+  () => {
     nextTick(() => {
       emits.nodesInitialized(getNodesInitialized.value)
     })
-  })
+  },
+)
 
 onMounted(() => {
   resizeObserver.value = new ResizeObserver((entries) => {


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Call `onNodesInitialized` whenever `areNodesInitialized` is `true` instead of calling it only once

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] Being unable to listen if new nodes have been initialized or not