### PR TITLE
refactor(core): render null if edge is hidden

### DIFF
--- a/.changeset/itchy-cats-kiss.md
+++ b/.changeset/itchy-cats-kiss.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Remove visibility (hidden) check from `getNodes` & `getEdges`

--- a/.changeset/shaggy-feet-shout.md
+++ b/.changeset/shaggy-feet-shout.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Render `null` if edge is hidden

--- a/packages/core/src/components/Edges/EdgeWrapper.ts
+++ b/packages/core/src/components/Edges/EdgeWrapper.ts
@@ -102,7 +102,7 @@ const EdgeWrapper = defineComponent({
         return null
       }
 
-      if (!edge || sourceNode.hidden || targetNode.hidden) {
+      if (!edge.value || edge.value.hidden || sourceNode.hidden || targetNode.hidden) {
         return null
       }
 

--- a/packages/core/src/container/NodeRenderer/NodeRenderer.vue
+++ b/packages/core/src/container/NodeRenderer/NodeRenderer.vue
@@ -7,8 +7,16 @@ import { useVueFlow } from '../../composables'
 import { ErrorCode, VueFlowError } from '../../utils'
 import { useNodesInitialized } from '../../composables/useNodesInitialized'
 
-const { nodes, nodesDraggable, nodesFocusable, elementsSelectable, nodesConnectable, getNodeTypes, updateNodeDimensions, emits } =
-  useVueFlow()
+const {
+  getNodes,
+  nodesDraggable,
+  nodesFocusable,
+  elementsSelectable,
+  nodesConnectable,
+  getNodeTypes,
+  updateNodeDimensions,
+  emits,
+} = useVueFlow()
 
 const nodesInitialized = useNodesInitialized()
 
@@ -23,7 +31,7 @@ watch(
   (initialized) => {
     if (initialized) {
       nextTick(() => {
-        emits.nodesInitialized(nodes.value)
+        emits.nodesInitialized(getNodes.value)
       })
     }
   },
@@ -101,7 +109,7 @@ export default {
   <div class="vue-flow__nodes vue-flow__container">
     <template v-if="resizeObserver">
       <NodeWrapper
-        v-for="node of nodes"
+        v-for="node of getNodes"
         :id="node.id"
         :key="node.id"
         :resize-observer="resizeObserver"


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Render `null` if edge is hidden
- Remove hidden check from `getNodes` and `getEdges`