### PR TITLE
fix(core): use existing node/edge obj for assignment

### DIFF
--- a/.changeset/odd-months-clap.md
+++ b/.changeset/odd-months-clap.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+When updating nodes or edges by overwriting the original array, update the nodes and edges in the state by using them as the target for `Object.assign`. This keeps reference in-tact and ensures reactivity when these objects are changed/updated

--- a/packages/core/src/composables/useVueFlow.ts
+++ b/packages/core/src/composables/useVueFlow.ts
@@ -1,7 +1,7 @@
 import { toRefs, tryOnScopeDispose } from '@vueuse/core'
 import type { EffectScope } from 'vue'
 import { computed, effectScope, getCurrentScope, inject, provide, reactive, watch } from 'vue'
-import type { EdgeChange, FlowOptions, FlowProps, NodeChange, State, VueFlowStore } from '../types'
+import type { EdgeChange, FlowOptions, FlowProps, NodeChange, VueFlowStore } from '../types'
 import { warn } from '../utils'
 import { useActions, useGetters, useState } from '../store'
 import { VueFlow } from '../context'
@@ -35,7 +35,7 @@ export class Storage {
   }
 
   public create(id: string, preloadedState?: FlowOptions): VueFlowStore {
-    const state: State = useState(preloadedState)
+    const state = useState()
 
     const reactiveState = reactive(state)
 
@@ -58,7 +58,7 @@ export class Storage {
 
     const actions = useActions(id, reactiveState, getters, nodeIds, edgeIds)
 
-    actions.setState(reactiveState)
+    actions.setState({ ...reactiveState, ...preloadedState })
 
     const flow: VueFlowStore = {
       ...hooksOn,

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -448,14 +448,14 @@ export function useActions(
     nextEdges = Array.isArray(nextEdges) ? nextEdges : [nextEdges]
 
     const validEdges = state.isValidConnection
-      ? nextEdges.filter((edge) =>
-          state.isValidConnection!(edge, {
+      ? nextEdges.filter((edge) => {
+          return state.isValidConnection?.(edge, {
             edges: state.edges,
             nodes: state.nodes,
             sourceNode: findNode(edge.source)!,
             targetNode: findNode(edge.target)!,
-          }),
-        )
+          })
+        })
       : nextEdges
 
     const changes = validEdges.reduce((edgeChanges, connection) => {

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -51,7 +51,7 @@ import {
   updateConnectionLookup,
   updateEdgeAction,
 } from '../utils'
-import { useState } from './state'
+import { storeOptionsToSkip, useState } from './state'
 
 export function useActions(
   id: string,
@@ -345,7 +345,6 @@ export function useActions(
 
   const setNodeExtent: Actions['setNodeExtent'] = (nodeExtent) => {
     state.nodeExtent = nodeExtent
-
     updateNodeInternals(nodeIds.value)
   }
 
@@ -742,19 +741,6 @@ export function useActions(
   const setState: Actions['setState'] = (options) => {
     const opts = options instanceof Function ? options(state) : options
 
-    // these options will be set using the appropriate methods
-    const skip: (keyof typeof opts)[] = [
-      'modelValue',
-      'nodes',
-      'edges',
-      'maxZoom',
-      'minZoom',
-      'translateExtent',
-      'nodeExtent',
-      'hooks',
-      'defaultEdgeOptions',
-    ]
-
     // these options cannot be set after initialization
     const exclude: (keyof typeof opts)[] = [
       'd3Zoom',
@@ -799,16 +785,13 @@ export function useActions(
       if (isDef(opts.translateExtent)) {
         setTranslateExtent(opts.translateExtent)
       }
-      if (isDef(opts.nodeExtent)) {
-        setNodeExtent(opts.nodeExtent)
-      }
     }
 
     for (const o of Object.keys(opts)) {
       const key = o as keyof State
       const option = opts[key]
 
-      if (![...skip, ...exclude].includes(key) && isDef(option)) {
+      if (![...storeOptionsToSkip, ...exclude].includes(key) && isDef(option)) {
         ;(<any>state)[key] = option
       }
     }

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -408,10 +408,10 @@ export function useActions(
         return res
       }
 
-      const storedEdge = findEdge(edge.id)
+      const existingEdge = findEdge(edge.id)
 
       res.push({
-        ...parseEdge(edge, Object.assign({}, storedEdge, state.defaultEdgeOptions)),
+        ...parseEdge(edge, existingEdge, state.defaultEdgeOptions),
         sourceNode,
         targetNode,
       })
@@ -459,15 +459,8 @@ export function useActions(
         )
       : nextEdges
 
-    const changes = validEdges.reduce((edgeChanges, param) => {
-      const edge = addEdgeToStore(
-        {
-          ...param,
-          ...state.defaultEdgeOptions,
-        },
-        state.edges,
-        state.hooks.error.trigger,
-      )
+    const changes = validEdges.reduce((edgeChanges, connection) => {
+      const edge = addEdgeToStore(connection, state.edges, state.hooks.error.trigger, state.defaultEdgeOptions)
 
       if (edge) {
         const sourceNode = findNode(edge.source)!

--- a/packages/core/src/store/state.ts
+++ b/packages/core/src/store/state.ts
@@ -10,7 +10,7 @@ import {
   StepEdge,
   StraightEdge,
 } from '../components'
-import { isDef, isMacOs } from '../utils'
+import { isMacOs } from '../utils'
 import { createHooks } from './hooks'
 
 export const defaultNodeTypes: DefaultNodeTypes = {
@@ -27,7 +27,7 @@ export const defaultEdgeTypes: DefaultEdgeTypes = {
   simplebezier: SimpleBezierEdge,
 }
 
-function defaultState(): State {
+export function useState(): State {
   return {
     vueFlowRef: null,
     viewportRef: null,
@@ -144,17 +144,18 @@ function defaultState(): State {
   }
 }
 
-export function useState(opts?: FlowOptions): State {
-  const state = defaultState()
-
-  if (opts) {
-    for (const key of Object.keys(opts)) {
-      const option = opts[key as keyof typeof opts]
-      if (isDef(option)) {
-        ;(state as any)[key] = option
-      }
-    }
-  }
-
-  return state
-}
+// these options will be set using the appropriate methods
+export const storeOptionsToSkip: (keyof Partial<FlowOptions & Omit<State, 'nodes' | 'edges' | 'modelValue'>>)[] = [
+  'id',
+  'vueFlowRef',
+  'viewportRef',
+  'initialized',
+  'modelValue',
+  'nodes',
+  'edges',
+  'maxZoom',
+  'minZoom',
+  'translateExtent',
+  'hooks',
+  'defaultEdgeOptions',
+]

--- a/packages/core/src/utils/store.ts
+++ b/packages/core/src/utils/store.ts
@@ -16,8 +16,8 @@ export function addEdgeToStore(
   triggerError: State['hooks']['error']['trigger'],
   defaultEdgeOptions?: DefaultEdgeOptions,
 ): GraphEdge | false {
-  if (!edgeParams.source || !edgeParams.target) {
-    triggerError(new VueFlowError(ErrorCode.EDGE_INVALID, (edgeParams as Edge).id))
+  if (!edgeParams || !edgeParams.source || !edgeParams.target) {
+    triggerError(new VueFlowError(ErrorCode.EDGE_INVALID, (edgeParams as undefined | Edge)?.id ?? `[ID UNKNOWN]`))
     return false
   }
 

--- a/packages/core/src/utils/store.ts
+++ b/packages/core/src/utils/store.ts
@@ -84,7 +84,7 @@ export function createGraphNodes(
 ) {
   const parentNodes: Record<string, true> = {}
 
-  const graphNodes = nodes.reduce((nextNodes, node, currentIndex) => {
+  const nextNodes = nodes.reduce((nextNodes, node, currentIndex) => {
     // make sure we don't try to add invalid nodes
     if (!isNode(node)) {
       triggerError(
@@ -103,10 +103,10 @@ export function createGraphNodes(
     return nextNodes.concat(parsed)
   }, [] as GraphNode[])
 
-  const nextNodes = [...graphNodes, ...currGraphNodes]
+  const allNodes = [...nextNodes, ...currGraphNodes]
 
-  for (const node of graphNodes) {
-    const parentNode = nextNodes.find((n) => n.id === node.parentNode)
+  for (const node of nextNodes) {
+    const parentNode = allNodes.find((n) => n.id === node.parentNode)
 
     if (node.parentNode && !parentNode) {
       triggerError(new VueFlowError(ErrorCode.NODE_MISSING_PARENT, node.id, node.parentNode))
@@ -123,7 +123,7 @@ export function createGraphNodes(
     }
   }
 
-  return graphNodes
+  return nextNodes
 }
 
 export function updateConnectionLookup(connectionLookup: ConnectionLookup, edges: Edge[]) {


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Use existing node / edge objects for target of `Object.assign` when parsing nodes / edges

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] Nodes / Edges losing reactivity when the original array is reassigned with a new one