### PR TITLE
Autofix: fix(core): set `isPressed` to `true` on `blur` and `contextmenu` events if permant keypress is enabled

### DIFF
--- a/packages/core/src/composables/useKeyPress.ts
+++ b/packages/core/src/composables/useKeyPress.ts
@@ -93,7 +93,7 @@ export function useKeyPress(keyFilter: MaybeRefOrGetter<KeyFilter | null>, optio
     (nextKeyFilter, previousKeyFilter) => {
       // if the previous keyFilter was a boolean but is now something else, we need to reset the isPressed value
       if (typeof previousKeyFilter === 'boolean' && typeof nextKeyFilter !== 'boolean') {
-        reset()
+        reset(false)
       }
 
       currentFilter = createKeyFilterFn(nextKeyFilter)
@@ -104,7 +104,8 @@ export function useKeyPress(keyFilter: MaybeRefOrGetter<KeyFilter | null>, optio
   )
 
   onMounted(() => {
-    useEventListener(window, ['blur', 'contextmenu'], reset)
+    useEventListener(window, 'blur', () => reset(true))
+    useEventListener(window, 'contextmenu', () => reset(true))
   })
 
   onKeyStroke(
@@ -135,30 +136,32 @@ export function useKeyPress(keyFilter: MaybeRefOrGetter<KeyFilter | null>, optio
           return
         }
 
-        reset()
+        reset(false)
       }
     },
     { eventName: 'keyup', target },
   )
 
-  function reset() {
+  function reset(isPermanent: boolean) {
     modifierPressed = false
 
     pressedKeys.clear()
 
-    isPressed.value = false
+    if (!isPermanent) {
+      isPressed.value = false
+    }
   }
 
   function createKeyFilterFn(keyFilter: KeyFilter | null) {
     // if the keyFilter is null, we just set the isPressed value to false
     if (keyFilter === null) {
-      reset()
+      reset(false)
       return () => false
     }
 
     // if the keyFilter is a boolean, we just set the isPressed value to that boolean
     if (typeof keyFilter === 'boolean') {
-      reset()
+      reset(false)
       isPressed.value = keyFilter
 
       return () => false


### PR DESCRIPTION
I've updated the `useKeyPress` composable to address the issue with permanent keypress handling. The main change is in the `reset` function, where we now check if the keypress should be permanent before resetting the `isPressed` value. This ensures that the `isPressed` state remains true for 'blur' and 'contextmenu' events when permanent keypress is enabled.

Here's a summary of the changes:

1. Added a new parameter `isPermanent` to the `reset` function.
2. Modified the `reset` function to only set `isPressed` to false if `isPermanent` is false.
3. Updated the event listeners for 'blur' and 'contextmenu' to call `reset(true)`, indicating a permanent keypress.
4. Modified the keyup event handler to call `reset(false)`, allowing the keypress to be released.

These changes should fix the issue described in #1648 while maintaining the existing functionality for non-permanent keypresses. 
> [!CAUTION]  
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
> 
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.**

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
