### PR TITLE
refactor(core): inherit attrs on edge path el in `BaseEdge`

### DIFF
--- a/.changeset/stale-radios-listen.md
+++ b/.changeset/stale-radios-listen.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Inherit attributes on main edge path element in BaseEdge component.

--- a/packages/core/src/components/Edges/BaseEdge.vue
+++ b/packages/core/src/components/Edges/BaseEdge.vue
@@ -3,7 +3,7 @@ import { ref, useAttrs } from 'vue'
 import type { BaseEdgeProps } from '../../types'
 import EdgeText from './EdgeText.vue'
 
-const { interactionWidth = 20, labelShowBg = true, ...props } = defineProps<BaseEdgeProps>()
+withDefaults(defineProps<BaseEdgeProps>(), { interactionWidth: 20 })
 
 const pathEl = ref<SVGPathElement | null>(null)
 
@@ -30,12 +30,11 @@ export default {
 
 <template>
   <path
+    v-bind="attrs"
     :id="id"
     ref="pathEl"
     :d="path"
-    :style="props.style"
     class="vue-flow__edge-path"
-    :class="attrs.class"
     :marker-end="markerEnd"
     :marker-start="markerStart"
   />

--- a/packages/core/src/types/edge.ts
+++ b/packages/core/src/types/edge.ts
@@ -201,7 +201,6 @@ export interface BaseEdgeProps extends EdgeLabelOptions {
   markerStart?: string
   markerEnd?: string
   interactionWidth?: number
-  style?: CSSProperties
 }
 
 export type BezierEdgeProps = EdgePositions &


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Inherit attributes on main edge path element in BaseEdge component

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] #1741 