### PR TITLE
feat(minimap): add `maskBorderRadius` prop

### DIFF
--- a/packages/minimap/src/MiniMap.vue
+++ b/packages/minimap/src/MiniMap.vue
@@ -21,6 +21,7 @@ const {
   position = 'bottom-right' as PanelPosition,
   maskStrokeColor = 'none',
   maskStrokeWidth = 1,
+  maskBorderRadius = 0,
   pannable = false,
   zoomable = false,
   ariaLabel = 'Vue Flow mini map',
@@ -104,10 +105,15 @@ const d = computed(() => {
     h${viewBox.value.width + viewBox.value.offset * 2}
     v${viewBox.value.height + viewBox.value.offset * 2}
     h${-viewBox.value.width - viewBox.value.offset * 2}z
-    M${viewBB.value.x},${viewBB.value.y}
-    h${viewBB.value.width}
-    v${viewBB.value.height}
-    h${-viewBB.value.width}z`
+    M${viewBB.value.x + maskBorderRadius},${viewBB.value.y}
+    h${viewBB.value.width - 2 * maskBorderRadius}
+    a${maskBorderRadius},${maskBorderRadius} 0 0 1 ${maskBorderRadius},${maskBorderRadius}
+    v${viewBB.value.height - 2 * maskBorderRadius}
+    a${maskBorderRadius},${maskBorderRadius} 0 0 1 -${maskBorderRadius},${maskBorderRadius}
+    h${-(viewBB.value.width - 2 * maskBorderRadius)}
+    a${maskBorderRadius},${maskBorderRadius} 0 0 1 -${maskBorderRadius},-${maskBorderRadius}
+    v${-(viewBB.value.height - 2 * maskBorderRadius)}
+    a${maskBorderRadius},${maskBorderRadius} 0 0 1 ${maskBorderRadius},-${maskBorderRadius}z`
 })
 
 watchEffect(

--- a/packages/minimap/src/types.ts
+++ b/packages/minimap/src/types.ts
@@ -41,6 +41,8 @@ export interface MiniMapProps {
   zoomStep?: number
   /** Specify minimap scale */
   offsetScale?: number
+  /** Mask border radius */
+  maskBorderRadius?: number
 }
 
 /** these props are passed to mini map node slots */


### PR DESCRIPTION
# 🚀 What's changed?

- Added the optional option for a mask border radius on the minimap
- - Default is still 0 as before. 

![maskBorderRadius](https://github.com/bcakmakoglu/vue-flow/assets/132454889/1394ec23-288a-48a3-a46b-49ad1fe882f0)
![noMaskBorderRadius](https://github.com/bcakmakoglu/vue-flow/assets/132454889/7d8a92e7-1664-4306-bf5d-57b070b24e76)
