### PR TITLE
fix(core): disable zoom on mobile when zoomToPinch is false

### DIFF
--- a/.changeset/khaki-peas-draw.md
+++ b/.changeset/khaki-peas-draw.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Disable pinch zoom on mobile if `zoomToPinch` is `false`


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Disable zooming on mobile when `zoomToPinch` is `false`