### PR TITLE
fix(frontend,core): prevent scrolling when using arrow keys to move nodes

### DIFF
--- a/.changeset/clever-eyes-leave.md
+++ b/.changeset/clever-eyes-leave.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Prevent page scroll when using arrow keys to move nodes.

--- a/packages/core/src/components/Nodes/NodeWrapper.ts
+++ b/packages/core/src/components/Nodes/NodeWrapper.ts
@@ -408,6 +408,9 @@ const NodeWrapper = defineComponent({
           nodeElement.value!,
         )
       } else if (isDraggable.value && node.selected && arrowKeyDiffs[event.key]) {
+        // prevent page scrolling
+        event.preventDefault()
+
         ariaLiveMessage.value = `Moved selected node ${event.key.replace('Arrow', '').toLowerCase()}. New position, x: ${~~node
           .position.x}, y: ${~~node.position.y}`
 


### PR DESCRIPTION
# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] #1697 