### PR TITLE
feat(core): add dom attributes option for nodes

### DIFF
--- a/packages/core/src/components/Nodes/NodeWrapper.ts
+++ b/packages/core/src/components/Nodes/NodeWrapper.ts
@@ -61,6 +61,7 @@ const NodeWrapper = defineComponent({
       elementsSelectable,
       nodesConnectable,
       nodesFocusable,
+      nodesAttrs,
       hooks,
     } = useVueFlow()
 
@@ -286,6 +287,8 @@ const NodeWrapper = defineComponent({
           'role': isFocusable.value ? 'button' : undefined,
           'aria-describedby': disableKeyboardA11y.value ? undefined : `${ARIA_NODE_DESC_KEY}-${vueFlowId}`,
           'aria-label': node.ariaLabel,
+          ...nodesAttrs?.value,
+          ...node.attrs,
           'onMouseenter': onMouseEnter,
           'onMousemove': onMouseMove,
           'onMouseleave': onMouseLeave,

--- a/packages/core/src/store/state.ts
+++ b/packages/core/src/store/state.ts
@@ -114,6 +114,8 @@ export function useState(): State {
 
     disableKeyboardA11y: false,
     ariaLiveMessage: '',
+
+    nodesAttrs: {},
   }
 }
 

--- a/packages/core/src/types/flow.ts
+++ b/packages/core/src/types/flow.ts
@@ -229,6 +229,8 @@ export interface FlowProps {
   autoPanOnConnect?: boolean
   autoPanOnNodeDrag?: boolean
   autoPanSpeed?: number
+
+  nodesAttrs?: Record<string, any>
 }
 
 /**

--- a/packages/core/src/types/node.ts
+++ b/packages/core/src/types/node.ts
@@ -109,6 +109,7 @@ export interface Node<Data = ElementData, CustomEvents extends Record<string, Cu
   events?: Partial<NodeEventsHandler<CustomEvents>>
   zIndex?: number
   ariaLabel?: string
+  attrs?: Record<string, any>
 }
 
 export interface GraphNode<


### PR DESCRIPTION
# 🚀 What's changed?

Added the possibility to customize HTML attributes of `.vue-flow__node` elements, globally through the nodesAttributes prop, and for each single node.

# 🐛 Fixes

None

# 🪴 To-Dos

None

# Motivation

For my use case, I need greater flexibility in customizing ARIA attributes — for example, being able to explicitly set a `role` or provide additional `aria-*` properties.

Currently, `role="button"` is set automatically when focusable is true and omitted otherwise, with no way to override this behavior. While `aria-label` can be configured, this alone is often not sufficient for proper accessibility. Other attributes, such as aria-describedby, are managed internally and cannot be customized externally, which limits the ability to implement more advanced accessibility patterns.

According to [WAI-ARIA](https://www.w3.org/TR/wai-aria/) specifications, for example, aria-describedby may include multiple ID references — something that is currently not supported via the API.

This PR is intended as a starting point for discussion, and I’m open to feedback on how to make this more flexible while fitting within the existing design.