### PR TITLE
 fix(core): prevent drag click when multi selection is active

### DIFF
--- a/.changeset/swift-cups-pay.md
+++ b/.changeset/swift-cups-pay.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Prevent drag-click handler when multi selection is active.

--- a/packages/core/src/composables/useDrag.ts
+++ b/packages/core/src/composables/useDrag.ts
@@ -229,24 +229,14 @@ export function useDrag(params: UseDragParams) {
   }
 
   const eventEnd = (event: UseDragEvent) => {
-    if (!dragStarted) {
-      const pointerPos = getPointerPosition(event)
-
-      const x = pointerPos.xSnapped - (lastPos.x ?? 0)
-      const y = pointerPos.ySnapped - (lastPos.y ?? 0)
-      const distance = Math.sqrt(x * x + y * y)
-
-      // dispatch a click event if the node was attempted to be dragged but the threshold was not exceeded
-      if (distance !== 0 && distance <= nodeDragThreshold.value) {
-        onClick?.(event.sourceEvent)
-      }
-
-      return
+    if (!dragging.value && !multiSelectionActive.value) {
+      onClick?.(event.sourceEvent)
     }
 
     dragging.value = false
     autoPanStarted = false
     dragStarted = false
+    lastPos = { x: undefined, y: undefined }
 
     cancelAnimationFrame(autoPanId)
 


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Prevent drag-click handler when multi selection is active
- Cleanup drag-click condition to only be valid when a node has not been moved

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] #1606 
