### PR TITLE
feat(core): export PanelPositionType

### DIFF
--- a/.changeset/curly-phones-reply.md
+++ b/.changeset/curly-phones-reply.md
@@ -1,0 +1,6 @@
+---
+"@vue-flow/controls": patch
+"@vue-flow/minimap": patch
+---
+
+Allow `PanelPositionType` as value for position

--- a/.changeset/six-trainers-juggle.md
+++ b/.changeset/six-trainers-juggle.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Export `PanelPositionType`

--- a/packages/controls/src/types.ts
+++ b/packages/controls/src/types.ts
@@ -1,4 +1,4 @@
-import type { FitViewParams, PanelPosition } from '@vue-flow/core'
+import type { FitViewParams, PanelPosition, PanelPositionType } from '@vue-flow/core'
 
 export interface ControlProps {
   /** Show the zoom icon */
@@ -10,5 +10,5 @@ export interface ControlProps {
   /** Params to use on fitView */
   fitViewParams?: FitViewParams
   /** Position of the controls {@link PanelPosition} */
-  position?: PanelPosition
+  position?: PanelPositionType | PanelPosition
 }

--- a/packages/core/src/types/panel.ts
+++ b/packages/core/src/types/panel.ts
@@ -10,7 +10,7 @@ export enum PanelPosition {
   BottomRight = 'bottom-right',
 }
 
-type PanelPositionType = 'top-left' | 'top-center' | 'top-right' | 'bottom-left' | 'bottom-center' | 'bottom-right'
+export type PanelPositionType = 'top-left' | 'top-center' | 'top-right' | 'bottom-left' | 'bottom-center' | 'bottom-right'
 
 export interface PanelProps {
   position: PanelPosition | PanelPositionType

--- a/packages/minimap/src/types.ts
+++ b/packages/minimap/src/types.ts
@@ -1,4 +1,4 @@
-import type { Dimensions, GraphNode, NodeMouseEvent, PanelPosition, XYPosition } from '@vue-flow/core'
+import type { Dimensions, GraphNode, NodeMouseEvent, PanelPosition, PanelPositionType, XYPosition } from '@vue-flow/core'
 import type { CSSProperties, InjectionKey } from 'vue'
 
 /** expects a node and returns a color value */
@@ -24,7 +24,7 @@ export interface MiniMapProps {
   /** Border width of minimap mask */
   maskStrokeWidth?: number
   /** Position of the minimap {@link PanelPosition} */
-  position?: PanelPosition
+  position?: PanelPositionType | PanelPosition
   /** Enable drag minimap to drag viewport */
   pannable?: boolean
   /** Enable zoom minimap to zoom viewport */


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Export `PanelPositionType` from core pkg
- Allow `PanelPositionType` as position in minimap and controls cmp