### PR TITLE
fix(EdgeLabelRenderer): provide correct zIndex

### DIFF
--- a/docs/examples/edges/EdgeWithButton.vue
+++ b/docs/examples/edges/EdgeWithButton.vue
@@ -57,9 +57,12 @@ export default {
   <BaseEdge :id="id" :style="style" :path="path[0]" :marker-end="markerEnd" />
 
   <!-- Use the `EdgeLabelRenderer` to escape the SVG world of edges and render your own custom label in a `<div>` ctx -->
-  <EdgeLabelRenderer>
+
+  <!-- Pass the `edge`'s ID to `EdgeLabelRenderer` and provide the correct `zIndex`. -->
+  <EdgeLabelRenderer v-slot="{ style: labelStyle }" :edge-id="id">
     <div
       :style="{
+        zIndex: labelStyle.zIndex,
         pointerEvents: 'all',
         position: 'absolute',
         transform: `translate(-50%, -50%) translate(${path[1]}px,${path[2]}px)`,

--- a/examples/vite/src/Edges/CustomEdge.vue
+++ b/examples/vite/src/Edges/CustomEdge.vue
@@ -32,9 +32,10 @@ export default {
 <template>
   <path :id="id" :style="style" class="vue-flow__edge-path" :d="path[0]" :marker-end="markerEnd" />
 
-  <EdgeLabelRenderer>
+  <EdgeLabelRenderer v-slot="{ style: labelStyle }" :edge-id="id">
     <div
       :style="{
+        zIndex: labelStyle.zIndex,
         pointerEvents: 'all',
         position: 'absolute',
         transform: `translate(-50%, -50%) translate(${path[1]}px,${path[2]}px)`,

--- a/examples/vite/src/Nesting/Nesting.vue
+++ b/examples/vite/src/Nesting/Nesting.vue
@@ -3,6 +3,7 @@ import { ConnectionMode, VueFlow, useVueFlow } from '@vue-flow/core'
 import { Background } from '@vue-flow/background'
 import { Controls } from '@vue-flow/controls'
 import { MiniMap } from '@vue-flow/minimap'
+import CustomEdge from '../Edges/CustomEdge.vue'
 
 const { onConnect, addEdges, addNodes, findNode } = useVueFlow({
   fitViewOnInit: true,
@@ -69,7 +70,7 @@ const { onConnect, addEdges, addNodes, findNode } = useVueFlow({
     { id: 'e3-4b', source: '3', target: '4b' },
     { id: 'e4a-4b1', source: '4a', target: '4b1' },
     { id: 'e4a-4b2', source: '4a', target: '4b2' },
-    { id: 'e4b1-4b2', source: '4b1', target: '4b2' },
+    { id: 'e4b1-4b2', source: '4b1', target: '4b2', type: 'custom' },
   ],
 })
 
@@ -100,6 +101,9 @@ onMounted(() => {
 
 <template>
   <VueFlow>
+    <template #edge-custom="props">
+      <CustomEdge v-bind="props" />
+    </template>
     <MiniMap />
     <Controls />
     <Background />

--- a/packages/core/src/components/Edges/EdgeLabelRenderer.vue
+++ b/packages/core/src/components/Edges/EdgeLabelRenderer.vue
@@ -1,11 +1,18 @@
 <script lang="ts" setup>
-import { toRef } from 'vue'
+import { computed, toRef } from 'vue'
 import type { TeleportProps } from 'vue'
 import { useVueFlow } from '../../composables'
+import { getEdgeZIndex } from '../../utils'
 
-const { viewportRef } = useVueFlow()
+const props = defineProps<{
+  edgeId?: string
+}>()
+const { viewportRef, findNode, elevateEdgesOnSelect, findEdge } = useVueFlow()
 
 const teleportTarget = toRef(() => viewportRef.value?.getElementsByClassName('vue-flow__edge-labels')[0] as TeleportProps['to'])
+
+const edge = computed(() => findEdge(props.edgeId))
+const z = computed(() => (edge.value ? getEdgeZIndex(edge.value, findNode, elevateEdgesOnSelect.value) : undefined))
 </script>
 
 <script lang="ts">
@@ -19,7 +26,7 @@ export default {
   <svg>
     <foreignObject height="0" width="0">
       <Teleport :to="teleportTarget" :disabled="!teleportTarget">
-        <slot />
+        <slot :style="{ zIndex: z }" />
       </Teleport>
     </foreignObject>
   </svg>


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->
When we use ```EdgeLabelRenderer``` to render labels, in the case of nested nodes, the elements will be obscured by the nodes. I think we should maintain the same hierarchy as Edge.

- ```EdgeLabelRenderer```: get correct zIndex from Edge, provide it for  EdgeLabelRenderer
- doc:  ```EdgeWithButton```, add relevant examples and explanations
- vite example-Nesting:  add relevant examples 
