### PR TITLE
docs: update class names in theming guide

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -4,7 +4,6 @@ CHANGELOG/*
 
 # Ignore all auto-generated files
 src/changelog
-
 src/typedocs
-
-src/public/*.js
+src/public/*.mjs
+src/.vitepress/cache

--- a/docs/src/guide/theming.md
+++ b/docs/src/guide/theming.md
@@ -187,9 +187,9 @@ Here you'll find a handy reference guide of class names and their respective ele
 | .vue-flow__edge           | Wrapper around each edge element                  |
 | .vue-flow__selectionpane  | Pane for handling user selection                  |
 | .vue-flow__selection      | Defines current user selection box                |
-| .vue-flow__edge-{type}    | Edge type (either custom or default)              |
-| .vue-flow__edge .selected | Defines the currently selected edge(s)            |
-| .vue-flow__edge .animated | Defines an animated edge                          |
+| .vue-flow__edge-\{type\}  | Edge type (either custom or default)              |
+| .vue-flow__edge.selected  | Defines the currently selected edge(s)            |
+| .vue-flow__edge.animated  | Defines an animated edge                          |
 | .vue-flow__edge-path      | SVG path for edge elements                        |
 | .vue-flow__edge-text      | Wrapper around edge label                         |
 | .vue-flow__edge-textbg    | Background wrapper around edge label              |
@@ -202,8 +202,8 @@ Here you'll find a handy reference guide of class names and their respective ele
 | --------------------- | ----------------------------------------- |
 | .vue-flow__nodes      | Rendering wrapper around nodes            |
 | .vue-flow__node       | Wrapper around each node element          |
-| .vue-flow__node .selected | Defines the currently selected node(s)  |
-| .vue-flow__node-{type}   | Node type (either custom or default)     |
+| .vue-flow__node.selected | Defines the currently selected node(s)  |
+| .vue-flow__node-\{type\}   | Node type (either custom or default)     |
 | .vue-flow__nodesselection | Defines selection rectangle for nodes   |
 
 #### Node Handles


### PR DESCRIPTION
Hi there 👋 

I was following the theming section recently and found two little things that I thought could be improved. Let me know what you think!

And also, thank you for the library<3

# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- The curly braces are now correctly escaped in the theming guide

Before:
![image](https://github.com/bcakmakoglu/vue-flow/assets/31937175/8b6fcdad-be7d-478e-8b55-f3cd6bc5337a)

After:
![image](https://github.com/bcakmakoglu/vue-flow/assets/31937175/cf753aa9-c3e8-4e83-98ae-d1e9c05ee20f)

- The CSS selectors for the `.selected` and `.animated` classes has been updated. They can be copy-pasted now from to docs to someone's custom CSS file.

Before, they were used as child selector, which doesn't work:

```css
/* This doesn't work, because the "selected" class is
    added directly to the node:*/
.vue-flow__node .selected {
  background: red
}

/*This works:*/
.vue-flow__node.selected {
  background: red
}
```