### PR TITLE
fix: stop default behavior when using the middle mouse button on canvas

### DIFF
--- a/packages/core/src/container/Viewport/Viewport.vue
+++ b/packages/core/src/container/Viewport/Viewport.vue
@@ -160,6 +160,10 @@ onMounted(() => {
     const pinchZoom = zoomOnPinch.value && event.ctrlKey
     const eventButton = (event as MouseEvent).button
 
+    if (eventButton === 1) {
+      event.preventDefault()
+    }
+
     if (
       (shouldPanOnDrag.value === true || (Array.isArray(shouldPanOnDrag.value) && shouldPanOnDrag.value.includes(1))) &&
       eventButton === 1 &&


### PR DESCRIPTION
# 🐛 Fixes

This pull request proposes a solution to issue #1557, by preventing the default behavior when using the middle mouse button (` eventButton === 1`) on the viewport.