### PR TITLE
feat(core): add option to use edge component for updates (previously ConnectionLine)

### DIFF
--- a/docs/examples/update-edge/App.vue
+++ b/docs/examples/update-edge/App.vue
@@ -2,7 +2,8 @@
 import { ref } from 'vue'
 import { Background } from '@vue-flow/background'
 import { VueFlow, useVueFlow } from '@vue-flow/core'
-
+import CustomEdge from './CustomEdge.vue'
+import CustomNode from './CustomNode.vue'
 const { updateEdge, addEdges } = useVueFlow()
 
 const nodes = ref([
@@ -14,6 +15,7 @@ const nodes = ref([
   },
   {
     id: '2',
+    type: 'custom',
     data: { label: 'Node <strong>B</strong>' },
     position: { x: 100, y: 100 },
   },
@@ -49,11 +51,20 @@ function onConnect(params) {
     :nodes="nodes"
     :edges="edges"
     fit-view-on-init
+    :nodes-connectable="true"
+    :keepEdgeTypeDuringUpdate="true"
     @edge-update="onEdgeUpdate"
     @connect="onConnect"
     @edge-update-start="onEdgeUpdateStart"
     @edge-update-end="onEdgeUpdateEnd"
   >
     <Background />
+
+    <template #edge-custom="customEdgeProps">
+      <CustomEdge v-bind="customEdgeProps" />
+    </template>
+    <template #node-custom="customNodeProps">
+      <CustomNode v-bind="customNodeProps" />
+    </template>
   </VueFlow>
 </template>

--- a/docs/examples/update-edge/CustomEdge.vue
+++ b/docs/examples/update-edge/CustomEdge.vue
@@ -1,0 +1,77 @@
+<script setup>
+import { BaseEdge, getBezierPath } from '@vue-flow/core'
+import { computed } from 'vue'
+
+const props = defineProps({
+  id: {
+    type: String,
+    required: true,
+  },
+  sourceX: {
+    type: Number,
+    required: true,
+  },
+  sourceY: {
+    type: Number,
+    required: true,
+  },
+  targetX: {
+    type: Number,
+    required: true,
+  },
+  targetY: {
+    type: Number,
+    required: true,
+  },
+  sourcePosition: {
+    type: String,
+    required: true,
+  },
+  targetPosition: {
+    type: String,
+    required: true,
+  },
+  data: {
+    type: Object,
+    required: false,
+  },
+  markerEnd: {
+    type: String,
+    required: false,
+  },
+  style: {
+    type: Object,
+    required: false,
+  },
+  animate: {
+    type: Boolean,
+    required: false,
+  },
+})
+
+const path = computed(() => getBezierPath(props))
+</script>
+
+<script>
+export default {
+  inheritAttrs: false,
+}
+</script>
+
+<template>
+  <BaseEdge
+    :id="id"
+    :style="{...style,stroke: 'red'}"
+    :path="path[0]"
+    :marker-end="markerEnd"
+    :label="data.text"
+    :label-x="path[1]"
+    :label-y="path[2]"
+    :label-style="{ fill: 'white' }"
+    :label-show-bg="true"
+    :label-bg-style="{ fill: 'red' }"
+    :label-bg-padding="[2, 4]"
+    :label-bg-border-radius="2"
+    :animate="animate"
+  />
+</template>

--- a/docs/examples/update-edge/CustomNode.vue
+++ b/docs/examples/update-edge/CustomNode.vue
@@ -1,0 +1,24 @@
+<script setup>
+import { Position, Handle } from '@vue-flow/core'
+
+// props were passed from the slot using `v-bind="customNodeProps"`
+const props = defineProps(['label'])
+</script>
+
+<template>
+  <div class="custom-node">
+    <Handle type="target" :position="Position.Top" />
+    <div>{{ props.data.label }}</div>
+    <Handle type="source" :position="Position.Bottom" connectionEdgeType="custom" />
+  </div>
+</template>
+
+<style scoped>
+.custom-node {
+  width: 150px;
+  height: 100px;
+  background-color: rgb(187, 230, 230);
+  border-radius: 5px;
+  border: 1px solid #222138;
+}
+</style>

--- a/docs/src/examples/edges/updatable-edge.md
+++ b/docs/src/examples/edges/updatable-edge.md
@@ -7,7 +7,7 @@ Update an edge by simply dragging it from one node to another at the edge-anchor
 You can enable updating edges either globally by passing the `edgesUpdatable` prop or you can enable it
 for specific edges by using the `updatable` attribute.
 
-
+Specify the `connectionEdgeType` prop on handles to define which edge type to use when creating connections from that Handle.
 <div class="mt-6">
   <ClientOnly>
     <Suspense>

--- a/docs/src/guide/handle.md
+++ b/docs/src/guide/handle.md
@@ -115,6 +115,41 @@ For example, you can set the `top` and `bottom` properties to position the handl
 <Handle id="source-b" type="source" :position="Position.Right" style="bottom: 10px; top: auto;" />
 ```
 
+## Specifying Edge Type for Connections
+
+You can specify which edge type should be used when creating connections from a handle by setting the `connectionEdgeType` prop.
+
+When a connection is created from a handle with `connectionEdgeType` specified, the resulting connection object will include a `type` field. 
+This allows `addEdges()` to automatically create edges with the specified type.
+
+```vue
+<script setup>
+import { Handle, Position } from '@vue-flow/core'
+</script>
+
+<template>
+  <!-- Connections from this handle will create 'smoothstep' edges -->
+  <Handle 
+    type="source" 
+    connectionEdgeType="custom"
+    :position="Position.Right" 
+  />
+</template>
+```
+
+```vue
+<script setup>
+import { ref } from 'vue'
+import { VueFlow, useVueFlow } from '@vue-flow/core'
+
+const { addEdges } = useVueFlow()
+
+// When onConnect is called, the connection will include type: 'custom'
+// addEdges will create an edge with this type
+onConnect(addEdges)
+</script>
+```
+
 ## Hidden Handles
 
 In some cases you might not want to display a handle at all. You can hide a handle by setting `opacity: 0` as the styles for that handle.

--- a/docs/src/guide/vue-flow/config.md
+++ b/docs/src/guide/vue-flow/config.md
@@ -771,6 +771,45 @@ const edges = ref([
 
   The radius at which an edge-updater can be triggered.
 
+### keep-edge-type-during-update (optional)
+
+- Type: `boolean`
+
+- Default: `false`
+
+- Details:
+
+  When updating an existing or new connection, the component displayed during the update is the corresponding Edge component, not the ConnectionLine.
+  
+  Works in conjunction with the `connectionEdgeType` prop on handles to show custom edge types during connection creation via interaction with Handle.
+
+- Example:
+
+```vue
+<script setup>
+import { ref } from 'vue'
+import { VueFlow } from '@vue-flow/core'
+
+const keepEdgeTypeDuringUpdate = ref(true)
+
+const nodes = ref([
+  { id: '1', position: { x: 250, y: 5 } },
+  { id: '2', position: { x: 100, y: 100 } },
+])
+
+const edges = ref([
+  { id: 'e1->2', source: '1', target: '2', updatable: true },
+])
+</script>
+<template>
+  <VueFlow 
+    :nodes="nodes" 
+    :edges="edges" 
+    :keep-edge-type-during-update="keepEdgeTypeDuringUpdate" 
+  />
+</template>
+```
+
 ### connect-on-click (optional)
 
 - Type: `boolean`

--- a/examples/vite/src/UpdatableEdge/CustomEdge.vue
+++ b/examples/vite/src/UpdatableEdge/CustomEdge.vue
@@ -1,0 +1,77 @@
+<script setup>
+import { BaseEdge, getBezierPath } from '@vue-flow/core'
+import { computed } from 'vue'
+
+const props = defineProps({
+  id: {
+    type: String,
+    required: true,
+  },
+  sourceX: {
+    type: Number,
+    required: true,
+  },
+  sourceY: {
+    type: Number,
+    required: true,
+  },
+  targetX: {
+    type: Number,
+    required: true,
+  },
+  targetY: {
+    type: Number,
+    required: true,
+  },
+  sourcePosition: {
+    type: String,
+    required: true,
+  },
+  targetPosition: {
+    type: String,
+    required: true,
+  },
+  data: {
+    type: Object,
+    required: false,
+  },
+  markerEnd: {
+    type: String,
+    required: false,
+  },
+  style: {
+    type: Object,
+    required: false,
+  },
+  animate: {
+    type: Boolean,
+    required: false,
+  },
+})
+
+const path = computed(() => getBezierPath(props))
+</script>
+
+<script>
+export default {
+  inheritAttrs: false,
+}
+</script>
+
+<template>
+  <BaseEdge
+    :id="id"
+    :style="{...style,stroke: 'red'}"
+    :path="path[0]"
+    :marker-end="markerEnd"
+    :label="data.text"
+    :label-x="path[1]"
+    :label-y="path[2]"
+    :label-style="{ fill: 'white' }"
+    :label-show-bg="true"
+    :label-bg-style="{ fill: 'red' }"
+    :label-bg-padding="[2, 4]"
+    :label-bg-border-radius="2"
+    :animate="animate"
+  />
+</template>

--- a/examples/vite/src/UpdatableEdge/CustomNode.vue
+++ b/examples/vite/src/UpdatableEdge/CustomNode.vue
@@ -1,0 +1,25 @@
+<script setup>
+import { Position, Handle } from '@vue-flow/core'
+
+// props were passed from the slot using `v-bind="customNodeProps"`
+const props = defineProps(['data'])
+</script>
+
+<template>
+  <div class="custom-node">
+    <Handle type="target" :position="Position.Top" />
+    <div>{{ props.data.label }}</div>
+    <Handle type="source" :position="Position.Bottom" connectionEdgeType="custom" />
+  </div>
+</template>
+
+<style scoped>
+.custom-node {
+  width: 150px;
+  height: 100px;
+  background-color: rgb(52, 52, 52);
+  border-radius: 5px;
+  border: 1px solid #222138;
+  color: white;
+}
+</style>

--- a/examples/vite/src/UpdatableEdge/UpdatableEdgeExample.vue
+++ b/examples/vite/src/UpdatableEdge/UpdatableEdgeExample.vue
@@ -48,7 +48,6 @@ function onEdgeUpdateEnd({ edge }: FlowEvents['edgeUpdateEnd']) {
 }
 
 function onEdgeUpdate({ edge, connection }: FlowEvents['edgeUpdate']) {
-  console.log('updating edge', edge, connection)
   return updateEdge(edge, connection)
 }
 </script>

--- a/examples/vite/src/UpdatableEdge/UpdatableEdgeExample.vue
+++ b/examples/vite/src/UpdatableEdge/UpdatableEdgeExample.vue
@@ -1,6 +1,10 @@
 <script lang="ts" setup>
+import { ref } from 'vue'
 import type { Elements, FlowEvents, VueFlowStore } from '@vue-flow/core'
+import { Background } from '@vue-flow/background'
 import { ConnectionMode, VueFlow, useVueFlow } from '@vue-flow/core'
+import CustomEdge from './CustomEdge.vue'
+import CustomNode from './CustomNode.vue'
 import { Controls } from '@vue-flow/controls'
 
 import '@vue-flow/controls/dist/style.css'
@@ -9,24 +13,25 @@ const initialElements: Elements = [
   {
     id: '1',
     type: 'input',
-    label: 'Node <strong>A</strong>',
+    data: { label: 'Node <strong>A</strong>' },
     position: { x: 250, y: 0 },
   },
   {
     id: '2',
-    label: 'Node <strong>B</strong>',
+    type: 'custom',
+    data: { label: 'Node <strong>B</strong>' },
     position: { x: 100, y: 100 },
   },
   {
     id: '3',
-    label: 'Node <strong>C</strong>',
+    data: { label: 'Node <strong>C</strong>' },
     position: { x: 400, y: 100 },
     style: { background: '#D6D5E6', color: '#333', border: '1px solid #222138', width: 180 },
   },
-  { id: 'e1-2', source: '1', target: '2', label: 'Updatable target', updatable: 'target' },
+  { id: 'e1-2', source: '1', target: '2', label: 'Updatable target', updatable: 'target',type: 'custom' },
 ]
 
-const { updateEdge } = useVueFlow()
+const { updateEdge, addEdges } = useVueFlow()
 
 const elements = ref(initialElements)
 
@@ -43,6 +48,7 @@ function onEdgeUpdateEnd({ edge }: FlowEvents['edgeUpdateEnd']) {
 }
 
 function onEdgeUpdate({ edge, connection }: FlowEvents['edgeUpdate']) {
+  console.log('updating edge', edge, connection)
   return updateEdge(edge, connection)
 }
 </script>
@@ -51,12 +57,22 @@ function onEdgeUpdate({ edge, connection }: FlowEvents['edgeUpdate']) {
   <VueFlow
     v-model="elements"
     :snap-to-grid="true"
-    :connection-mode="ConnectionMode.Loose"
+    fit-view-on-init
+    :nodes-connectable="true"
+    :keepEdgeTypeDuringUpdate="true"
     @pane-ready="onLoad"
     @edge-update="onEdgeUpdate"
     @edge-update-start="onEdgeUpdateStart"
     @edge-update-end="onEdgeUpdateEnd"
+    @connect="addEdges"
   >
     <Controls />
+
+    <template #edge-custom="customEdgeProps">
+      <CustomEdge v-bind="customEdgeProps" />
+    </template>
+    <template #node-custom="customNodeProps">
+      <CustomNode v-bind="customNodeProps" />
+    </template>
   </VueFlow>
 </template>

--- a/packages/core/src/components/ConnectionEdge/index.ts
+++ b/packages/core/src/components/ConnectionEdge/index.ts
@@ -11,16 +11,18 @@ const ConnectionEdge = defineComponent({
   compatConfig: { MODE: 3 },
   setup() {
     const {
-      id: vueFlowId,
+      id:VueFlowId,
       connectionMode,
       connectionStartHandle,
       connectionEndHandle,
       connectionPosition,
+      connectionLineOptions,
       connectionStatus,
-      updateExistingEdge,
       viewport,
       findNode,
+      connectionEdgeType,
       getEdgeTypes,
+      connectionExistingEdge
     } = useVueFlow()
 
     const slots = inject(Slots)
@@ -36,14 +38,19 @@ const ConnectionEdge = defineComponent({
         y: (connectionPosition.value.y - viewport.value.y) / viewport.value.zoom,
       }
     })
-    
 
+    const markerStart = computed(() =>
+      connectionLineOptions.value.markerStart ? `url(#${getMarkerId(connectionLineOptions.value.markerStart, VueFlowId)})` : '',
+    )
 
+    const markerEnd = computed(() =>
+      connectionLineOptions.value.markerEnd ? `url(#${getMarkerId(connectionLineOptions.value.markerEnd, VueFlowId)})` : '',
+    )
 
     return () => {
-
-      if(updateExistingEdge.value){
-        return null;
+      // Hide ConnectionEdge when updating edge type is not kept
+      if(connectionExistingEdge.value) {
+        return null
       }
 
       if (!fromNode.value || !connectionStartHandle.value) {
@@ -91,7 +98,7 @@ const ConnectionEdge = defineComponent({
       const toPosition = connectionEndHandle.value?.position ?? (fromPosition ? oppositePosition[fromPosition] : undefined)
 
       // Get the edge component for the specified type
-      const edgeTypeName = 'default'
+      const edgeTypeName = toValue(connectionEdgeType) || 'default'
       const slot = slots?.[`edge-${edgeTypeName}`]
       
       let edgeComponent: EdgeComponent | false = false
@@ -153,9 +160,12 @@ const ConnectionEdge = defineComponent({
             sourceY: fromY,
             targetX: toXY.value.x,
             targetY: toXY.value.y,
-            
             sourceHandle: fromHandle,
             targetHandle: toHandle,
+            markerStart: markerStart.value,
+            markerEnd: markerEnd.value,
+            style: { pointerEvents: 'none' },
+            data: {},
           }),
         ),
       )

--- a/packages/core/src/components/ConnectionEdge/index.ts
+++ b/packages/core/src/components/ConnectionEdge/index.ts
@@ -1,0 +1,166 @@
+import { computed, defineComponent, getCurrentInstance, h, inject, resolveComponent, toValue } from 'vue'
+import type { EdgeComponent, HandleElement } from '../../types'
+import { ConnectionMode, Position } from '../../types'
+import { getHandlePosition, getMarkerId, oppositePosition } from '../../utils'
+import { useVueFlow } from '../../composables'
+import { Slots } from '../../context'
+import { getBezierPath } from '../Edges/utils'
+
+const ConnectionEdge = defineComponent({
+  name: 'ConnectionEdge',
+  compatConfig: { MODE: 3 },
+  setup() {
+    const {
+      id: vueFlowId,
+      connectionMode,
+      connectionStartHandle,
+      connectionEndHandle,
+      connectionPosition,
+      connectionStatus,
+      updateExistingEdge,
+      viewport,
+      findNode,
+      getEdgeTypes,
+    } = useVueFlow()
+
+    const slots = inject(Slots)
+    const instance = getCurrentInstance()
+
+    const fromNode = computed(() => findNode(connectionStartHandle.value?.nodeId))
+
+    const toNode = computed(() => findNode(connectionEndHandle.value?.nodeId) ?? null)
+
+    const toXY = computed(() => {
+      return {
+        x: (connectionPosition.value.x - viewport.value.x) / viewport.value.zoom,
+        y: (connectionPosition.value.y - viewport.value.y) / viewport.value.zoom,
+      }
+    })
+    
+
+
+
+    return () => {
+
+      if(updateExistingEdge.value){
+        return null;
+      }
+
+      if (!fromNode.value || !connectionStartHandle.value) {
+        return null
+      }
+
+      const startHandleId = connectionStartHandle.value.id
+
+      const handleType = connectionStartHandle.value.type
+
+      const fromHandleBounds = fromNode.value.handleBounds
+      let handleBounds = fromHandleBounds?.[handleType] ?? []
+
+      if (connectionMode.value === ConnectionMode.Loose) {
+        const oppositeBounds = fromHandleBounds?.[handleType === 'source' ? 'target' : 'source'] ?? []
+        handleBounds = [...handleBounds, ...oppositeBounds]
+      }
+
+      if (!handleBounds || handleBounds.length === 0) {
+        return null
+      }
+
+      const fromHandle = (startHandleId ? handleBounds.find((d) => d.id === startHandleId) : handleBounds[0]) ?? null
+      const fromPosition = fromHandle?.position ?? Position.Top
+      const { x: fromX, y: fromY } = getHandlePosition(fromNode.value, fromHandle, fromPosition)
+
+      let toHandle: HandleElement | null = null
+
+      // When snapped to a handle
+      if (toNode.value && connectionEndHandle.value) {
+        // if connection mode is strict, we only look for handles of the opposite type
+        if (connectionMode.value === ConnectionMode.Strict) {
+          toHandle =
+            toNode.value.handleBounds[handleType === 'source' ? 'target' : 'source']?.find(
+              (d) => d.id === connectionEndHandle.value?.id,
+            ) || null
+        } else {
+          toHandle =
+            [...(toNode.value.handleBounds.source ?? []), ...(toNode.value.handleBounds.target ?? [])]?.find(
+              (d) => d.id === connectionEndHandle.value?.id,
+            ) || null
+        }
+      }
+
+      const toPosition = connectionEndHandle.value?.position ?? (fromPosition ? oppositePosition[fromPosition] : undefined)
+
+      // Get the edge component for the specified type
+      const edgeTypeName = 'default'
+      const slot = slots?.[`edge-${edgeTypeName}`]
+      
+      let edgeComponent: EdgeComponent | false = false
+      
+      if (slot) {
+        edgeComponent = slot
+      } else {
+        let edgeType = getEdgeTypes.value[edgeTypeName]
+
+        if (typeof edgeType === 'string') {
+          if (instance) {
+            const components = Object.keys(instance.appContext.components)
+            if (components && components.includes(edgeTypeName)) {
+              edgeType = resolveComponent(edgeTypeName, false) as EdgeComponent
+            }
+          }
+        }
+
+        if (edgeType && typeof edgeType !== 'string') {
+          edgeComponent = edgeType
+        } else {
+          // Fallback to default edge type
+          edgeComponent = getEdgeTypes.value.default
+        }
+      }
+
+      if (!edgeComponent) {
+        return null
+      }
+
+      // Calculate default path for positioning
+      const [dAttr] = getBezierPath({
+        sourceX: fromX,
+        sourceY: fromY,
+        sourcePosition: fromPosition,
+        targetX: toXY.value.x,
+        targetY: toXY.value.y,
+        targetPosition: toPosition,
+      })
+
+
+
+      return h(
+        'svg',
+        { class: 'vue-flow__edges vue-flow__connectionedge vue-flow__container' },
+        h(
+          'g',
+          { class: ['vue-flow__edge', 'vue-flow__edge-preview', connectionStatus.value] },
+          h(edgeComponent as any, {
+            id: '__connection-edge-preview__',
+            sourceNode: fromNode.value,
+            targetNode: toNode.value ?? null,
+            source: fromNode.value.id,
+            target: toNode.value?.id ?? '',
+            type: edgeTypeName,
+            sourcePosition: fromPosition,
+            targetPosition: toPosition,
+            sourceX: fromX,
+            sourceY: fromY,
+            targetX: toXY.value.x,
+            targetY: toXY.value.y,
+            
+            sourceHandle: fromHandle,
+            targetHandle: toHandle,
+          }),
+        ),
+      )
+    }
+  },
+})
+
+export default ConnectionEdge

--- a/packages/core/src/components/Edges/EdgeWrapper.ts
+++ b/packages/core/src/components/Edges/EdgeWrapper.ts
@@ -45,6 +45,7 @@ const EdgeWrapper = defineComponent({
       hooks,
       viewport,
       connectionPosition,
+      keepEdgeTypeDuringUpdate
     } = useVueFlow()
 
     const edge = computed(() => findEdge(props.id)!)
@@ -118,6 +119,7 @@ const EdgeWrapper = defineComponent({
       onEdgeUpdate,
       onEdgeUpdateEnd,
       edgeId: props.id,
+      connectionEdgeType: toRef(() => edge.value.type) || null,
     })
 
     return () => {
@@ -178,7 +180,7 @@ const EdgeWrapper = defineComponent({
       let targetY = handleTargetY
 
       // When updating this edge, use connection position for the appropriate end
-      if (updating.value && connectionPosition.value && !Number.isNaN(connectionPosition.value.x) && !Number.isNaN(connectionPosition.value.y)) {
+      if (keepEdgeTypeDuringUpdate?.value && updating.value && connectionPosition.value && !Number.isNaN(connectionPosition.value.x) && !Number.isNaN(connectionPosition.value.y)) {
         const dynamicPos = pointToRendererPoint(connectionPosition.value,viewport.value)
 
         // If updating the source(edgeUpdaterType == target), override source coordinates
@@ -233,6 +235,8 @@ const EdgeWrapper = defineComponent({
           'onKeyDown': isFocusable.value ? onKeyDown : undefined,
         },
         [
+          !keepEdgeTypeDuringUpdate?.value && updating.value
+          ? null :
           h(edgeCmp.value === false ? getEdgeTypes.value.default : (edgeCmp.value as any), {
               id: props.id,
               sourceNode,
@@ -266,7 +270,7 @@ const EdgeWrapper = defineComponent({
               ...pathOptions,
             }),
           [
-            isUpdatable.value === 'source' || isUpdatable.value === true
+            (!updating.value && isUpdatable.value === 'source' || isUpdatable.value === true)
               ? [
                   h(
                     'g',
@@ -286,7 +290,7 @@ const EdgeWrapper = defineComponent({
                   ),
                 ]
               : null,
-            isUpdatable.value === 'target' || isUpdatable.value === true
+            (!updating.value && isUpdatable.value === 'target' || isUpdatable.value === true)
               ? [
                   h(
                     'g',

--- a/packages/core/src/components/Handle/Handle.vue
+++ b/packages/core/src/components/Handle/Handle.vue
@@ -11,6 +11,7 @@ const {
   connectableStart = true,
   connectableEnd = true,
   id: handleId = null,
+  connectionEdgeType = null,
   ...props
 } = defineProps<HandleProps>()
 
@@ -59,6 +60,7 @@ const { handlePointerDown, handleClick } = useHandle({
   handleId,
   isValidConnection,
   type,
+  connectionEdgeType
 })
 
 const isConnectable = computed(() => {

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -1,6 +1,7 @@
 export * from './Nodes'
 export * from './Edges'
 export { default as ConnectionLine } from './ConnectionLine'
+export { default as ConnectionEdge } from './ConnectionEdge'
 export { default as Handle } from './Handle/Handle.vue'
 export { default as NodesSelection } from './NodesSelection/NodesSelection.vue'
 export { default as UserSelection } from './UserSelection/UserSelection.vue'

--- a/packages/core/src/composables/useHandle.ts
+++ b/packages/core/src/composables/useHandle.ts
@@ -29,8 +29,8 @@ export interface UseHandleProps {
   edgeUpdaterType?: MaybeRefOrGetter<HandleType>
   onEdgeUpdate?: (event: MouseTouchEvent, connection: Connection) => void
   onEdgeUpdateEnd?: (event: MouseTouchEvent) => void
-  edgeTypeOnCreate?: string | MaybeRefOrGetter<string | null>
-  edgeId: string
+  edgeId?: string | null
+  connectionEdgeType?: string | MaybeRefOrGetter<string | null> | null
 }
 
 function alwaysValid() {
@@ -53,6 +53,7 @@ export function useHandle({
   onEdgeUpdate,
   onEdgeUpdateEnd,
   edgeId,
+  connectionEdgeType
 }: UseHandleProps) {
   const {
     id: flowId,
@@ -174,7 +175,8 @@ export function useHandle({
           y: y - containerBounds.top,
         },
         false,
-        !!edgeId
+        !!edgeId,
+        toValue(connectionEdgeType)
       )
 
       emits.connectStart({ event, nodeId: toValue(nodeId), handleId: toValue(handleId), handleType })
@@ -291,10 +293,14 @@ export function useHandle({
         }
 
         if ((closestHandle || handleDomNode) && connection && isValid) {
+          
+          // Add connectionEdgeType to connection if specified
+          const connectionWithType = toValue(connectionEdgeType) ? { ...connection, type: toValue(connectionEdgeType) } : connection
+
           if (!onEdgeUpdate) {
-            emits.connect(connection)
+            emits.connect(connectionWithType)
           } else {
-            onEdgeUpdate(event, connection)
+            onEdgeUpdate(event, connectionWithType)
           }
         }
 
@@ -349,7 +355,8 @@ export function useHandle({
         },
         undefined,
         true,
-        !!edgeId
+        !!edgeId,
+        toValue(connectionEdgeType)
       )
 
       return
@@ -398,7 +405,9 @@ export function useHandle({
     const isOwnHandle = result.connection?.source === result.connection?.target
 
     if (result.isValid && result.connection && !isOwnHandle) {
-      emits.connect(result.connection)
+      // Add connectionEdgeType to connection if specified
+      const connectionWithType = toValue(connectionEdgeType)? { ...result.connection, type: toValue(connectionEdgeType) }: result.connection
+      emits.connect(connectionWithType)
     }
 
     emits.clickConnectEnd(event)

--- a/packages/core/src/composables/useHandle.ts
+++ b/packages/core/src/composables/useHandle.ts
@@ -29,6 +29,8 @@ export interface UseHandleProps {
   edgeUpdaterType?: MaybeRefOrGetter<HandleType>
   onEdgeUpdate?: (event: MouseTouchEvent, connection: Connection) => void
   onEdgeUpdateEnd?: (event: MouseTouchEvent) => void
+  edgeTypeOnCreate?: string | MaybeRefOrGetter<string | null>
+  edgeId: string
 }
 
 function alwaysValid() {
@@ -50,6 +52,7 @@ export function useHandle({
   edgeUpdaterType,
   onEdgeUpdate,
   onEdgeUpdateEnd,
+  edgeId,
 }: UseHandleProps) {
   const {
     id: flowId,
@@ -72,6 +75,7 @@ export function useHandle({
     nodes,
     isValidConnection: isValidConnectionProp,
     nodeLookup,
+    getEdgeTypes,
   } = useVueFlow()
 
   let connection: Connection | null = null
@@ -169,6 +173,8 @@ export function useHandle({
           x: x - containerBounds.left,
           y: y - containerBounds.top,
         },
+        false,
+        !!edgeId
       )
 
       emits.connectStart({ event, nodeId: toValue(nodeId), handleId: toValue(handleId), handleType })
@@ -332,7 +338,7 @@ export function useHandle({
 
     if (!connectionClickStartHandle.value) {
       emits.clickConnectStart({ event, nodeId: toValue(nodeId), handleId: toValue(handleId) })
-
+      
       startConnection(
         {
           nodeId: toValue(nodeId),
@@ -343,6 +349,7 @@ export function useHandle({
         },
         undefined,
         true,
+        !!edgeId
       )
 
       return

--- a/packages/core/src/container/EdgeRenderer/EdgeRenderer.vue
+++ b/packages/core/src/container/EdgeRenderer/EdgeRenderer.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import EdgeWrapper from '../../components/Edges/EdgeWrapper'
 import ConnectionLine from '../../components/ConnectionLine'
+import ConnectionEdge from '../../components/ConnectionEdge'
 import { useVueFlow } from '../../composables'
 import { getEdgeZIndex } from '../../utils'
 import MarkerDefinitions from './MarkerDefinitions.vue'
@@ -27,5 +28,6 @@ export default {
     <EdgeWrapper :id="edge.id" />
   </svg>
 
+  <ConnectionEdge />
   <ConnectionLine />
 </template>

--- a/packages/core/src/container/EdgeRenderer/EdgeRenderer.vue
+++ b/packages/core/src/container/EdgeRenderer/EdgeRenderer.vue
@@ -7,7 +7,6 @@ import { getEdgeZIndex } from '../../utils'
 import MarkerDefinitions from './MarkerDefinitions.vue'
 
 const { findNode, getEdges, elevateEdgesOnSelect, keepEdgeTypeDuringUpdate } = useVueFlow()
-console.log('keepEdgeTypeDuringUpdate in EdgeRenderer:', keepEdgeTypeDuringUpdate)
 </script>
 
 <script lang="ts">

--- a/packages/core/src/container/EdgeRenderer/EdgeRenderer.vue
+++ b/packages/core/src/container/EdgeRenderer/EdgeRenderer.vue
@@ -6,7 +6,8 @@ import { useVueFlow } from '../../composables'
 import { getEdgeZIndex } from '../../utils'
 import MarkerDefinitions from './MarkerDefinitions.vue'
 
-const { findNode, getEdges, elevateEdgesOnSelect } = useVueFlow()
+const { findNode, getEdges, elevateEdgesOnSelect, keepEdgeTypeDuringUpdate } = useVueFlow()
+console.log('keepEdgeTypeDuringUpdate in EdgeRenderer:', keepEdgeTypeDuringUpdate)
 </script>
 
 <script lang="ts">
@@ -28,6 +29,6 @@ export default {
     <EdgeWrapper :id="edge.id" />
   </svg>
 
-  <ConnectionEdge />
-  <ConnectionLine />
+  <ConnectionEdge v-if="keepEdgeTypeDuringUpdate" />
+  <ConnectionLine v-else />
 </template>

--- a/packages/core/src/container/VueFlow/VueFlow.vue
+++ b/packages/core/src/container/VueFlow/VueFlow.vue
@@ -46,6 +46,7 @@ const props = withDefaults(defineProps<FlowProps>(), {
   multiSelectionKeyCode: undefined,
   panActivationKeyCode: undefined,
   zoomActivationKeyCode: undefined,
+  keepEdgeTypeDuringUpdate: undefined,
 })
 
 const emit = defineEmits<FlowEmits>()

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -595,13 +595,14 @@ export function useActions(state: State, nodeLookup: ComputedRef<NodeLookup>, ed
     node.data = options.replace ? nextData : { ...node.data, ...nextData }
   }
 
-  const startConnection: Actions['startConnection'] = (startHandle, position, isClick = false, updateExistingEdge = false) => {
+  const startConnection: Actions['startConnection'] = (startHandle, position, isClick = false, connectionExistingEdge = false, connectionEdgeType = null) => {
     if (isClick) {
       state.connectionClickStartHandle = startHandle
     } else {
       state.connectionStartHandle = startHandle
     }
-    state.updateExistingEdge = updateExistingEdge
+    state.connectionExistingEdge = connectionExistingEdge
+    state.connectionEdgeType = connectionEdgeType
 
     state.connectionEndHandle = null
     state.connectionStatus = null
@@ -622,7 +623,7 @@ export function useActions(state: State, nodeLookup: ComputedRef<NodeLookup>, ed
     state.connectionPosition = { x: Number.NaN, y: Number.NaN }
     state.connectionEndHandle = null
     state.connectionStatus = null
-    state.edgeTypeOnCreate = null
+    state.connectionEdgeType = null
 
     if (isClick) {
       state.connectionClickStartHandle = null

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -595,16 +595,16 @@ export function useActions(state: State, nodeLookup: ComputedRef<NodeLookup>, ed
     node.data = options.replace ? nextData : { ...node.data, ...nextData }
   }
 
-  const startConnection: Actions['startConnection'] = (startHandle, position, isClick = false) => {
+  const startConnection: Actions['startConnection'] = (startHandle, position, isClick = false, updateExistingEdge = false) => {
     if (isClick) {
       state.connectionClickStartHandle = startHandle
     } else {
       state.connectionStartHandle = startHandle
     }
+    state.updateExistingEdge = updateExistingEdge
 
     state.connectionEndHandle = null
     state.connectionStatus = null
-
     if (position) {
       state.connectionPosition = position
     }
@@ -622,6 +622,7 @@ export function useActions(state: State, nodeLookup: ComputedRef<NodeLookup>, ed
     state.connectionPosition = { x: Number.NaN, y: Number.NaN }
     state.connectionEndHandle = null
     state.connectionStatus = null
+    state.edgeTypeOnCreate = null
 
     if (isClick) {
       state.connectionClickStartHandle = null

--- a/packages/core/src/store/state.ts
+++ b/packages/core/src/store/state.ts
@@ -74,6 +74,7 @@ export function useState(): State {
     connectOnClick: true,
     connectionStatus: null,
     isValidConnection: null,
+    updateExistingEdge: null,
 
     snapGrid: [15, 15],
     snapToGrid: false,

--- a/packages/core/src/store/state.ts
+++ b/packages/core/src/store/state.ts
@@ -74,7 +74,9 @@ export function useState(): State {
     connectOnClick: true,
     connectionStatus: null,
     isValidConnection: null,
-    updateExistingEdge: null,
+    connectionExistingEdge: null,
+    connectionEdgeType: null,
+    keepEdgeTypeDuringUpdate: false,
 
     snapGrid: [15, 15],
     snapToGrid: false,

--- a/packages/core/src/types/connection.ts
+++ b/packages/core/src/types/connection.ts
@@ -31,6 +31,8 @@ export interface Connection {
   sourceHandle?: string | null
   /** Target handle id */
   targetHandle?: string | null
+  /** Edge type for the connection (used when creating edges from connections) */
+  type?: string | null
 }
 
 /**

--- a/packages/core/src/types/flow.ts
+++ b/packages/core/src/types/flow.ts
@@ -200,6 +200,8 @@ export interface FlowProps {
   preventScrolling?: boolean
   selectionMode?: SelectionMode
   edgeUpdaterRadius?: number
+  /** renders custom edge type during update instead of ConnectionLine */
+  keepEdgeTypeDuringUpdate?: boolean
   /** will be renamed to `fitView` */
   fitViewOnInit?: boolean
   /** allow connection with click handlers, i.e. support touch devices */

--- a/packages/core/src/types/handle.ts
+++ b/packages/core/src/types/handle.ts
@@ -3,7 +3,7 @@ import type { Connection, ConnectionMode } from './connection'
 import type { GraphEdge } from './edge'
 import type { GraphNode } from './node'
 import type { NodeLookup } from './store'
-
+import type { MaybeRefOrGetter } from 'vue'
 export type HandleType = 'source' | 'target'
 
 export interface HandleElement extends XYPosition, Dimensions {
@@ -52,6 +52,8 @@ export interface HandleProps {
   position?: Position
   /** A valid connection func {@link ValidConnectionFunc} */
   isValidConnection?: ValidConnectionFunc
+  /** Edge type to create when connecting from this handle */
+  connectionEdgeType?: string | MaybeRefOrGetter<string | null> 
   /** Enable/disable connecting to handle altogether */
   connectable?: HandleConnectable
   /** Can this handle be used to *start* a connection */

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -102,6 +102,7 @@ export interface State extends Omit<FlowProps, 'id' | 'modelValue'> {
   connectionRadius: number
   connectionStatus: ConnectionStatus | null
   isValidConnection: ValidConnectionFunc | null
+  updateExistingEdge: boolean | null
 
   connectOnClick: boolean
   edgeUpdaterRadius: number
@@ -302,7 +303,7 @@ export interface Actions extends Omit<ViewportHelper, 'viewportInitialized'> {
   /** force update node internal data, if handle bounds are incorrect, you might want to use this */
   updateNodeInternals: UpdateNodeInternals
   /** start a connection */
-  startConnection: (startHandle: ConnectingHandle, position?: XYPosition, isClick?: boolean) => void
+  startConnection: (startHandle: ConnectingHandle, position?: XYPosition, isClick?: boolean, updateExistingEdge?: boolean | null) => void
   /** update connection position */
   updateConnection: (position: XYPosition, result?: ConnectingHandle | null, status?: ConnectionStatus | null) => void
   /** end (or cancel) a connection */

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -1,4 +1,4 @@
-import type { CSSProperties, ComputedRef, ToRefs } from 'vue'
+import type { CSSProperties, ComputedRef, MaybeRefOrGetter, ToRefs } from 'vue'
 import type { KeyFilter } from '@vueuse/core'
 import type { ViewportHelper } from '../composables'
 import type {
@@ -102,7 +102,8 @@ export interface State extends Omit<FlowProps, 'id' | 'modelValue'> {
   connectionRadius: number
   connectionStatus: ConnectionStatus | null
   isValidConnection: ValidConnectionFunc | null
-  updateExistingEdge: boolean | null
+  connectionExistingEdge: boolean | null
+  connectionEdgeType: string | null
 
   connectOnClick: boolean
   edgeUpdaterRadius: number
@@ -303,7 +304,7 @@ export interface Actions extends Omit<ViewportHelper, 'viewportInitialized'> {
   /** force update node internal data, if handle bounds are incorrect, you might want to use this */
   updateNodeInternals: UpdateNodeInternals
   /** start a connection */
-  startConnection: (startHandle: ConnectingHandle, position?: XYPosition, isClick?: boolean, updateExistingEdge?: boolean | null) => void
+  startConnection: (startHandle: ConnectingHandle, position?: XYPosition, isClick?: boolean, connectionExistingEdge?: boolean | null, connectionEdgeType?: string | null) => void
   /** update connection position */
   updateConnection: (position: XYPosition, result?: ConnectingHandle | null, status?: ConnectionStatus | null) => void
   /** end (or cancel) a connection */


### PR DESCRIPTION
## 🚀 What’s Changed

### 1. Edge updates now support `EdgeComponent`
When updating an edge, it’s now possible to use the `EdgeComponent` instead of the `ConnectionLine` component.

**Before**  
https://github.com/user-attachments/assets/913e02a5-86c3-43d7-beb3-a16dc6b8843f  

**After**  
https://github.com/user-attachments/assets/a7ba29ea-c118-4652-930c-b04ffee542f4  

---

### 2. Create new edges from handles with a custom edge type
Handles can now define the edge type used during creation via the `connectionEdgeType` prop.

```vue
<Handle
  type="source"
  :position="Position.Bottom"
  connectionEdgeType="custom"
/>
```
Before
https://github.com/user-attachments/assets/b44a7d42-3440-448e-9a7f-1f4dd325c107

keepEdgeTypeDuringUpdate = false
https://github.com/user-attachments/assets/9851c80e-0378-4be6-aead-8de80a406306

keepEdgeTypeDuringUpdate = true
https://github.com/user-attachments/assets/4803f96d-3be4-4abd-9425-abc6c7289b69

### 3. New keepEdgeTypeDuringUpdate option

A new keepEdgeTypeDuringUpdate option has been added to VueFlow.

Default: false (backwards-compatible)

When false, the ConnectionLine component is used for edge updates and new connections (same behavior as before).

When true, the existing edge type is preserved during updates.

```vue
<VueFlow :keepEdgeTypeDuringUpdate="true" />
```
## 🪴 To-Dos

Update CHANGELOG.md with feature notes for connection-edge support.

## 📝 Notes

This is only my second PR, so feedback and guidance are very welcome.
