### PR TITLE
fix(core): add button to elements to ignore in useKeyPress

### DIFF
--- a/.changeset/lemon-terms-joke.md
+++ b/.changeset/lemon-terms-joke.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Prevent keypress events from being swallowed when a button element is focused.

--- a/packages/core/src/composables/useKeyPress.ts
+++ b/packages/core/src/composables/useKeyPress.ts
@@ -11,6 +11,8 @@ export interface UseKeyPressOptions {
   target?: MaybeRefOrGetter<EventTarget | null | undefined>
 }
 
+const inputTags = ['INPUT', 'SELECT', 'TEXTAREA', 'BUTTON']
+
 export function isInputDOMNode(event: KeyboardEvent): boolean {
   const target = (event.composedPath?.()?.[0] || event.target) as HTMLElement
 
@@ -19,7 +21,7 @@ export function isInputDOMNode(event: KeyboardEvent): boolean {
   const closest = typeof target?.closest === 'function' ? target.closest('.nokey') : null
 
   // when an input field is focused we don't want to trigger deletion or movement of nodes
-  return ['INPUT', 'SELECT', 'TEXTAREA'].includes(target?.nodeName) || hasAttribute || !!closest
+  return inputTags.includes(target?.nodeName) || hasAttribute || !!closest
 }
 
 // we want to be able to do a multi selection event if we are in an input field


### PR DESCRIPTION
Signed-off-by: braks <78412429+bcakmakoglu@users.noreply.github.com>

# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Prevent keypress events from being swallowed when btn element is focused

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] #1805 
