### PR TITLE
fix(core): disable drag when using multi-touch

### DIFF
--- a/.changeset/selfish-vans-report.md
+++ b/.changeset/selfish-vans-report.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Disable dragging when using multi-touch

--- a/packages/core/src/composables/useDrag.ts
+++ b/packages/core/src/composables/useDrag.ts
@@ -185,6 +185,10 @@ export function useDrag(params: UseDragParams) {
   }
 
   const eventStart = (event: UseDragEvent, nodeEl: Element) => {
+    if (event.sourceEvent.type === 'touchmove' && event.sourceEvent.touches.length > 1) {
+      return
+    }
+
     if (nodeDragThreshold.value === 0) {
       startDrag(event, nodeEl)
     }


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Disable dragging when using multi-touch (like pinch zoom)

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] #1020 
