### PR TITLE
refactor(core): use all nodes in node renderer

### DIFF
--- a/.changeset/warm-seahorses-retire.md
+++ b/.changeset/warm-seahorses-retire.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Render `null` if node is hidden but render whole list of nodes regardless of visibility

--- a/packages/core/src/container/NodeRenderer/NodeRenderer.vue
+++ b/packages/core/src/container/NodeRenderer/NodeRenderer.vue
@@ -7,17 +7,8 @@ import { useVueFlow } from '../../composables'
 import { ErrorCode, VueFlowError } from '../../utils'
 import { useNodesInitialized } from '../../composables/useNodesInitialized'
 
-const {
-  nodes,
-  nodesDraggable,
-  nodesFocusable,
-  elementsSelectable,
-  nodesConnectable,
-  getNodes,
-  getNodeTypes,
-  updateNodeDimensions,
-  emits,
-} = useVueFlow()
+const { nodes, nodesDraggable, nodesFocusable, elementsSelectable, nodesConnectable, getNodeTypes, updateNodeDimensions, emits } =
+  useVueFlow()
 
 const nodesInitialized = useNodesInitialized()
 
@@ -110,7 +101,7 @@ export default {
   <div class="vue-flow__nodes vue-flow__container">
     <template v-if="resizeObserver">
       <NodeWrapper
-        v-for="node of getNodes"
+        v-for="node of nodes"
         :id="node.id"
         :key="node.id"
         :resize-observer="resizeObserver"


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Use all nodes (even hidden ones) to render list of nodes
- Render `null` if node is hidden
- Re-observe  node element when visible

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] #1443 

