### PR TITLE
fix(core): dispatch click if drag move was attempted

### DIFF
--- a/packages/core/src/components/Nodes/NodeWrapper.ts
+++ b/packages/core/src/components/Nodes/NodeWrapper.ts
@@ -130,7 +130,7 @@ const NodeWrapper = defineComponent({
         emit.dragStop(event)
       },
       onClick(event) {
-        emit.click({ node, event })
+        onSelectNode(event)
       },
     })
 


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Dispatch click event if node drag was attempted but threshold was not exceeded

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] #1521 