### PR TITLE
fix(core): emit node click if drag was aborted

### DIFF
--- a/.changeset/giant-pears-agree.md
+++ b/.changeset/giant-pears-agree.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Prevent duplicate node click event by checking if drag was actually aborted before emitting node-click

--- a/packages/core/src/components/Nodes/NodeWrapper.ts
+++ b/packages/core/src/components/Nodes/NodeWrapper.ts
@@ -120,14 +120,17 @@ const NodeWrapper = defineComponent({
       disabled: () => !isDraggable.value,
       selectable: isSelectable,
       dragHandle: () => node.dragHandle,
-      onStart(args) {
-        emit.dragStart(args)
+      onStart(event) {
+        emit.dragStart(event)
       },
-      onDrag(args) {
-        emit.drag(args)
+      onDrag(event) {
+        emit.drag(event)
       },
-      onStop(args) {
-        emit.dragStop(args)
+      onStop(event) {
+        emit.dragStop(event)
+      },
+      onClick(event) {
+        emit.click({ node, event })
       },
     })
 

--- a/packages/core/src/composables/useDrag.ts
+++ b/packages/core/src/composables/useDrag.ts
@@ -71,6 +71,7 @@ export function useDrag(params: UseDragParams) {
   let mousePosition: XYPosition = { x: 0, y: 0 }
   let dragEvent: MouseEvent | null = null
   let dragStarted = false
+  let dragAborted = false
 
   let autoPanId = 0
   let autoPanStarted = false
@@ -148,6 +149,7 @@ export function useDrag(params: UseDragParams) {
 
   const startDrag = (event: UseDragEvent, nodeEl: Element) => {
     dragStarted = true
+    dragAborted = false
 
     const node = findNode(id)
     if (!selectNodesOnDrag.value && !multiSelectionActive.value && node) {
@@ -214,6 +216,8 @@ export function useDrag(params: UseDragParams) {
 
       if (distance > nodeDragThreshold.value) {
         startDrag(event, nodeEl)
+      } else {
+        dragAborted = true
       }
     }
 
@@ -228,11 +232,15 @@ export function useDrag(params: UseDragParams) {
 
   const eventEnd = (event: UseDragEvent) => {
     if (!dragStarted) {
-      const node = findNode(id)
+      if (dragAborted) {
+        const node = findNode(id)
 
-      if (node) {
-        emits.nodeClick({ node, event: event.sourceEvent })
+        if (node) {
+          emits.nodeClick({ node, event: event.sourceEvent })
+        }
       }
+
+      dragAborted = false
 
       return
     }
@@ -240,6 +248,8 @@ export function useDrag(params: UseDragParams) {
     dragging.value = false
     autoPanStarted = false
     dragStarted = false
+    dragAborted = false
+
     cancelAnimationFrame(autoPanId)
 
     if (dragItems.length) {


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Check if node drag was aborted before trying to emit node click event

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] #1521 