### PR TITLE
docs: replace `source.id` with `source`

### DIFF
--- a/docs/src/guide/vue-flow/config.md
+++ b/docs/src/guide/vue-flow/config.md
@@ -745,7 +745,7 @@ const connector = (params) => {
   }
   
   return {
-    id: `edge-${params.source.id}-${params.target}`,
+    id: `edge-${params.source}-${params.target}`,
     source: params.source,
     target: params.target,
     label: `Edge ${params.source}-${params.target}`,


### PR DESCRIPTION
# 🐛 Fixes

- Fixes a typo in the docs