### PR TITLE
fix(core): use default cursor and apply drag cursor if node is draggable

### DIFF
--- a/.changeset/eleven-bulldogs-rhyme.md
+++ b/.changeset/eleven-bulldogs-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Use default cursor for nodes and use grab cursor if node is draggable

--- a/packages/core/src/components/Nodes/NodeWrapper.ts
+++ b/packages/core/src/components/Nodes/NodeWrapper.ts
@@ -192,6 +192,7 @@ const NodeWrapper = defineComponent({
             {
               [noPanClassName.value]: props.draggable,
               dragging: dragging?.value,
+              draggable: props.draggable,
               selected: node.value.selected,
               selectable: props.selectable,
               parent: node.value.isParent,

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -153,11 +153,16 @@
   pointer-events: all;
   transform-origin: 0 0;
   box-sizing: border-box;
-  cursor: grab;
+  cursor: default;
 
-  &.dragging {
-     cursor: grabbing;
-   }
+  &.draggable {
+    cursor: grab;
+    pointer-events: all;
+
+    &.dragging {
+      cursor: grabbing;
+    }
+  }
 }
 
 .vue-flow__nodesselection {


### PR DESCRIPTION
# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] Incorrect cursor if nodes are not draggable
