### PR TITLE
fix(docs): correct parameters for edge event handlers

### DIFF
--- a/docs/src/guide/edge.md
+++ b/docs/src/guide/edge.md
@@ -861,16 +861,16 @@ const edges = ref([
 ])
   
 // bind listeners to the event handlers
-onEdgeClick((event, edge) => {
-  console.log('edge clicked', edge)
+onEdgeClick((event) => {
+  console.log('edge clicked', event)
 })
 
-onEdgeDoubleClick((event, edge) => {
-  console.log('edge double clicked', edge)
+onEdgeDoubleClick((event) => {
+  console.log('edge double clicked', event)
 })
 
-onEdgeContextMenu((event, edge) => {
-  console.log('edge context menu', edge)
+onEdgeContextMenu((event) => {
+  console.log('edge context menu', event)
 })
   
 // ... and so on  


### PR DESCRIPTION
### Description
Fix incorrect parameter definitions for edge event handlers in the documentation.

### Issue
The documentation currently shows handlers like:

```js
onEdgeClick((event, edge) => {})
```
However, according to the source code, the handler only receives a single `event` parameter. The edge is included in the emitted payload instead.

### Actual Behavior (from source code)
```ts
function onEdgeClick(event: MouseEvent) {
  const data = { event, edge: edge.value }
  emit.click(data)
}
```

### Changes
Updated the documentation to reflect the correct function signature.

### Notes
Let me know if any further adjustments are needed.
I can update other related handlers if needed.