### PR TITLE
fix(core): allow multiselect when input is focused

### DIFF
--- a/.changeset/blue-frogs-swim.md
+++ b/.changeset/blue-frogs-swim.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Allow multi-select when input is focused.


### PR DESCRIPTION
Signed-off-by: braks <78412429+bcakmakoglu@users.noreply.github.com>

# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Set default for `actInsideInputWithModifier` to `true`
	- Allow multi select when input is focused
