### PR TITLE
refactor(core): use `data` obj for labels in default nodes

### DIFF
--- a/packages/core/src/components/Nodes/DefaultNode.ts
+++ b/packages/core/src/components/Nodes/DefaultNode.ts
@@ -4,14 +4,17 @@ import Handle from '../Handle/Handle.vue'
 import type { NodeProps } from '../../types'
 import { Position } from '../../types'
 
-const DefaultNode: FunctionalComponent<NodeProps> = function ({
+const DefaultNode: FunctionalComponent<NodeProps<{ label: any }>> = function ({
   sourcePosition = Position.Bottom,
   targetPosition = Position.Top,
-  label,
+  label: _label,
   connectable = true,
   isValidTargetPos,
   isValidSourcePos,
+  data,
 }) {
+  const label = data.label || _label
+
   return [
     h(Handle as Component, { type: 'target', position: targetPosition, connectable, isValidConnection: isValidTargetPos }),
     typeof label !== 'string' && label ? h(label) : h('div', { innerHTML: label }),
@@ -19,7 +22,7 @@ const DefaultNode: FunctionalComponent<NodeProps> = function ({
   ]
 }
 
-DefaultNode.props = ['sourcePosition', 'targetPosition', 'label', 'isValidTargetPos', 'isValidSourcePos', 'connectable']
+DefaultNode.props = ['sourcePosition', 'targetPosition', 'label', 'isValidTargetPos', 'isValidSourcePos', 'connectable', 'data']
 DefaultNode.inheritAttrs = false
 DefaultNode.compatConfig = { MODE: 3 }
 

--- a/packages/core/src/components/Nodes/InputNode.ts
+++ b/packages/core/src/components/Nodes/InputNode.ts
@@ -4,19 +4,22 @@ import Handle from '../Handle/Handle.vue'
 import type { NodeProps } from '../../types'
 import { Position } from '../../types'
 
-const InputNode: FunctionalComponent<NodeProps> = function ({
+const InputNode: FunctionalComponent<NodeProps<{ label: any }>> = function ({
   sourcePosition = Position.Bottom,
-  label,
+  label: _label,
   connectable = true,
   isValidSourcePos,
+  data,
 }) {
+  const label = data.label || _label
+
   return [
     typeof label !== 'string' && label ? h(label) : h('div', { innerHTML: label }),
     h(Handle as Component, { type: 'source', position: sourcePosition, connectable, isValidConnection: isValidSourcePos }),
   ]
 }
 
-InputNode.props = ['sourcePosition', 'label', 'isValidSourcePos', 'connectable']
+InputNode.props = ['sourcePosition', 'label', 'isValidSourcePos', 'connectable', 'data']
 InputNode.inheritAttrs = false
 InputNode.compatConfig = { MODE: 3 }
 

--- a/packages/core/src/components/Nodes/OutputNode.ts
+++ b/packages/core/src/components/Nodes/OutputNode.ts
@@ -6,17 +6,20 @@ import { Position } from '../../types'
 
 const OutputNode: FunctionalComponent<NodeProps> = function ({
   targetPosition = Position.Top,
-  label,
+  label: _label,
   connectable = true,
   isValidTargetPos,
+  data,
 }) {
+  const label = data.label || _label
+
   return [
     h(Handle as Component, { type: 'target', position: targetPosition, connectable, isValidConnection: isValidTargetPos }),
     typeof label !== 'string' && label ? h(label) : h('div', { innerHTML: label }),
   ]
 }
 
-OutputNode.props = ['targetPosition', 'label', 'isValidTargetPos', 'connectable']
+OutputNode.props = ['targetPosition', 'label', 'isValidTargetPos', 'connectable', 'data']
 OutputNode.inheritAttrs = false
 OutputNode.compatConfig = { MODE: 3 }
 


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Use data object for default node labels since `node.label` is deprecated now