### PR TITLE
 fix(core): prevent overwriting size in node styles object 

### DIFF
--- a/.changeset/nice-seals-tickle.md
+++ b/.changeset/nice-seals-tickle.md
@@ -1,0 +1,6 @@
+---
+"@vue-flow/core": patch
+---
+
+Prevent overwriting width/height in node styles object with `node.width`/`node.height` if `width`/`height` already exist in the styles object. 
+Fixes NodeResizer not working when initial size was passed to a node through `node.width`/`node.height`.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,9 +6,10 @@
   "author": "Burak Cakmakoglu<78412429+bcakmakoglu@users.noreply.github.com>",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/bcakmakoglu/vue-flow"
+    "url": "git+https://github.com/bcakmakoglu/vue-flow",
+    "directory": "packages/core"
   },
-  "homepage": "https://github.com/bcakmakoglu/vue-flow#readme",
+  "homepage": "https://vueflow.dev",
   "bugs": {
     "url": "https://github.com/bcakmakoglu/vue-flow/issues"
   },

--- a/packages/core/src/components/Nodes/NodeWrapper.ts
+++ b/packages/core/src/components/Nodes/NodeWrapper.ts
@@ -142,11 +142,11 @@ const NodeWrapper = defineComponent({
       const width = node.width instanceof Function ? node.width(node) : node.width
       const height = node.height instanceof Function ? node.height(node) : node.height
 
-      if (width) {
+      if (!styles.width && width) {
         styles.width = typeof width === 'string' ? width : `${width}px`
       }
 
-      if (height) {
+      if (!styles.height && height) {
         styles.height = typeof height === 'string' ? height : `${height}px`
       }
 

--- a/packages/core/src/utils/changes.ts
+++ b/packages/core/src/utils/changes.ts
@@ -166,7 +166,7 @@ export function applyChanges<
               element.dimensions = currentChange.dimensions
             }
 
-            if (typeof currentChange.updateStyle !== 'undefined') {
+            if (typeof currentChange.updateStyle !== 'undefined' && currentChange.updateStyle) {
               element.style = {
                 ...(element.style || {}),
                 width: `${currentChange.dimensions?.width}px`,


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Avoid overwriting size in styles object with node.width/height if size already exists in the styles object

