### PR TITLE
feat(core): allow string array or object as class to node/edge objects

### DIFF
--- a/.changeset/thin-beans-wait.md
+++ b/.changeset/thin-beans-wait.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Allow passing a Record<string, any> as class to node/edge objects

--- a/.changeset/thirty-days-retire.md
+++ b/.changeset/thirty-days-retire.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Allow passing an array of strings as class to node/edge objects

--- a/packages/core/src/types/edge.ts
+++ b/packages/core/src/types/edge.ts
@@ -92,7 +92,7 @@ export interface DefaultEdge<
   /** Disable/enable deleting edge */
   deletable?: boolean
   /** Additional class names, can be a string or a callback returning a string (receives current flow element) */
-  class?: string | ClassFunc<GraphEdge<Data, CustomEvents>>
+  class?: string | string[] | ClassFunc<GraphEdge<Data, CustomEvents>>
   /** Additional styles, can be an object or a callback returning an object (receives current flow element) */
   style?: Styles | StyleFunc<GraphEdge<Data, CustomEvents>>
   /** Is edge hidden */

--- a/packages/core/src/types/edge.ts
+++ b/packages/core/src/types/edge.ts
@@ -92,7 +92,7 @@ export interface DefaultEdge<
   /** Disable/enable deleting edge */
   deletable?: boolean
   /** Additional class names, can be a string or a callback returning a string (receives current flow element) */
-  class?: string | string[] | ClassFunc<GraphEdge<Data, CustomEvents>>
+  class?: string | string[] | Record<string, any> | ClassFunc<GraphEdge<Data, CustomEvents>>
   /** Additional styles, can be an object or a callback returning an object (receives current flow element) */
   style?: Styles | StyleFunc<GraphEdge<Data, CustomEvents>>
   /** Is edge hidden */

--- a/packages/core/src/types/node.ts
+++ b/packages/core/src/types/node.ts
@@ -90,7 +90,7 @@ export interface Node<Data = ElementData, CustomEvents extends Record<string, Cu
   height?: number | string | HeightFunc
 
   /** Additional class names, can be a string or a callback returning a string (receives current flow element) */
-  class?: string | string[] | ClassFunc<GraphNode<Data, CustomEvents>>
+  class?: string | string[] | Record<string, any> | ClassFunc<GraphNode<Data, CustomEvents>>
   /** Additional styles, can be an object or a callback returning an object (receives current flow element) */
   style?: Styles | StyleFunc<GraphNode<Data, CustomEvents>>
   /** Is node hidden */

--- a/packages/core/src/types/node.ts
+++ b/packages/core/src/types/node.ts
@@ -90,7 +90,7 @@ export interface Node<Data = ElementData, CustomEvents extends Record<string, Cu
   height?: number | string | HeightFunc
 
   /** Additional class names, can be a string or a callback returning a string (receives current flow element) */
-  class?: string | ClassFunc<GraphNode<Data, CustomEvents>>
+  class?: string | string[] | ClassFunc<GraphNode<Data, CustomEvents>>
   /** Additional styles, can be an object or a callback returning an object (receives current flow element) */
   style?: Styles | StyleFunc<GraphNode<Data, CustomEvents>>
   /** Is node hidden */


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Allow passing `string[]` or `Record<string, any>` as class to node/edge objects
