### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/src/guide/getting-started.md
+++ b/docs/src/guide/getting-started.md
@@ -436,7 +436,7 @@ const props = defineProps<EdgeProps>()
 const path = computed(() => getBezierPath(props))
 </script>
 
-<script>
+<script lang="ts">
 export default {
   inheritAttrs: false,
 }


### PR DESCRIPTION
In the example `SpecialEdge.vue`  file (TS), we missed the TypeScript language descriptor in the second script section.

# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Change 1 The example now compiles (npm run build)
- ...

# 🐛 Fixes
<!--- Tell us what issues this pr fixes -->

- [x] The second script segment in the SpecialEdge.vue example file was missing a language designator. 

# 🪴 To-Dos
<!--- Tell us if there are To-Dos left -->

- [ ] To-Do 1 As of right now, the demo still doesn't render any nodes for me. But probably that's on me. 