### PR TITLE
fix(minimap): bind attrs to minimap node 

### DIFF
--- a/.changeset/tough-taxis-tan.md
+++ b/.changeset/tough-taxis-tan.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/minimap": patch
+---
+
+Bind attributes to minimap node elements.

--- a/packages/minimap/src/MiniMapNode.vue
+++ b/packages/minimap/src/MiniMapNode.vue
@@ -39,16 +39,22 @@ function onMouseLeave(event: MouseEvent) {
 export default {
   name: 'MiniMapNode',
   compatConfig: { MODE: 3 },
+  inheritAttrs: false,
 }
 </script>
 
 <template>
   <template v-if="!hidden && dimensions.width !== 0 && dimensions.height !== 0">
-    <component :is="miniMapSlots[`node-${props.type}`]" v-if="miniMapSlots[`node-${props.type}`]" v-bind="props" />
+    <component
+      :is="miniMapSlots[`node-${props.type}`]"
+      v-if="miniMapSlots[`node-${props.type}`]"
+      v-bind="{ ...props, ...$attrs }"
+    />
 
     <rect
       v-else
       :id="id"
+      v-bind="$attrs"
       class="vue-flow__minimap-node"
       :class="{ selected, dragging }"
       :x="position.x"


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- do not inherit attrs on minimap nodes
- bind attrs to minimap node elements

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] #1753 
