### PR TITLE
docs: add note for VS Code extension webviews

### DIFF
--- a/docs/src/guide/troubleshooting.md
+++ b/docs/src/guide/troubleshooting.md
@@ -6,6 +6,12 @@ title: Troubleshooting
 
 This section aims to help you understand, avoid, and fix errors that may occur when using Vue Flow.
 
+## VS Code Webviews
+
+There may be issues with node panning and dragging when using Vue Flow in a VS Code extension webview environment.
+
+As a workaround, you can implement any broken functionality directly. See [this issue](https://github.com/bcakmakoglu/vue-flow/issues/1986) for more details.
+
 ## Errors and Fixes
 
 Vue Flow can emit several error types to help diagnose and resolve issues.


### PR DESCRIPTION
# :notebook: Documentation

This PR adds a note in `Guide > Troubleshooting` regarding how Vue Flow may not function correctly in a VS Code extension webview environment.

I've had it link to #1986 instead of documenting the workaround directly in that section, as the workaround felt quite specific to put inside of documentation.

It'll save anyone a bit of time if they ended up having the same issue as I did  :grin: 
