### PR TITLE
refactor(core,nodes)!: use `NodeBase` to extend `Node` type

### DIFF
--- a/.changeset/dull-squids-scream.md
+++ b/.changeset/dull-squids-scream.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": major
+---
+
+Remove `applyChanges` util and use `applyNodeChanges` / `applyEdgeChanges` instead

--- a/.changeset/gold-birds-mix.md
+++ b/.changeset/gold-birds-mix.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": major
+---
+
+Remove deprecated getters `getNode`, `getEdge`, `getElements`, `getNodesInitialized`, `areNodesInitialized`

--- a/.changeset/quick-starfishes-attack.md
+++ b/.changeset/quick-starfishes-attack.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": major
+---
+
+Remove `modelValue` prop from FlowProps

--- a/.changeset/strong-spiders-wink.md
+++ b/.changeset/strong-spiders-wink.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": major
+---
+
+Remove deprecated actions `setElements`, `addSelectedElements`, `removeSelectedElements`

--- a/packages/core/src/components/Nodes/DefaultNode.ts
+++ b/packages/core/src/components/Nodes/DefaultNode.ts
@@ -1,28 +1,25 @@
 import type { Component, FunctionalComponent } from 'vue'
 import { h } from 'vue'
 import Handle from '../Handle/Handle.vue'
-import type { NodeProps } from '../../types'
+import type { Node, NodeProps } from '../../types'
 import { Position } from '../../types'
 
-const DefaultNode: FunctionalComponent<NodeProps<{ label: any }>> = function ({
+const DefaultNode: FunctionalComponent<NodeProps<Node<{ label: any }, 'default'>>> = function ({
   sourcePosition = Position.Bottom,
   targetPosition = Position.Top,
-  label: _label,
-  connectable = true,
-  isValidTargetPos,
-  isValidSourcePos,
+  isConnectable = true,
   data,
 }) {
-  const label = data.label || _label
+  const label = data.label
 
   return [
-    h(Handle as Component, { type: 'target', position: targetPosition, connectable, isValidConnection: isValidTargetPos }),
+    h(Handle as Component, { type: 'target', position: targetPosition, isConnectable }),
     typeof label !== 'string' && label ? h(label) : h('div', { innerHTML: label }),
-    h(Handle as Component, { type: 'source', position: sourcePosition, connectable, isValidConnection: isValidSourcePos }),
+    h(Handle as Component, { type: 'source', position: sourcePosition, isConnectable }),
   ]
 }
 
-DefaultNode.props = ['sourcePosition', 'targetPosition', 'label', 'isValidTargetPos', 'isValidSourcePos', 'connectable', 'data']
+DefaultNode.props = ['sourcePosition', 'targetPosition', 'isConnectable', 'data']
 DefaultNode.inheritAttrs = false
 DefaultNode.compatConfig = { MODE: 3 }
 

--- a/packages/core/src/components/Nodes/InputNode.ts
+++ b/packages/core/src/components/Nodes/InputNode.ts
@@ -1,25 +1,23 @@
 import type { Component, FunctionalComponent } from 'vue'
 import { h } from 'vue'
 import Handle from '../Handle/Handle.vue'
-import type { NodeProps } from '../../types'
+import type { Node, NodeProps } from '../../types'
 import { Position } from '../../types'
 
-const InputNode: FunctionalComponent<NodeProps<{ label: any }>> = function ({
+const InputNode: FunctionalComponent<NodeProps<Node<{ label: any }, 'input'>>> = function ({
   sourcePosition = Position.Bottom,
-  label: _label,
-  connectable = true,
-  isValidSourcePos,
+  isConnectable = true,
   data,
 }) {
-  const label = data.label || _label
+  const label = data.label
 
   return [
     typeof label !== 'string' && label ? h(label) : h('div', { innerHTML: label }),
-    h(Handle as Component, { type: 'source', position: sourcePosition, connectable, isValidConnection: isValidSourcePos }),
+    h(Handle as Component, { type: 'source', position: sourcePosition, isConnectable }),
   ]
 }
 
-InputNode.props = ['sourcePosition', 'label', 'isValidSourcePos', 'connectable', 'data']
+InputNode.props = ['sourcePosition', 'isConnectable', 'data']
 InputNode.inheritAttrs = false
 InputNode.compatConfig = { MODE: 3 }
 

--- a/packages/core/src/components/Nodes/OutputNode.ts
+++ b/packages/core/src/components/Nodes/OutputNode.ts
@@ -1,25 +1,23 @@
 import type { Component, FunctionalComponent } from 'vue'
 import { h } from 'vue'
 import Handle from '../Handle/Handle.vue'
-import type { NodeProps } from '../../types'
+import type { Node, NodeProps } from '../../types'
 import { Position } from '../../types'
 
-const OutputNode: FunctionalComponent<NodeProps<{ label: any }>> = function ({
+const OutputNode: FunctionalComponent<NodeProps<Node<{ label: any }, 'output'>>> = function ({
   targetPosition = Position.Top,
-  label: _label,
-  connectable = true,
-  isValidTargetPos,
+  isConnectable = true,
   data,
 }) {
-  const label = data.label || _label
+  const label = data.label
 
   return [
-    h(Handle as Component, { type: 'target', position: targetPosition, connectable, isValidConnection: isValidTargetPos }),
+    h(Handle as Component, { type: 'target', position: targetPosition, isConnectable }),
     typeof label !== 'string' && label ? h(label) : h('div', { innerHTML: label }),
   ]
 }
 
-OutputNode.props = ['targetPosition', 'label', 'isValidTargetPos', 'connectable', 'data']
+OutputNode.props = ['targetPosition', 'isConnectable', 'data']
 OutputNode.inheritAttrs = false
 OutputNode.compatConfig = { MODE: 3 }
 

--- a/packages/core/src/composables/useNode.ts
+++ b/packages/core/src/composables/useNode.ts
@@ -1,5 +1,5 @@
 import { computed, inject, ref } from 'vue'
-import type { CustomEvent, ElementData } from '../types'
+import type { NodeBase } from '@xyflow/system'
 import { ErrorCode, VueFlowError, getConnectedEdges } from '../utils'
 import { NodeRef } from '../context'
 import { useVueFlow } from './useVueFlow'
@@ -16,13 +16,13 @@ import { useNodeId } from './useNodeId'
  * @param id - The id of the node to access
  * @returns the node id, the node, the node dom element, it's parent and connected edges
  */
-export function useNode<Data = ElementData, CustomEvents extends Record<string, CustomEvent> = any>(id?: string) {
+export function useNode<NodeType extends NodeBase = NodeBase>(id?: string) {
   const nodeId = id ?? useNodeId() ?? ''
   const nodeEl = inject(NodeRef, ref(null))
 
   const { findNode, edges, emits } = useVueFlow()
 
-  const node = findNode<Data, CustomEvents>(nodeId)!
+  const node = findNode<NodeType>(nodeId)!
 
   if (!node) {
     emits.error(new VueFlowError(ErrorCode.NODE_NOT_FOUND, nodeId))
@@ -32,7 +32,7 @@ export function useNode<Data = ElementData, CustomEvents extends Record<string, 
     id: nodeId,
     nodeEl,
     node,
-    parentNode: computed(() => findNode(node.parentNode)),
+    parentNode: computed(() => findNode(node.parentId)),
     connectedEdges: computed(() => getConnectedEdges([node], edges.value)),
   }
 }

--- a/packages/core/src/composables/useNode.ts
+++ b/packages/core/src/composables/useNode.ts
@@ -1,7 +1,7 @@
 import { computed, inject, ref } from 'vue'
-import type { NodeBase } from '@xyflow/system'
 import { ErrorCode, VueFlowError, getConnectedEdges } from '../utils'
 import { NodeRef } from '../context'
+import type { GraphNode, Node } from '../types'
 import { useVueFlow } from './useVueFlow'
 import { useNodeId } from './useNodeId'
 
@@ -16,13 +16,13 @@ import { useNodeId } from './useNodeId'
  * @param id - The id of the node to access
  * @returns the node id, the node, the node dom element, it's parent and connected edges
  */
-export function useNode<NodeType extends NodeBase = NodeBase>(id?: string) {
+export function useNode<NodeType extends Node = Node>(id?: string) {
   const nodeId = id ?? useNodeId() ?? ''
   const nodeEl = inject(NodeRef, ref(null))
 
-  const { findNode, edges, emits } = useVueFlow()
+  const { getNode, edges, emits } = useVueFlow()
 
-  const node = findNode<NodeType>(nodeId)!
+  const node = getNode(nodeId) as GraphNode<NodeType>
 
   if (!node) {
     emits.error(new VueFlowError(ErrorCode.NODE_NOT_FOUND, nodeId))
@@ -32,7 +32,7 @@ export function useNode<NodeType extends NodeBase = NodeBase>(id?: string) {
     id: nodeId,
     nodeEl,
     node,
-    parentNode: computed(() => findNode(node.parentId)),
+    parentNode: computed(() => getNode(node.parentId)),
     connectedEdges: computed(() => getConnectedEdges([node], edges.value)),
   }
 }

--- a/packages/core/src/store/getters.ts
+++ b/packages/core/src/store/getters.ts
@@ -1,24 +1,10 @@
 import type { ComputedRef } from 'vue'
 import { computed } from 'vue'
-import type { ComputedGetters, EdgeLookup, GraphEdge, GraphNode, NodeLookup, State } from '../types'
+import type { ComputedGetters, GraphEdge, GraphNode, NodeLookup, State } from '../types'
 import { getNodesInside, isEdgeVisible } from '../utils'
 import { defaultEdgeTypes, defaultNodeTypes } from '../utils/defaultNodesEdges'
 
-export function useGetters(
-  state: State,
-  nodeLookup: ComputedRef<NodeLookup>,
-  edgeLookup: ComputedRef<EdgeLookup>,
-): ComputedGetters {
-  /**
-   * @deprecated will be removed in next major version; use findNode instead
-   */
-  const getNode: ComputedGetters['getNode'] = computed(() => (id) => nodeLookup.value.get(id))
-
-  /**
-   * @deprecated will be removed in next major version; use findEdge instead
-   */
-  const getEdge: ComputedGetters['getEdge'] = computed(() => (id) => edgeLookup.value.get(id))
-
+export function useGetters(state: State, nodeLookup: ComputedRef<NodeLookup>): ComputedGetters {
   const getEdgeTypes: ComputedGetters['getEdgeTypes'] = computed(() => {
     const edgeTypes: Record<string, any> = {
       ...defaultEdgeTypes,
@@ -77,12 +63,12 @@ export function useGetters(
 
         if (
           isEdgeVisible({
-            sourcePos: source.computedPosition || { x: 0, y: 0 },
-            targetPos: target.computedPosition || { x: 0, y: 0 },
-            sourceWidth: source.dimensions.width,
-            sourceHeight: source.dimensions.height,
-            targetWidth: target.dimensions.width,
-            targetHeight: target.dimensions.height,
+            sourcePos: source.internals.positionAbsolute || { x: 0, y: 0 },
+            targetPos: target.internals.positionAbsolute || { x: 0, y: 0 },
+            sourceWidth: source.measured.width || 0,
+            sourceHeight: source.measured.height || 0,
+            targetWidth: target.measured.width || 0,
+            targetHeight: target.measured.height || 0,
             width: state.dimensions.width,
             height: state.dimensions.height,
             viewport: state.viewport,
@@ -97,8 +83,6 @@ export function useGetters(
 
     return state.edges
   })
-
-  const getElements: ComputedGetters['getElements'] = computed(() => [...getNodes.value, ...getEdges.value])
 
   const getSelectedNodes: ComputedGetters['getSelectedNodes'] = computed(() => {
     const selectedNodes: GraphNode[] = []
@@ -122,45 +106,12 @@ export function useGetters(
     return selectedEdges
   })
 
-  const getSelectedElements: ComputedGetters['getSelectedElements'] = computed(() => [
-    ...getSelectedNodes.value,
-    ...getSelectedEdges.value,
-  ])
-
-  /**
-   * @deprecated will be removed in next major version; use `useNodesInitialized` instead
-   */
-  const getNodesInitialized: ComputedGetters['getNodesInitialized'] = computed(() => {
-    const initializedNodes: GraphNode[] = []
-
-    for (const node of state.nodes) {
-      if (!!node.dimensions.width && !!node.dimensions.height && node.handleBounds !== undefined) {
-        initializedNodes.push(node)
-      }
-    }
-
-    return initializedNodes
-  })
-
-  /**
-   * @deprecated will be removed in next major version; use `useNodesInitialized` instead
-   */
-  const areNodesInitialized: ComputedGetters['areNodesInitialized'] = computed(
-    () => getNodes.value.length > 0 && getNodesInitialized.value.length === getNodes.value.length,
-  )
-
   return {
-    getNode,
-    getEdge,
-    getElements,
     getEdgeTypes,
     getNodeTypes,
     getEdges,
     getNodes,
-    getSelectedElements,
     getSelectedNodes,
     getSelectedEdges,
-    getNodesInitialized,
-    areNodesInitialized,
   }
 }

--- a/packages/core/src/store/state.ts
+++ b/packages/core/src/store/state.ts
@@ -1,5 +1,5 @@
 import { isMacOs } from '@xyflow/system'
-import type { FlowOptions, State } from '../types'
+import type { FlowProps, State } from '../types'
 import { ConnectionLineType, ConnectionMode, PanOnScrollMode, SelectionMode } from '../types'
 
 import { createHooks } from './hooks'
@@ -118,12 +118,11 @@ export function useState(): State {
 }
 
 // these options will be set using the appropriate methods
-export const storeOptionsToSkip: (keyof Partial<FlowOptions & Omit<State, 'nodes' | 'edges' | 'modelValue'>>)[] = [
+export const storeOptionsToSkip: (keyof Partial<FlowProps & Omit<State, 'nodes' | 'edges' | 'modelValue'>>)[] = [
   'id',
   'vueFlowRef',
   'viewportRef',
   'initialized',
-  'modelValue',
   'nodes',
   'edges',
   'maxZoom',

--- a/packages/core/src/types/changes.ts
+++ b/packages/core/src/types/changes.ts
@@ -43,8 +43,8 @@ export interface NodeRemoveChange {
   type: 'remove'
 }
 
-export interface NodeAddChange<Data = ElementData> {
-  item: GraphNode<Data>
+export interface NodeAddChange<NodeType extends Node = Node> {
+  item: GraphNode<NodeType>
   type: 'add'
 }
 

--- a/packages/core/src/types/edge.ts
+++ b/packages/core/src/types/edge.ts
@@ -1,5 +1,5 @@
 import type { CSSProperties, Component, VNode } from 'vue'
-import type { ClassFunc, ElementData, Position, StyleFunc, Styles } from './flow'
+import type { ElementData, Position, Styles } from './flow'
 import type { GraphNode } from './node'
 import type { EdgeComponent, EdgeTextProps } from './components'
 import type { CustomEvent, EdgeEventsHandler, EdgeEventsOn } from './hooks'
@@ -92,9 +92,9 @@ export interface DefaultEdge<
   /** Disable/enable deleting edge */
   deletable?: boolean
   /** Additional class names, can be a string or a callback returning a string (receives current flow element) */
-  class?: string | string[] | Record<string, any> | ClassFunc<GraphEdge<Data, CustomEvents>>
+  class?: string | string[] | Record<string, any>
   /** Additional styles, can be an object or a callback returning an object (receives current flow element) */
-  style?: Styles | StyleFunc<GraphEdge<Data, CustomEvents>>
+  style?: Styles
   /** Is edge hidden */
   hidden?: boolean
   /** Radius of mouse event triggers (to ease selecting edges), defaults to 2 */

--- a/packages/core/src/types/flow.ts
+++ b/packages/core/src/types/flow.ts
@@ -84,16 +84,6 @@ export interface FlowExportObject {
   nodes: Node[]
   /** exported edges */
   edges: Edge[]
-  /**
-   * exported viewport position
-   * @deprecated use {@link FlowExportObject.viewport} instead
-   */
-  position: [x: number, y: number]
-  /**
-   * exported zoom level
-   * @deprecated use {@link FlowExportObject.viewport} instead
-   */
-  zoom: number
   /** exported viewport (position + zoom) */
   viewport: ViewportTransform
 }

--- a/packages/core/src/types/flow.ts
+++ b/packages/core/src/types/flow.ts
@@ -22,6 +22,8 @@ import type { VueFlowStore } from './store'
 
 export type MaybeElement = Node | Edge | Connection | Element
 
+export type ElementData = Record<string, unknown>
+
 export interface CustomThemeVars {
   [key: string]: string | number | undefined
 }

--- a/packages/core/src/types/flow.ts
+++ b/packages/core/src/types/flow.ts
@@ -15,52 +15,12 @@ import type {
 } from './connection'
 import type { PanOnScrollMode, ViewportTransform } from './zoom'
 import type { EdgeTypesObject, NodeTypesObject } from './components'
-import type { CustomEvent, EdgeMouseEvent, EdgeUpdateEvent, NodeDragEvent, NodeMouseEvent } from './hooks'
+import type { EdgeMouseEvent, EdgeUpdateEvent, NodeDragEvent, NodeMouseEvent } from './hooks'
 import type { ValidConnectionFunc } from './handle'
 import type { EdgeChange, NodeChange } from './changes'
 import type { VueFlowStore } from './store'
 
-// todo: should be object type
-export type ElementData = any
-
-/**
- * @deprecated - will be removed in the next major version
- * A flow element (after parsing into state)
- */
-export type FlowElement<
-  NodeData = ElementData,
-  EdgeData = ElementData,
-  NodeEvents extends Record<string, CustomEvent> = any,
-  EdgeEvents extends Record<string, CustomEvent> = any,
-> = GraphNode<NodeData, NodeEvents> | GraphEdge<EdgeData, EdgeEvents>
-
-/**
- * @deprecated - will be removed in the next major version
- * An array of flow elements (after parsing into state)
- */
-export type FlowElements<
-  NodeData = ElementData,
-  EdgeData = ElementData,
-  NodeEvents extends Record<string, CustomEvent> = any,
-  EdgeEvents extends Record<string, CustomEvent> = any,
-> = FlowElement<NodeData, EdgeData, NodeEvents, EdgeEvents>[]
-
-/** Initial elements (before parsing into state) */
-export type Element<
-  NodeData = ElementData,
-  EdgeData = ElementData,
-  NodeEvents extends Record<string, CustomEvent> = any,
-  EdgeEvents extends Record<string, CustomEvent> = any,
-> = Node<NodeData, NodeEvents> | Edge<EdgeData, EdgeEvents>
-
-export type Elements<
-  NodeData = ElementData,
-  EdgeData = ElementData,
-  NodeEvents extends Record<string, CustomEvent> = any,
-  EdgeEvents extends Record<string, CustomEvent> = any,
-> = Element<NodeData, EdgeData, NodeEvents, EdgeEvents>[]
-
-export type MaybeElement = Node | Edge | Connection | FlowElement | Element
+export type MaybeElement = Node | Edge | Connection | Element
 
 export interface CustomThemeVars {
   [key: string]: string | number | undefined
@@ -75,12 +35,8 @@ export type CSSVars =
   | '--vf-handle'
 
 export type ThemeVars = { [key in CSSVars]?: CSSProperties['color'] }
-export type Styles = CSSProperties & ThemeVars & CustomThemeVars
-/** @deprecated will be removed in the next major version */
-export type ClassFunc<ElementType extends FlowElement = FlowElement> = (element: ElementType) => string | void
 
-/** @deprecated will be removed in the next major version */
-export type StyleFunc<ElementType extends FlowElement = FlowElement> = (element: ElementType) => Styles | void
+export type Styles = CSSProperties & ThemeVars & CustomThemeVars
 
 /** Handle Positions */
 export enum Position {
@@ -142,11 +98,6 @@ export interface FlowExportObject {
 
 export interface FlowProps {
   id?: string
-  /**
-   * all elements (nodes + edges)
-   * @deprecated use {@link FlowProps.nodes} & {@link FlowProps.nodes} instead
-   */
-  modelValue?: Elements
   nodes?: Node[]
   edges?: Edge[]
   /** either use the edgeTypes prop to define your edge-types or use slots (<template #edge-mySpecialType="props">) */
@@ -306,7 +257,6 @@ export interface FlowEmits {
   (event: 'nodeDragStop', nodeDragEvent: NodeDragEvent): void
 
   /** v-model event definitions */
-  (event: 'update:modelValue', value: FlowElements): void
   (event: 'update:nodes', value: GraphNode[]): void
   (event: 'update:edges', value: GraphEdge[]): void
 }

--- a/packages/core/src/types/handle.ts
+++ b/packages/core/src/types/handle.ts
@@ -1,7 +1,5 @@
 import type { Dimensions, Position, XYPosition } from './flow'
 import type { Connection } from './connection'
-import type { GraphEdge } from './edge'
-import type { GraphNode } from './node'
 
 export type HandleType = 'source' | 'target'
 
@@ -31,12 +29,9 @@ export interface ConnectingHandle {
 }
 
 /** A valid connection function can determine if an attempted connection is valid or not, i.e. abort creating a new edge */
-export type ValidConnectionFunc = (
-  connection: Connection,
-  elements: { edges: GraphEdge[]; nodes: GraphNode[]; sourceNode: GraphNode; targetNode: GraphNode },
-) => boolean
+export type ValidConnectionFunc = (connection: Connection) => boolean
 
-export type HandleConnectableFunc = (node: GraphNode, connectedEdges: GraphEdge[]) => boolean
+export type HandleConnectableFunc = (nodeId: string, handleId: string | null) => boolean
 
 /**
  * set to true to allow unlimited connections,

--- a/packages/core/src/types/node.ts
+++ b/packages/core/src/types/node.ts
@@ -1,8 +1,6 @@
-import type { Component, VNode } from 'vue'
-import type { NodeBase } from '@xyflow/system'
-import type { Dimensions, Position, Styles, XYPosition, XYZPosition } from './flow'
-import type { HandleConnectable, HandleElement, ValidConnectionFunc } from './handle'
-import type { NodeEventsOn } from './hooks'
+import type { NodeBase, NodeProps as NodePropsBase } from '@xyflow/system'
+import type { Styles } from './flow'
+import type { HandleConnectable, HandleElement } from './handle'
 
 export type ElementData = Record<string, unknown>
 
@@ -25,17 +23,11 @@ export interface NodeHandleBounds {
   target?: HandleElement[]
 }
 
-/** @deprecated will be removed in next major release */
-export type WidthFunc = (node: GraphNode) => number | string | void
-
-/** @deprecated will be removed in next major release */
-export type HeightFunc = (node: GraphNode) => number | string | void
-
 /**
  * The node data structure that gets used for the nodes prop.
  * @public
  */
-export interface Node<NodeData extends Record<string, unknown> = Record<string, unknown>, NodeType extends string = string>
+export interface Node<NodeData extends ElementData = ElementData, NodeType extends string = string>
   extends Omit<NodeBase<NodeData, NodeType>, 'connectable' | 'extent' | 'origin'> {
   /** Disable/enable connecting node */
   connectable?: HandleConnectable
@@ -47,80 +39,8 @@ export interface Node<NodeData extends Record<string, unknown> = Record<string, 
   style?: Styles
 }
 
-export interface GraphNode<Data extends ElementData = ElementData, Type extends string = string> extends Node<Data, Type> {
-  /** absolute position in relation to parent elements + z-index */
-  computedPosition: XYZPosition
-  handleBounds: NodeHandleBounds
-  /** node width, height */
-  dimensions: Dimensions
-  isParent: boolean
-  selected: boolean
-  resizing: boolean
-  dragging: boolean
-}
-
 /** these props are passed to node components */
-export interface NodeProps<Data = ElementData, CustomEvents = object, Type extends string = string> {
-  /** unique node id */
-  id: string
-  /** node type */
-  type: Type
-  /** is node selected */
-  selected: boolean
+export interface NodeProps<NodeType extends NodeBase = NodeBase> extends Omit<NodePropsBase<NodeType>, 'isConnectable'> {
   /** can node handles be connected, you need to forward this to your handles for this prop to have any effect */
-  connectable: HandleConnectable
-  /**
-   * @deprecated - will be removed in next major release and replaced with `computedPosition`
-   * node x, y (relative) position on graph
-   */
-  position: XYPosition
-  /** dom element dimensions (width, height) */
-  dimensions: Dimensions
-  /**
-   * @deprecated - will be removed in next major release and replaced with `{ data: { label: string | VNode | Component } }`
-   * node label, either pass a string or a VNode
-   * For example like this: `h('div', props, children)`)
-   * Object is just a type-hack for Vue, ignore that
-   */
-  label?: string | VNode | Component | object
-  /**
-   * @deprecated will be removed in next major release
-   * called when used as target for new connection
-   */
-  isValidTargetPos?: ValidConnectionFunc
-  /**
-   * @deprecated will be removed in next major release
-   * called when used as source for new connection
-   */
-  isValidSourcePos?: ValidConnectionFunc
-  /**
-   * @deprecated - will be removed in next major release. Use `parentNodeId` instead
-   * parent node id
-   */
-  parent?: string
-  /**
-   * todo: rename to `parentId` in next major release
-   * parent node id
-   */
-  parentNodeId?: string
-  /** is node currently dragging */
-  dragging: boolean
-  /** is node currently resizing */
-  resizing: boolean
-  /** node z-index */
-  zIndex: number
-  /** handle position */
-  targetPosition?: Position
-  /** handle position */
-  sourcePosition?: Position
-  /** drag handle query selector */
-  dragHandle?: string
-
-  /** additional data of node */
-  data: Data
-  /**
-   * @deprecated - will be removed in next major release
-   * contextual and custom events of node
-   */
-  events: NodeEventsOn<CustomEvents>
+  isConnectable: HandleConnectable
 }

--- a/packages/core/src/types/node.ts
+++ b/packages/core/src/types/node.ts
@@ -34,6 +34,8 @@ export interface Node<NodeData extends ElementData = ElementData, NodeType exten
   extends Omit<NodeBase<NodeData, NodeType>, 'connectable' | 'extent' | 'origin'> {
   /** Disable/enable connecting node */
   connectable?: HandleConnectable
+  /** Disable/enable focusing node */
+  focusable?: boolean
   /** define node extent, i.e. area in which node can be moved */
   extent?: CoordinateExtent | CoordinateExtentRange | 'parent'
   /** Additional class names, can be a string or a callback returning a string (receives current flow element) */

--- a/packages/core/src/types/node.ts
+++ b/packages/core/src/types/node.ts
@@ -1,5 +1,5 @@
-import type { NodeBase, NodeProps as NodePropsBase } from '@xyflow/system'
-import type { ElementData, Styles } from './flow'
+import type { NodeBase } from '@xyflow/system'
+import type { ElementData, Styles, XYPosition } from './flow'
 import type { HandleConnectable, HandleElement } from './handle'
 
 /** Defined as [[x-from, y-from], [x-to, y-to]] */
@@ -21,6 +21,11 @@ export interface NodeHandleBounds {
   target?: HandleElement[]
 }
 
+export type NodeBounds = XYPosition & {
+  width: number | null
+  height: number | null
+}
+
 /**
  * The node data structure that gets used for the nodes prop.
  * @public
@@ -37,8 +42,44 @@ export interface Node<NodeData extends ElementData = ElementData, NodeType exten
   style?: Styles
 }
 
-/** these props are passed to node components */
-export interface NodeProps<NodeType extends NodeBase = NodeBase> extends Omit<NodePropsBase<NodeType>, 'isConnectable'> {
-  /** can node handles be connected, you need to forward this to your handles for this prop to have any effect */
-  isConnectable: HandleConnectable
+export type GraphNode<NodeType extends Node = Node> = NodeType & {
+  measured: {
+    width?: number
+    height?: number
+  }
+  internals: {
+    positionAbsolute: XYPosition
+    z: number
+    /**
+     * Holds a reference to the original node object provided by the user.
+     * Used as an optimization to avoid certain operations.
+     */
+    userNode: NodeType
+    handleBounds?: NodeHandleBounds
+    bounds?: NodeBounds
+  }
 }
+
+export type NodeProps<NodeType extends Node = Node> = Pick<
+  NodeType,
+  | 'id'
+  | 'data'
+  | 'width'
+  | 'height'
+  | 'sourcePosition'
+  | 'targetPosition'
+  | 'selected'
+  | 'dragHandle'
+  | 'selectable'
+  | 'deletable'
+  | 'draggable'
+  | 'parentId'
+> &
+  Required<Pick<NodeType, 'type' | 'dragging' | 'zIndex'>> & {
+    /** whether a node is connectable or not */
+    isConnectable: HandleConnectable
+    /** position absolute x value */
+    positionAbsoluteX: number
+    /** position absolute x value */
+    positionAbsoluteY: number
+  }

--- a/packages/core/src/types/node.ts
+++ b/packages/core/src/types/node.ts
@@ -1,8 +1,6 @@
 import type { NodeBase, NodeProps as NodePropsBase } from '@xyflow/system'
-import type { Styles } from './flow'
+import type { ElementData, Styles } from './flow'
 import type { HandleConnectable, HandleElement } from './handle'
-
-export type ElementData = Record<string, unknown>
 
 /** Defined as [[x-from, y-from], [x-to, y-to]] */
 export type CoordinateExtent = [extentFrom: [fromX: number, fromY: number], extentTo: [toX: number, toY: number]]

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -1,11 +1,10 @@
 import type { CSSProperties, ComputedRef, ToRefs } from 'vue'
 import type { KeyFilter } from '@vueuse/core'
+import type { InternalNodeBase, NodeBase } from '@xyflow/system'
 import type { ViewportHelper } from '../composables'
 import type {
   Dimensions,
   ElementData,
-  Elements,
-  FlowElements,
   FlowExportObject,
   FlowOptions,
   FlowProps,
@@ -161,8 +160,6 @@ export interface State extends Omit<FlowProps, 'id' | 'modelValue'> {
   ariaLiveMessage: string
 }
 
-export type SetElements = (elements: Elements | ((elements: FlowElements) => Elements)) => void
-
 export type SetNodes = (nodes: Node[] | ((nodes: GraphNode[]) => Node[])) => void
 
 export type SetEdges = (edges: Edge[] | ((edges: GraphEdge[]) => Edge[])) => void
@@ -206,9 +203,9 @@ export type UpdateNodeDimensions = (updates: UpdateNodeDimensionsParams[]) => vo
 
 export type UpdateNodeInternals = (nodeIds?: string[]) => void
 
-export type FindNode = <Data = ElementData, CustomEvents extends Record<string, CustomEvent> = any>(
+export type FindNode = <NodeType extends NodeBase = NodeBase>(
   id: string | undefined | null,
-) => GraphNode<Data, CustomEvents> | undefined
+) => InternalNodeBase<NodeType> | undefined
 
 export type FindEdge = <Data = ElementData, CustomEvents extends Record<string, CustomEvent> = any>(
   id: string | undefined | null,
@@ -235,8 +232,6 @@ export type UpdateNodeData = <Data = ElementData, CustomEvents extends Record<st
 export type IsNodeIntersecting = (node: (Partial<Node> & { id: Node['id'] }) | Rect, area: Rect, partially?: boolean) => boolean
 
 export interface Actions extends Omit<ViewportHelper, 'viewportInitialized'> {
-  /** parses elements (nodes + edges) and re-sets the state */
-  setElements: SetElements
   /** parses nodes and re-sets the state */
   setNodes: SetNodes
   /** parses edges and re-sets the state */
@@ -265,11 +260,6 @@ export interface Actions extends Omit<ViewportHelper, 'viewportInitialized'> {
   applyEdgeChanges: (changes: EdgeChange[]) => GraphEdge[]
   /** applies default node change handler */
   applyNodeChanges: (changes: NodeChange[]) => GraphNode[]
-  /**
-   * manually select elements and add to state
-   * @deprecated will be removed in the next major, use {@link Actions.addSelectedNodes} or {@link Actions.addSelectedEdges} instead
-   */
-  addSelectedElements: (elements: FlowElements) => void
   /** manually select edges and add to state */
   addSelectedEdges: (edges: GraphEdge[]) => void
   /** manually select nodes and add to state */
@@ -278,11 +268,6 @@ export interface Actions extends Omit<ViewportHelper, 'viewportInitialized'> {
   removeSelectedEdges: (edges: GraphEdge[]) => void
   /** manually unselect nodes and remove from state */
   removeSelectedNodes: (nodes: GraphNode[]) => void
-  /**
-   * @deprecated will be replaced in the next major
-   * unselect selected elements (if none are passed, all elements are unselected)
-   */
-  removeSelectedElements: (elements?: Elements) => void
   /** apply min zoom value to d3 */
   setMinZoom: (zoom: number) => void
   /** apply max zoom value to d3 */
@@ -341,11 +326,6 @@ export interface Getters {
   getEdgeTypes: Record<keyof DefaultEdgeTypes | string, EdgeComponent>
   /** returns object containing current node types */
   getNodeTypes: Record<keyof DefaultNodeTypes | string, NodeComponent>
-  /**
-   * get all elements
-   * @deprecated - will be removed in next major version
-   */
-  getElements: FlowElements
   /** all visible node */
   getNodes: GraphNode[]
   /** all visible edges */
@@ -360,8 +340,6 @@ export interface Getters {
    * @deprecated use {@link Actions.findEdge} instead
    */
   getEdge: (id: string) => GraphEdge | undefined
-  /** returns all currently selected elements */
-  getSelectedElements: FlowElements
   /** returns all currently selected nodes */
   getSelectedNodes: GraphNode[]
   /** returns all currently selected edges */

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -1,19 +1,7 @@
 import type { CSSProperties, ComputedRef, ToRefs } from 'vue'
 import type { KeyFilter } from '@vueuse/core'
-import type { InternalNodeBase, NodeBase } from '@xyflow/system'
 import type { ViewportHelper } from '../composables'
-import type {
-  Dimensions,
-  ElementData,
-  FlowExportObject,
-  FlowOptions,
-  FlowProps,
-  Rect,
-  SelectionMode,
-  SelectionRect,
-  SnapGrid,
-  XYPosition,
-} from './flow'
+import type { Dimensions, FlowExportObject, FlowProps, Rect, SelectionMode, SelectionRect, SnapGrid, XYPosition } from './flow'
 import type { DefaultEdgeTypes, DefaultNodeTypes, EdgeComponent, NodeComponent } from './components'
 import type {
   Connection,
@@ -27,7 +15,7 @@ import type {
 import type { DefaultEdgeOptions, Edge, EdgeUpdatable, GraphEdge } from './edge'
 import type { CoordinateExtent, CoordinateExtentRange, GraphNode, Node } from './node'
 import type { D3Selection, D3Zoom, D3ZoomHandler, PanOnScrollMode, ViewportTransform } from './zoom'
-import type { CustomEvent, FlowHooks, FlowHooksEmit, FlowHooksOn } from './hooks'
+import type { FlowHooks, FlowHooksEmit, FlowHooksOn } from './hooks'
 import type { EdgeChange, NodeChange, NodeDragItem } from './changes'
 import type { ConnectingHandle, ValidConnectionFunc } from './handle'
 
@@ -160,102 +148,81 @@ export interface State extends Omit<FlowProps, 'id' | 'modelValue'> {
   ariaLiveMessage: string
 }
 
-export type SetNodes = (nodes: Node[] | ((nodes: GraphNode[]) => Node[])) => void
-
-export type SetEdges = (edges: Edge[] | ((edges: GraphEdge[]) => Edge[])) => void
-
-export type AddNodes = (nodes: Node | Node[] | ((nodes: GraphNode[]) => Node | Node[])) => void
-
-export type RemoveNodes = (
-  nodes: (string | Node) | (Node | string)[] | ((nodes: GraphNode[]) => (string | Node) | (Node | string)[]),
-  removeConnectedEdges?: boolean,
-  removeChildren?: boolean,
-) => void
-
-export type RemoveEdges = (
-  edges: (string | Edge) | (Edge | string)[] | ((edges: GraphEdge[]) => (string | Edge) | (Edge | string)[]),
-) => void
-
-export type AddEdges = (
-  edgesOrConnections:
-    | (Edge | Connection)
-    | (Edge | Connection)[]
-    | ((edges: GraphEdge[]) => (Edge | Connection) | (Edge | Connection)[]),
-) => void
-
-export type UpdateEdge = (oldEdge: GraphEdge, newConnection: Connection, shouldReplaceId?: boolean) => GraphEdge | false
-
-export type UpdateEdgeData = <Data = ElementData, CustomEvents extends Record<string, CustomEvent> = any>(
-  id: string,
-  dataUpdate: Partial<Data> | ((edge: GraphEdge<Data, CustomEvents>) => Partial<Data>),
-  options?: { replace: boolean },
-) => void
-
-export type SetState = (
-  state:
-    | Partial<FlowOptions & Omit<State, 'nodes' | 'edges' | 'modelValue'>>
-    | ((state: State) => Partial<FlowOptions & Omit<State, 'nodes' | 'edges' | 'modelValue'>>),
-) => void
-
-export type UpdateNodePosition = (dragItems: NodeDragItem[], changed: boolean, dragging: boolean) => void
-
-export type UpdateNodeDimensions = (updates: UpdateNodeDimensionsParams[]) => void
-
-export type UpdateNodeInternals = (nodeIds?: string[]) => void
-
-export type FindNode = <NodeType extends NodeBase = NodeBase>(
-  id: string | undefined | null,
-) => InternalNodeBase<NodeType> | undefined
-
-export type FindEdge = <Data = ElementData, CustomEvents extends Record<string, CustomEvent> = any>(
-  id: string | undefined | null,
-) => GraphEdge<Data, CustomEvents> | undefined
-
-export type GetIntersectingNodes = (
-  node: (Partial<Node> & { id: Node['id'] }) | Rect,
-  partially?: boolean,
-  nodes?: GraphNode[],
-) => GraphNode[]
-
-export type UpdateNode = <Data = ElementData, CustomEvents extends Record<string, CustomEvent> = any>(
-  id: string,
-  nodeUpdate: Partial<Node<Data, CustomEvents>> | ((node: GraphNode<Data, CustomEvents>) => Partial<Node<Data, CustomEvents>>),
-  options?: { replace: boolean },
-) => void
-
-export type UpdateNodeData = <Data = ElementData, CustomEvents extends Record<string, CustomEvent> = any>(
-  id: string,
-  dataUpdate: Partial<Data> | ((node: GraphNode<Data, CustomEvents>) => Partial<Data>),
-  options?: { replace: boolean },
-) => void
-
-export type IsNodeIntersecting = (node: (Partial<Node> & { id: Node['id'] }) | Rect, area: Rect, partially?: boolean) => boolean
-
-export interface Actions extends Omit<ViewportHelper, 'viewportInitialized'> {
+export interface Actions<NodeType extends Node = Node, EdgeType extends Edge = Edge>
+  extends Omit<ViewportHelper, 'viewportInitialized'> {
   /** parses nodes and re-sets the state */
-  setNodes: SetNodes
+  setNodes: (nodes: Node[] | ((nodes: GraphNode[]) => Node[])) => void
   /** parses edges and re-sets the state */
-  setEdges: SetEdges
+  setEdges: (edges: Edge[] | ((edges: GraphEdge[]) => Edge[])) => void
   /** parses nodes and adds to state */
-  addNodes: AddNodes
+  addNodes: (nodes: Node | Node[] | ((nodes: GraphNode[]) => Node | Node[])) => void
   /** parses edges and adds to state */
-  addEdges: AddEdges
+  addEdges: (
+    edgesOrConnections:
+      | (Edge | Connection)
+      | (Edge | Connection)[]
+      | ((edges: GraphEdge[]) => (Edge | Connection) | (Edge | Connection)[]),
+  ) => void
   /** remove nodes (and possibly connected edges and children) from state */
-  removeNodes: RemoveNodes
+  removeNodes: (
+    nodes: (string | Node) | (Node | string)[] | ((nodes: GraphNode[]) => (string | Node) | (Node | string)[]),
+    removeConnectedEdges?: boolean,
+    removeChildren?: boolean,
+  ) => void
   /** remove edges from state */
-  removeEdges: RemoveEdges
+  removeEdges: (
+    edges: (string | Edge) | (Edge | string)[] | ((edges: GraphEdge[]) => (string | Edge) | (Edge | string)[]),
+  ) => void
   /** find a node by id */
-  findNode: FindNode
+  getNode: (id: string | undefined | null) => GraphNode<NodeType> | undefined
   /** find an edge by id */
-  findEdge: FindEdge
-  /** updates an edge */
-  updateEdge: UpdateEdge
-  /** updates the data of an edge */
-  updateEdgeData: UpdateEdgeData
-  /** updates a node */
-  updateNode: UpdateNode
-  /** updates the data of a node */
-  updateNodeData: UpdateNodeData
+  getEdge: (id: string | undefined | null) => GraphEdge<EdgeType> | undefined
+  updateEdge: (oldEdge: GraphEdge, newConnection: Connection, shouldReplaceId?: boolean) => GraphEdge | false
+  /**
+   * Updates the data attribute of a edge.
+   *
+   * @param id - id of the edge to update
+   * @param dataUpdate - the data update as an object or a function that receives the current data and returns the data update
+   * @param options.replace - if true, the data is replaced with the data update, otherwise the changes get merged
+   *
+   * @example
+   * updateEdgeData('edge-1', { label: 'A new label' });
+   */
+  updateEdgeData: (
+    id: string,
+    dataUpdate: Partial<EdgeType['data']> | ((edge: EdgeType) => Partial<EdgeType['data']>),
+    options?: { replace: boolean },
+  ) => void
+  /**
+   * Updates a node.
+   *
+   * @param id - id of the node to update
+   * @param nodeUpdate - the node update as an object or a function that receives the current node and returns the node update
+   * @param options.replace - if true, the node is replaced with the node update, otherwise the changes get merged
+   *
+   * @example
+   * updateNode('node-1', (node) => ({ position: { x: node.position.x + 10, y: node.position.y } }));
+   */
+  updateNode: (
+    id: string,
+    nodeUpdate: Partial<NodeType> | ((node: NodeType) => Partial<NodeType>),
+    options?: { replace: boolean },
+  ) => void
+  /**
+   * Updates the data attribute of a node.
+   *
+   * @param id - id of the node to update
+   * @param dataUpdate - the data update as an object or a function that receives the current data and returns the data update
+   * @param options.replace - if true, the data is replaced with the data update, otherwise the changes get merged
+   *
+   * @example
+   * updateNodeData('node-1', { label: 'A new label' });
+   */
+  updateNodeData: (
+    id: string,
+    dataUpdate: Partial<NodeType['data']> | ((node: NodeType) => Partial<NodeType['data']>),
+    options?: { replace: boolean },
+  ) => void
   /** applies default edge change handler */
   applyEdgeChanges: (changes: EdgeChange[]) => GraphEdge[]
   /** applies default node change handler */
@@ -280,13 +247,17 @@ export interface Actions extends Omit<ViewportHelper, 'viewportInitialized'> {
   /** enable/disable node interaction (dragging, selecting etc) */
   setInteractive: (isInteractive: boolean) => void
   /** set new state */
-  setState: SetState
+  setState: (
+    state:
+      | Partial<FlowProps & Omit<State, 'nodes' | 'edges' | 'modelValue'>>
+      | ((state: State) => Partial<FlowProps & Omit<State, 'nodes' | 'edges' | 'modelValue'>>),
+  ) => void
   /** return an object of graph values (elements, viewport transform) for storage and re-loading a graph */
   toObject: () => FlowExportObject
   /** load graph from export obj */
   fromObject: (obj: FlowExportObject) => Promise<boolean>
   /** force update node internal data, if handle bounds are incorrect, you might want to use this */
-  updateNodeInternals: UpdateNodeInternals
+  updateNodeInternals: (nodeIds?: string[]) => void
   /** start a connection */
   startConnection: (startHandle: ConnectingHandle, position?: XYPosition, isClick?: boolean) => void
   /** update connection position */
@@ -295,14 +266,30 @@ export interface Actions extends Omit<ViewportHelper, 'viewportInitialized'> {
   endConnection: (event?: MouseEvent | TouchEvent, isClick?: boolean) => void
 
   /** internal position updater, you probably don't want to use this */
-  updateNodePositions: UpdateNodePosition
+  updateNodePositions: (dragItems: NodeDragItem[], changed: boolean, dragging: boolean) => void
   /** internal dimensions' updater, you probably don't want to use this */
-  updateNodeDimensions: UpdateNodeDimensions
+  updateNodeDimensions: (updates: UpdateNodeDimensionsParams[]) => void
 
-  /** returns all node intersections */
-  getIntersectingNodes: GetIntersectingNodes
-  /** check if a node is intersecting with a defined area */
-  isNodeIntersecting: IsNodeIntersecting
+  /**
+   * Returns all nodes that intersect with the given node or rect.
+   *
+   * @param node - the node or rect to check for intersections
+   * @param partially - if true, the node is considered to be intersecting if it partially overlaps with the passed node or rect
+   * @param nodes - optional nodes array to check for intersections
+   *
+   * @returns an array of intersecting nodes
+   */
+  getIntersectingNodes: (node: NodeType | { id: Node['id'] } | Rect, partially?: boolean, nodes?: NodeType[]) => NodeType[]
+  /**
+   * Checks if the given node or rect intersects with the passed rect.
+   *
+   * @param node - the node or rect to check for intersections
+   * @param area - the rect to check for intersections
+   * @param partially - if true, the node is considered to be intersecting if it partially overlaps with the passed react
+   *
+   * @returns true if the node or rect intersects with the given area
+   */
+  isNodeIntersecting: (node: NodeType | { id: Node['id'] } | Rect, area: Rect, partially?: boolean) => boolean
   /** get a node's incomers */
   getIncomers: (nodeOrId: Node | string) => GraphNode[]
   /** get a node's outgoers */
@@ -330,30 +317,10 @@ export interface Getters {
   getNodes: GraphNode[]
   /** all visible edges */
   getEdges: GraphEdge[]
-  /**
-   * returns a node by id
-   * @deprecated use {@link Actions.findNode} instead
-   */
-  getNode: (id: string) => GraphNode | undefined
-  /**
-   * returns an edge by id
-   * @deprecated use {@link Actions.findEdge} instead
-   */
-  getEdge: (id: string) => GraphEdge | undefined
   /** returns all currently selected nodes */
   getSelectedNodes: GraphNode[]
   /** returns all currently selected edges */
   getSelectedEdges: GraphEdge[]
-  /**
-   * returns all nodes that are initialized, i.e. they have actual dimensions
-   * @deprecated - will be removed in next major version; use {@link useNodesInitialized} instead
-   */
-  getNodesInitialized: GraphNode[]
-  /**
-   * returns a boolean flag whether all current nodes are initialized
-   * @deprecated - will be removed in next major version; use {@link useNodesInitialized} instead
-   */
-  areNodesInitialized: boolean
 }
 
 export type ComputedGetters = {

--- a/packages/core/src/utils/changes.ts
+++ b/packages/core/src/utils/changes.ts
@@ -1,38 +1,38 @@
-import { nextTick } from 'vue'
 import type {
   EdgeAddChange,
   EdgeChange,
+  EdgeLookup,
   EdgeRemoveChange,
   EdgeSelectionChange,
-  ElementChange,
-  FlowElement,
   GraphEdge,
   GraphNode,
   NodeAddChange,
   NodeChange,
+  NodeLookup,
   NodeRemoveChange,
   NodeSelectionChange,
-  StyleFunc,
   Styles,
 } from '../types'
-import { isGraphNode } from '.'
 
 function handleParentExpand(updateItem: GraphNode, parent: GraphNode) {
   if (parent) {
-    const extendWidth = updateItem.position.x + updateItem.dimensions.width - parent.dimensions.width
-    const extendHeight = updateItem.position.y + updateItem.dimensions.height - parent.dimensions.height
+    const itemWidth = updateItem.measured.width || 0
+    const itemHeight = updateItem.measured.height || 0
+    const parentWidth = updateItem.measured.width || 0
+    const parentHeight = updateItem.measured.height || 0
+
+    const extendWidth = updateItem.position.x + itemWidth - parentWidth
+    const extendHeight = updateItem.position.y + itemHeight - parentHeight
 
     if (extendWidth > 0 || extendHeight > 0 || updateItem.position.x < 0 || updateItem.position.y < 0) {
       let parentStyles: Styles = {}
 
-      if (typeof parent.style === 'function') {
-        parentStyles = { ...parent.style(parent) }
-      } else if (parent.style) {
+      if (parent.style) {
         parentStyles = { ...parent.style }
       }
 
-      parentStyles.width = parentStyles.width ?? `${parent.dimensions.width}px`
-      parentStyles.height = parentStyles.height ?? `${parent.dimensions.height}px`
+      parentStyles.width = parentStyles.width ?? `${parent.measured.width}px`
+      parentStyles.height = parentStyles.height ?? `${parent.measured.height}px`
 
       if (extendWidth > 0) {
         if (typeof parentStyles.width === 'string') {
@@ -80,136 +80,80 @@ function handleParentExpand(updateItem: GraphNode, parent: GraphNode) {
         updateItem.position.y = 0
       }
 
-      parent.dimensions.width = Number(parentStyles.width.toString().replace('px', ''))
-      parent.dimensions.height = Number(parentStyles.height.toString().replace('px', ''))
-
-      if (typeof parent.style === 'function') {
-        parent.style = (p) => {
-          const styleFunc = parent.style as StyleFunc
-
-          return {
-            ...styleFunc(p),
-            ...parentStyles,
-          }
-        }
-      } else {
-        parent.style = {
-          ...parent.style,
-          ...parentStyles,
-        }
+      parent.width = Number(parentStyles.width.toString().replace('px', ''))
+      parent.height = Number(parentStyles.height.toString().replace('px', ''))
+      parent.style = {
+        ...parent.style,
+        ...parentStyles,
       }
     }
   }
 }
 
-export function applyChanges<
-  T extends FlowElement = FlowElement,
-  C extends ElementChange = T extends GraphNode ? NodeChange : EdgeChange,
->(changes: C[], elements: T[]): T[] {
-  const addRemoveChanges = changes.filter((c) => c.type === 'add' || c.type === 'remove') as (
-    | NodeAddChange
-    | EdgeAddChange
-    | NodeRemoveChange
-    | EdgeRemoveChange
-  )[]
-
-  for (const change of addRemoveChanges) {
+export function applyEdgeChanges(changes: EdgeChange[], edgeLookup: EdgeLookup) {
+  for (const change of changes) {
     if (change.type === 'add') {
-      const index = elements.findIndex((el) => el.id === change.item.id)
+      edgeLookup.set(change.item.id, change.item)
+    }
 
-      if (index === -1) {
-        elements.push(<T>change.item)
-      }
-    } else if (change.type === 'remove') {
-      const index = elements.findIndex((el) => el.id === change.id)
+    if (change.type === 'remove') {
+      edgeLookup.delete(change.id)
+    }
 
-      if (index !== -1) {
-        elements.splice(index, 1)
+    if (change.type === 'select') {
+      const edge = edgeLookup.get(change.id)
+
+      if (edge) {
+        edge.selected = change.selected
       }
     }
   }
 
-  const elementIds = elements.map((el) => el.id)
+  return Array.from(edgeLookup.values())
+}
 
-  for (const element of elements) {
-    for (const currentChange of changes) {
-      if ((<any>currentChange).id !== element.id) {
-        continue
+export function applyNodeChanges(changes: NodeChange[], nodeLookup: NodeLookup) {
+  for (const change of changes) {
+    if (change.type === 'add') {
+      nodeLookup.set(change.item.id, change.item)
+    }
+
+    if (change.type === 'remove') {
+      nodeLookup.delete(change.id)
+    }
+
+    if (change.type === 'select') {
+      const node = nodeLookup.get(change.id)
+
+      if (node) {
+        node.selected = change.selected
       }
+    }
 
-      switch (currentChange.type) {
-        case 'select':
-          element.selected = currentChange.selected
-          break
-        case 'position':
-          if (isGraphNode(element)) {
-            if (typeof currentChange.position !== 'undefined') {
-              element.position = currentChange.position
-            }
+    if (change.type === 'position') {
+      const node = nodeLookup.get(change.id)
 
-            if (typeof currentChange.dragging !== 'undefined') {
-              element.dragging = currentChange.dragging
-            }
+      if (node) {
+        if (typeof change.position !== 'undefined') {
+          node.position = change.position
+        }
 
-            if (element.expandParent && element.parentNode) {
-              const parent = elements[elementIds.indexOf(element.parentNode)]
+        if (typeof change.dragging !== 'undefined') {
+          node.dragging = change.dragging
+        }
 
-              if (parent && isGraphNode(parent)) {
-                handleParentExpand(element, parent)
-              }
-            }
+        if (node.expandParent && node.parentId) {
+          const parent = nodeLookup.get(node.parentId)
+
+          if (parent) {
+            handleParentExpand(node, parent)
           }
-          break
-        case 'dimensions':
-          if (isGraphNode(element)) {
-            if (typeof currentChange.dimensions !== 'undefined') {
-              element.dimensions = currentChange.dimensions
-            }
-
-            if (typeof currentChange.updateStyle !== 'undefined') {
-              element.style = {
-                ...(element.style || {}),
-                width: `${currentChange.dimensions?.width}px`,
-                height: `${currentChange.dimensions?.height}px`,
-              }
-            }
-
-            if (typeof currentChange.resizing !== 'undefined') {
-              element.resizing = currentChange.resizing
-            }
-
-            if (element.expandParent && element.parentNode) {
-              const parent = elements[elementIds.indexOf(element.parentNode)]
-
-              if (parent && isGraphNode(parent)) {
-                const parentInit = !!parent.dimensions.width && !!parent.dimensions.height
-
-                if (!parentInit) {
-                  nextTick(() => {
-                    handleParentExpand(element, parent)
-                  })
-                } else {
-                  handleParentExpand(element, parent)
-                }
-              }
-            }
-          }
-          break
+        }
       }
     }
   }
 
-  return elements
-}
-
-/** @deprecated Use store instance and call `applyChanges` with template-ref or the one received by `onPaneReady` instead */
-export function applyEdgeChanges(changes: EdgeChange[], edges: GraphEdge[]) {
-  return applyChanges(changes, edges)
-}
-
-/** @deprecated Use store instance and call `applyChanges` with template-ref or the one received by `onPaneReady` instead */
-export function applyNodeChanges(changes: NodeChange[], nodes: GraphNode[]) {
-  return applyChanges(changes, nodes)
+  return Array.from(nodeLookup.values())
 }
 
 export function createSelectionChange(id: string, selected: boolean): NodeSelectionChange | EdgeSelectionChange {


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Use `NodeBase` to extend `Node` type
- Remove deprecated node options
