### PR TITLE
fix(core): emit node click event when drag was ended with no movement

### DIFF
--- a/.changeset/two-countries-brake.md
+++ b/.changeset/two-countries-brake.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Emit `nodeClick` event when a node is dragged without exceeding the node drag threshold (i.e. no visible movement has happened)

--- a/packages/core/src/composables/useDrag.ts
+++ b/packages/core/src/composables/useDrag.ts
@@ -228,6 +228,12 @@ export function useDrag(params: UseDragParams) {
 
   const eventEnd = (event: UseDragEvent) => {
     if (!dragStarted) {
+      const node = findNode(id)
+
+      if (node) {
+        emits.nodeClick({ node, event: event.sourceEvent })
+      }
+
       return
     }
 


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- When node drag ends and the threshold was not exceeded (meaning `dragStarted` is `false`) emit the node click event

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] #1521 
