### PR TITLE
fix(core): support nopan with pan-on-scroll

### DIFF
--- a/.changeset/large-spies-joke.md
+++ b/.changeset/large-spies-joke.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+fix(core): support nopan with pan-on-scroll

--- a/packages/core/src/components/Edges/EdgeWrapper.ts
+++ b/packages/core/src/components/Edges/EdgeWrapper.ts
@@ -42,6 +42,7 @@ const EdgeWrapper = defineComponent({
       edgesUpdatable,
       edgesFocusable,
       hooks,
+      panOnDrag,
     } = useVueFlow()
 
     const edge = computed(() => findEdge(props.id)!)
@@ -183,9 +184,9 @@ const EdgeWrapper = defineComponent({
           'class': [
             'vue-flow__edge',
             `vue-flow__edge-${edgeCmp.value === false ? 'default' : edge.value.type || 'default'}`,
-            noPanClassName.value,
             edgeClass.value,
             {
+              [noPanClassName.value]: panOnDrag.value,
               updating: mouseOver.value,
               selected: edge.value.selected,
               animated: edge.value.animated,

--- a/packages/core/src/components/Nodes/NodeWrapper.ts
+++ b/packages/core/src/components/Nodes/NodeWrapper.ts
@@ -62,6 +62,7 @@ const NodeWrapper = defineComponent({
       nodesConnectable,
       nodesFocusable,
       hooks,
+      panOnDrag,
     } = useVueFlow()
 
     const nodeElement = ref<HTMLDivElement | null>(null)
@@ -266,7 +267,7 @@ const NodeWrapper = defineComponent({
             'vue-flow__node',
             `vue-flow__node-${nodeCmp.value === false ? 'default' : node.type || 'default'}`,
             {
-              [noPanClassName.value]: isDraggable.value,
+              [noPanClassName.value]: isDraggable.value && panOnDrag.value,
               dragging: dragging?.value,
               draggable: isDraggable.value,
               selected: node.selected,

--- a/packages/core/src/container/Viewport/Viewport.vue
+++ b/packages/core/src/container/Viewport/Viewport.vue
@@ -302,6 +302,10 @@ onMounted(() => {
               return
             }
 
+            if (isWrappedWithClass(event, noPanClassName.value)) {
+              return false
+            }
+
             // increase scroll speed in firefox
             // firefox: deltaMode === 1; chrome: deltaMode === 0
             const deltaNormalize = event.deltaMode === 1 ? 20 : 1


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- check for `nopan` container when panning on scroll
- only add `nopan` class to nodes & edges when `pan-on-drag` is truthy
