### PR TITLE
fix(core): check if injected state matches options and scope id 

### DIFF
--- a/.changeset/beige-shoes-fold.md
+++ b/.changeset/beige-shoes-fold.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Check if injected vue flow state matches options id, otherwise create new state

--- a/.changeset/funny-jokes-lie.md
+++ b/.changeset/funny-jokes-lie.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Prefer options id over scope id when finding vue flow internal state by id

--- a/packages/core/src/composables/useVueFlow.ts
+++ b/packages/core/src/composables/useVueFlow.ts
@@ -33,7 +33,7 @@ export function useVueFlow(idOrOpts?: any): VueFlowStore {
   const options = isOptsObj ? idOrOpts : { id: idOrOpts }
 
   const id = options.id
-  const vueFlowId = scope?.vueFlowId || id
+  const vueFlowId = id ?? scope?.vueFlowId
 
   let vueFlow: Injection
 

--- a/packages/core/src/composables/useVueFlow.ts
+++ b/packages/core/src/composables/useVueFlow.ts
@@ -42,9 +42,9 @@ export function useVueFlow(idOrOpts?: any): VueFlowStore {
    * this should be the regular way after initialization
    */
   if (scope) {
-    const injection = inject(VueFlow, null)
-    if (typeof injection !== 'undefined' && injection !== null) {
-      vueFlow = injection
+    const injectedState = inject(VueFlow, null)
+    if (typeof injectedState !== 'undefined' && injectedState !== null && (!vueFlowId || injectedState.id === vueFlowId)) {
+      vueFlow = injectedState
     }
   }
 
@@ -63,7 +63,7 @@ export function useVueFlow(idOrOpts?: any): VueFlowStore {
    * _or_ if the store instance we found does not match up with provided ids
    * create a new store instance and register it in storage
    */
-  if (!vueFlow || (vueFlow && id && id !== vueFlow.id)) {
+  if (!vueFlow || (vueFlowId && vueFlow.id !== vueFlowId)) {
     const name = id ?? storage.getId()
 
     const state = storage.create(name, options)


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Prefer options id over scoped id when finding vue flow state
- Check if injected vue flow state id matches options or scope id, otherwise create new state