### PR TITLE
fix(core): Zoom and Pan keys prevent entering space on input while shift is pressed

### DIFF
--- a/packages/core/src/container/Viewport/Viewport.vue
+++ b/packages/core/src/container/Viewport/Viewport.vue
@@ -60,11 +60,11 @@ let prevTransform: ViewportTransform = {
   zoom: 0,
 }
 
-const panKeyPressed = useKeyPress(panActivationKeyCode)
+const panKeyPressed = useKeyPress(panActivationKeyCode, { actInsideInputWithModifier: false })
 
 const selectionKeyPressed = useKeyPress(selectionKeyCode)
 
-const zoomKeyPressed = useKeyPress(zoomActivationKeyCode)
+const zoomKeyPressed = useKeyPress(zoomActivationKeyCode, { actInsideInputWithModifier: false })
 
 const shouldPanOnDrag = toRef(
   () =>


### PR DESCRIPTION
# 🚀 What's changed?

Zooming and Panning mode can no longer be entered via shortcut while an input is currently focused on the page.

Co-authored by [@MiloradFilipovic](https://github.com/stars/MiloradFilipovic)

# 🐛 Fixes

- [x] [🐛 [BUG]: Space keydown events on text input elements swallowed by zoom and pan shortcut #1999](https://github.com/bcakmakoglu/vue-flow/issues/1999)


# 🪴 To-Dos
- [ ] Add tests?
