### PR TITLE
fix(core): allow wheel evt to bubble up if not used by vf 

### DIFF
--- a/.changeset/lovely-buttons-tickle.md
+++ b/.changeset/lovely-buttons-tickle.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Allow wheel events to bubble up to the user if the event is not caught and used by the viewport

--- a/packages/core/src/container/Viewport/Viewport.vue
+++ b/packages/core/src/container/Viewport/Viewport.vue
@@ -333,7 +333,13 @@ onMounted(() => {
           function (this: any, event: WheelEvent, d: any) {
             // we still want to enable pinch zooming even if preventScrolling is set to false
             const invalidEvent = !preventScrolling.value && event.type === 'wheel' && !event.ctrlKey
-            if (invalidEvent || isWrappedWithClass(event, noWheelClassName.value)) {
+
+            const zoomScroll = zoomKeyPressed.value || zoomOnScroll.value
+            const pinchZoom = zoomOnPinch.value && event.ctrlKey
+
+            const scrollEventsDisabled = !zoomScroll && !panOnScroll.value && !pinchZoom && event.type === 'wheel'
+
+            if (scrollEventsDisabled || invalidEvent || isWrappedWithClass(event, noWheelClassName.value)) {
               return null
             }
 


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Allow wheel events to bubble up to the user if the event is unused and not caught by the viewport

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] #1360 