### PR TITLE
refactor(core): use node/edge id as only dependency for nodes/edges list

### DIFF
--- a/.changeset/calm-pigs-yawn.md
+++ b/.changeset/calm-pigs-yawn.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Return non-nullable edge from `useEdge`

--- a/.changeset/four-singers-suffer.md
+++ b/.changeset/four-singers-suffer.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Use node/edge id as the only dependency to render nodes/edges.

--- a/packages/core/src/components/Nodes/NodeWrapper.ts
+++ b/packages/core/src/components/Nodes/NodeWrapper.ts
@@ -279,7 +279,7 @@ const NodeWrapper = defineComponent({
           'onKeydown': onKeyDown,
         },
         [
-          h(nodeCmp.value === false ? getNodeTypes.value.default : nodeCmp.value, {
+          h(nodeCmp.value === false ? getNodeTypes.value.default : (nodeCmp.value as any), {
             id: node.id,
             type: node.type,
             data: node.data,

--- a/packages/core/src/composables/useEdge.ts
+++ b/packages/core/src/composables/useEdge.ts
@@ -21,7 +21,7 @@ export function useEdge<Data = ElementData, CustomEvents extends Record<string, 
 
   const { findEdge, emits } = useVueFlow()
 
-  const edge = findEdge<Data, CustomEvents>(edgeId)
+  const edge = findEdge<Data, CustomEvents>(edgeId)!
 
   if (!edge) {
     emits.error(new VueFlowError(ErrorCode.EDGE_NOT_FOUND, edgeId))

--- a/packages/core/src/container/EdgeRenderer/EdgeRenderer.vue
+++ b/packages/core/src/container/EdgeRenderer/EdgeRenderer.vue
@@ -77,18 +77,11 @@ export default {
     <svg
       v-for="edge of getEdges"
       :key="edge.id"
+      v-memo="[edge.id]"
       class="vue-flow__edges vue-flow__container"
       :style="{ zIndex: getEdgeZIndex(edge, findNode, elevateEdgesOnSelect) }"
     >
-      <EdgeWrapper
-        :id="edge.id"
-        :edge="edge"
-        :type="getType(edge.type, edge.template)"
-        :name="edge.type || 'default'"
-        :selectable="selectable(edge.selectable)"
-        :updatable="updatable(edge.updatable)"
-        :focusable="focusable(edge.focusable)"
-      />
+      <EdgeWrapper :id="edge.id" />
     </svg>
 
     <ConnectionLine />

--- a/packages/core/src/container/EdgeRenderer/EdgeRenderer.vue
+++ b/packages/core/src/container/EdgeRenderer/EdgeRenderer.vue
@@ -1,66 +1,11 @@
 <script lang="ts" setup>
-import { getCurrentInstance, inject, resolveComponent } from 'vue'
 import EdgeWrapper from '../../components/Edges/EdgeWrapper'
 import ConnectionLine from '../../components/ConnectionLine'
-import type { EdgeComponent, EdgeUpdatable, GraphEdge } from '../../types'
-import { Slots } from '../../context'
 import { useVueFlow } from '../../composables'
-import { ErrorCode, VueFlowError, getEdgeZIndex } from '../../utils'
+import { getEdgeZIndex } from '../../utils'
 import MarkerDefinitions from './MarkerDefinitions.vue'
 
-const slots = inject(Slots)
-
-const {
-  edgesUpdatable,
-  edgesFocusable,
-  elementsSelectable,
-  findNode,
-  getEdges,
-  getEdgeTypes,
-  elevateEdgesOnSelect,
-  dimensions,
-  emits,
-} = useVueFlow()
-
-const instance = getCurrentInstance()
-
-function selectable(edgeSelectable?: boolean) {
-  return typeof edgeSelectable === 'undefined' ? elementsSelectable.value : edgeSelectable
-}
-function updatable(edgeUpdatable?: EdgeUpdatable) {
-  return typeof edgeUpdatable === 'undefined' ? edgesUpdatable.value : edgeUpdatable
-}
-function focusable(edgeFocusable?: boolean) {
-  return typeof edgeFocusable === 'undefined' ? edgesFocusable.value : edgeFocusable
-}
-
-function getType(type?: string, template?: GraphEdge['template']) {
-  const name = type || 'default'
-
-  const slot = slots?.[`edge-${name}`]
-  if (slot) {
-    return slot
-  }
-
-  let edgeType = template ?? getEdgeTypes.value[name]
-
-  if (typeof edgeType === 'string') {
-    if (instance) {
-      const components = Object.keys(instance.appContext.components)
-      if (components && components.includes(name)) {
-        edgeType = resolveComponent(name, false) as EdgeComponent
-      }
-    }
-  }
-
-  if (edgeType && typeof edgeType !== 'string') {
-    return edgeType
-  }
-
-  emits.error(new VueFlowError(ErrorCode.EDGE_TYPE_MISSING, edgeType))
-
-  return false
-}
+const { findNode, getEdges, elevateEdgesOnSelect, dimensions } = useVueFlow()
 </script>
 
 <script lang="ts">

--- a/packages/core/src/container/NodeRenderer/NodeRenderer.vue
+++ b/packages/core/src/container/NodeRenderer/NodeRenderer.vue
@@ -1,35 +1,19 @@
 <script lang="ts" setup>
-import { getCurrentInstance, inject, nextTick, onBeforeUnmount, onMounted, ref, resolveComponent, watch } from 'vue'
+import { nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { NodeWrapper } from '../../components'
-import type { GraphNode, HandleConnectable, NodeComponent } from '../../types'
-import { Slots } from '../../context'
 import { useVueFlow } from '../../composables'
-import { ErrorCode, VueFlowError } from '../../utils'
 import { useNodesInitialized } from '../../composables/useNodesInitialized'
 
-const {
-  getNodes,
-  nodesDraggable,
-  nodesFocusable,
-  elementsSelectable,
-  nodesConnectable,
-  getNodeTypes,
-  updateNodeDimensions,
-  emits,
-} = useVueFlow()
+const { getNodes, updateNodeDimensions, emits } = useVueFlow()
 
 const nodesInitialized = useNodesInitialized()
 
-const slots = inject(Slots)
-
 const resizeObserver = ref<ResizeObserver>()
-
-const instance = getCurrentInstance()
 
 watch(
   nodesInitialized,
-  (initialized) => {
-    if (initialized) {
+  (isInit) => {
+    if (isInit) {
       nextTick(() => {
         emits.nodesInitialized(getNodes.value)
       })
@@ -55,47 +39,6 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => resizeObserver.value?.disconnect())
-
-function draggable(nodeDraggable?: boolean) {
-  return typeof nodeDraggable === 'undefined' ? nodesDraggable.value : nodeDraggable
-}
-function selectable(nodeSelectable?: boolean) {
-  return typeof nodeSelectable === 'undefined' ? elementsSelectable.value : nodeSelectable
-}
-function connectable(nodeConnectable?: HandleConnectable) {
-  return typeof nodeConnectable === 'undefined' ? nodesConnectable.value : nodeConnectable
-}
-function focusable(nodeFocusable?: boolean) {
-  return typeof nodeFocusable === 'undefined' ? nodesFocusable.value : nodeFocusable
-}
-
-function getType(type?: string, template?: GraphNode['template']) {
-  const name = type || 'default'
-
-  const slot = slots?.[`node-${name}`]
-  if (slot) {
-    return slot
-  }
-
-  let nodeType = template ?? getNodeTypes.value[name]
-
-  if (typeof nodeType === 'string') {
-    if (instance) {
-      const components = Object.keys(instance.appContext.components)
-      if (components && components.includes(name)) {
-        nodeType = resolveComponent(name, false) as NodeComponent
-      }
-    }
-  }
-
-  if (nodeType && typeof nodeType !== 'string') {
-    return nodeType
-  }
-
-  emits.error(new VueFlowError(ErrorCode.NODE_TYPE_MISSING, nodeType))
-
-  return false
-}
 </script>
 
 <script lang="ts">
@@ -108,19 +51,7 @@ export default {
 <template>
   <div class="vue-flow__nodes vue-flow__container">
     <template v-if="resizeObserver">
-      <NodeWrapper
-        v-for="node of getNodes"
-        :id="node.id"
-        :key="node.id"
-        :resize-observer="resizeObserver"
-        :type="getType(node.type, node.template)"
-        :name="node.type || 'default'"
-        :draggable="draggable(node.draggable)"
-        :selectable="selectable(node.selectable)"
-        :connectable="connectable(node.connectable)"
-        :focusable="focusable(node.focusable)"
-        :node="node"
-      />
+      <NodeWrapper v-for="node of getNodes" :id="node.id" :key="node.id" v-memo="[node.id]" :resize-observer="resizeObserver" />
     </template>
   </div>
 </template>


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Only use node/edge id as dependency to re-render lists
