### PR TITLE
fix(core): set `isPressed` to `true` on `blur` and `contextmenu` events if permant keypress is enabled

### DIFF
--- a/.changeset/lovely-hairs-push.md
+++ b/.changeset/lovely-hairs-push.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Set `isPressed` to `true` if permanent keypress is enabled

--- a/packages/core/src/composables/useKeyPress.ts
+++ b/packages/core/src/composables/useKeyPress.ts
@@ -146,7 +146,7 @@ export function useKeyPress(keyFilter: MaybeRefOrGetter<KeyFilter | boolean | nu
 
     pressedKeys.clear()
 
-    isPressed.value = false
+    isPressed.value = toValue(keyFilter) === true
   }
 
   function createKeyFilterFn(keyFilter: KeyFilter | boolean | null) {


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- set `isPressed` to `true` on `blur` and `contextmenu` events if permant keypress is enabled

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] #1648