### PR TITLE
fix(core): ignore minor drag movements when marking aborted drag

### DIFF
--- a/.changeset/popular-cars-design.md
+++ b/.changeset/popular-cars-design.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+ignore minor mouse movements when marking a node drag as aborted

--- a/packages/core/src/composables/useDrag.ts
+++ b/packages/core/src/composables/useDrag.ts
@@ -217,6 +217,9 @@ export function useDrag(params: UseDragParams) {
       if (distance > nodeDragThreshold.value) {
         startDrag(event, nodeEl)
       }
+
+      // we have to ignore very small movements as they would be picked up as regular clicks even though a potential drag might have been registered as well
+      dragAborted = distance >= 0.5 && distance < nodeDragThreshold.value
     }
 
     // skip events without movement
@@ -225,8 +228,6 @@ export function useDrag(params: UseDragParams) {
       mousePosition = getEventPosition(event.sourceEvent, containerBounds!)
 
       updateNodes(pointerPos)
-    } else {
-      dragAborted = true
     }
   }
 


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- ignore minor movements when marking a node drag as aborted

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] #1521 