### PR TITLE
fix(core): prevent esc keypress when a11y is disabled

### DIFF
--- a/.changeset/silent-pigs-swim.md
+++ b/.changeset/silent-pigs-swim.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Prevent esc keypress triggers when keyboard a11y is disabled

--- a/packages/core/src/components/Edges/EdgeWrapper.ts
+++ b/packages/core/src/components/Edges/EdgeWrapper.ts
@@ -44,6 +44,7 @@ const EdgeWrapper = defineComponent({
       findNode,
       isValidConnection,
       multiSelectionActive,
+      disableKeyboardA11y,
     } = useVueFlow()
 
     const hooks = useEdgeHooks(props.edge, emits)
@@ -334,7 +335,7 @@ const EdgeWrapper = defineComponent({
     }
 
     function onKeyDown(event: KeyboardEvent) {
-      if (elementSelectionKeys.includes(event.key) && props.selectable) {
+      if (!disableKeyboardA11y.value && elementSelectionKeys.includes(event.key) && props.selectable) {
         const unselect = event.key === 'Escape'
 
         if (unselect) {

--- a/packages/core/src/components/Nodes/NodeWrapper.ts
+++ b/packages/core/src/components/Nodes/NodeWrapper.ts
@@ -319,7 +319,7 @@ const NodeWrapper = defineComponent({
     }
 
     function onKeyDown(event: KeyboardEvent) {
-      if (isInputDOMNode(event)) {
+      if (isInputDOMNode(event) || disableKeyboardA11y.value) {
         return
       }
 
@@ -335,7 +335,7 @@ const NodeWrapper = defineComponent({
           unselect,
           nodeElement.value!,
         )
-      } else if (!disableKeyboardA11y.value && props.draggable && node.value.selected && arrowKeyDiffs[event.key]) {
+      } else if (props.draggable && node.value.selected && arrowKeyDiffs[event.key]) {
         ariaLiveMessage.value = `Moved selected node ${event.key.replace('Arrow', '').toLowerCase()}. New position, x: ${~~node
           .value.position.x}, y: ${~~node.value.position.y}`
 


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Avoid catching esc key press if keyboard a11y is disabled