### PR TITLE
 fix(core): push into changes arr instead of using index 

### DIFF
--- a/.changeset/fluffy-mayflies-fetch.md
+++ b/.changeset/fluffy-mayflies-fetch.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Push into dimensions changes array instead of using index access.

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -156,11 +156,11 @@ export function useActions(state: State, nodeLookup: ComputedRef<NodeLookup>, ed
           node.handleBounds.source = getHandleBounds('.source', update.nodeElement, nodeBounds, zoom)
           node.handleBounds.target = getHandleBounds('.target', update.nodeElement, nodeBounds, zoom)
 
-          changes[i] = {
+          changes.push({
             id: node.id,
             type: 'dimensions',
             dimensions,
-          }
+          })
         }
       }
     }


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Push into dimensions changes array instead of adding by index

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] #1568 