### PR TITLE
fix(core): remove ref prop from BaseEdge

### DIFF
--- a/.changeset/tall-years-roll.md
+++ b/.changeset/tall-years-roll.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Remove `ref` prop from `BaseEdge`

--- a/packages/core/src/types/edge.ts
+++ b/packages/core/src/types/edge.ts
@@ -1,4 +1,4 @@
-import type { CSSProperties, Component, VNode, VNodeRef } from 'vue'
+import type { CSSProperties, Component, VNode } from 'vue'
 import type { ClassFunc, ElementData, Position, StyleFunc, Styles } from './flow'
 import type { GraphNode } from './node'
 import type { EdgeComponent, EdgeTextProps } from './components'
@@ -202,7 +202,6 @@ export interface BaseEdgeProps extends EdgeLabelOptions {
   markerEnd?: string
   interactionWidth?: number
   style?: CSSProperties
-  ref?: VNodeRef
 }
 
 export type BezierEdgeProps = EdgePositions &


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Remove invalid `ref` prop from `BaseEdge` component

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] #1334 