### PR TITLE
fix(core,edges): use nullish check to fallback to default center

### DIFF
--- a/.changeset/purple-tomatoes-repair.md
+++ b/.changeset/purple-tomatoes-repair.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Use nullish check to fallback to default center values in `getSmoothstepPath`

--- a/packages/core/src/components/Edges/utils/smoothstep.ts
+++ b/packages/core/src/components/Edges/utils/smoothstep.ts
@@ -85,8 +85,8 @@ function getPoints({
 
   // opposite handle positions, default case
   if (sourceDir[dirAccessor] * targetDir[dirAccessor] === -1) {
-    centerX = center.x || defaultCenterX
-    centerY = center.y || defaultCenterY
+    centerX = center.x ?? defaultCenterX
+    centerY = center.y ?? defaultCenterY
     //    --->
     //    |
     // >---


### PR DESCRIPTION
# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [X] Center not properly applied if it's at `0`
