### PR TITLE
refactor(core)!: remove long-deprecated getNode/getEdge, FlowExportObject.position/zoom, GraphEdge.events

### DIFF
--- a/.changeset/remove-clean-deprecations.md
+++ b/.changeset/remove-clean-deprecations.md
@@ -1,0 +1,9 @@
+---
+"@vue-flow/core": major
+---
+
+Remove long-deprecated APIs (2.0). Each has a drop-in replacement:
+
+- **`getNode` / `getEdge` getters removed** — use `findNode(id)` / `findEdge(id)` from `useVueFlow()` (same return value; they accept `string | undefined | null`).
+- **`FlowExportObject.position` / `FlowExportObject.zoom` removed** — `toObject()` no longer emits them; use `FlowExportObject.viewport` (`{ x, y, zoom }`) instead.
+- **`GraphEdge.events` removed** — this legacy per-edge handler bag was vestigial (never read); edge events are emitted through the store (`useVueFlow().onEdgeClick`, etc.).

--- a/examples/vite/src/SaveRestore/Controls.vue
+++ b/examples/vite/src/SaveRestore/Controls.vue
@@ -24,13 +24,13 @@ function onRestore() {
   const flow = state.value
 
   if (flow) {
-    const [x = 0, y = 0] = flow.position
+    const { x = 0, y = 0, zoom = 0 } = flow.viewport
 
     setNodes(flow.nodes)
 
     setEdges(flow.edges)
 
-    setViewport({ x, y, zoom: flow.zoom || 0 })
+    setViewport({ x, y, zoom })
   }
 }
 

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -218,7 +218,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
       return
     }
 
-    // The public contract: `findNode`/`getNode` return the user-facing `Node` (the exact object held in
+    // The public contract: `findNode` returns the user-facing `Node` (the exact object held in
     // `state.nodes`/v-model), which the store keeps on the InternalNode as `internals.userNode`. Enriched
     // data (internals/measured) is reached via `getInternalNode`. Typed `DeepReadonly` (zero runtime) so
     // mutating the result is a compile error → use the helpers (updateNode/applyNodeChanges/setNodes).
@@ -226,7 +226,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
   }
 
   // The enriched-node accessor (xyflow/react parity): returns the lookup `InternalNode` (enriched
-  // `internals`/`measured`), whereas `findNode`/`getNode` return the user-facing `Node` (`internals.userNode`).
+  // `internals`/`measured`), whereas `findNode` returns the user-facing `Node` (`internals.userNode`).
   // Internal call sites that need `internals`/`measured` use this.
   const getInternalNode: Actions<NodeType>['getInternalNode'] = (id) => {
     if (!id) {
@@ -917,7 +917,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
     }
 
     for (const edge of state.edges) {
-      const { selected: _, sourceNode: __, targetNode: ___, events: ____, ...rest } = edge
+      const { selected: _, sourceNode: __, targetNode: ___, ...rest } = edge
 
       edges.push(rest)
     }
@@ -927,8 +927,6 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
       JSON.stringify({
         nodes,
         edges,
-        position: [state.viewport.x, state.viewport.y],
-        zoom: state.viewport.zoom,
         viewport: state.viewport,
       } as FlowExportObject),
     )

--- a/packages/core/src/store/createStore.ts
+++ b/packages/core/src/store/createStore.ts
@@ -106,7 +106,7 @@ export function createVueFlowStore<NodeType extends Node = Node, EdgeType extend
   >
   const edgeLookup = reactive(new Map<string, GraphEdge<EdgeType>>()) as EdgeLookup<EdgeType>
 
-  const getters = useGetters<NodeType, EdgeType>(reactiveState, nodeLookup, edgeLookup)
+  const getters = useGetters<NodeType, EdgeType>(reactiveState, nodeLookup)
 
   const actions = useActions<NodeType, EdgeType>(reactiveState, nodeLookup, parentLookup, edgeLookup)
 

--- a/packages/core/src/store/getters.ts
+++ b/packages/core/src/store/getters.ts
@@ -1,26 +1,13 @@
 import { computed } from 'vue'
 import type { DeepReadonly } from 'vue'
 import { getNodesInside, isEdgeVisible } from '@xyflow/system'
-import type { ComputedGetters, Edge, EdgeLookup, GraphEdge, Node, NodeLookup, State } from '../types'
+import type { ComputedGetters, Edge, GraphEdge, Node, NodeLookup, State } from '../types'
 import { defaultEdgeTypes, defaultNodeTypes } from '../utils/defaultNodesEdges'
 
 export function useGetters<NodeType extends Node = Node, EdgeType extends Edge = Edge>(
   state: State<NodeType, EdgeType>,
   nodeLookup: NodeLookup<NodeType>,
-  edgeLookup: EdgeLookup<EdgeType>,
 ): ComputedGetters<NodeType, EdgeType> {
-  /**
-   * @deprecated will be removed in next major version; use findNode instead
-   */
-  const getNode: ComputedGetters<NodeType>['getNode'] = computed(
-    () => (id) => nodeLookup.get(id)?.internals.userNode as DeepReadonly<NodeType> | undefined,
-  )
-
-  /**
-   * @deprecated will be removed in next major version; use findEdge instead
-   */
-  const getEdge: ComputedGetters<NodeType, EdgeType>['getEdge'] = computed(() => (id) => edgeLookup.get(id))
-
   const getEdgeTypes: ComputedGetters<NodeType, EdgeType>['getEdgeTypes'] = computed(() => {
     const edgeTypes: Record<string, any> = {
       ...defaultEdgeTypes,
@@ -120,8 +107,6 @@ export function useGetters<NodeType extends Node = Node, EdgeType extends Edge =
   })
 
   return {
-    getNode,
-    getEdge,
     getEdgeTypes,
     getNodeTypes,
     getEdges,

--- a/packages/core/src/types/edge.ts
+++ b/packages/core/src/types/edge.ts
@@ -3,7 +3,6 @@ import type { CSSProperties, Component, SVGAttributes, VNode } from 'vue'
 import type { ElementData, Position, Styles } from './flow'
 import type { GraphNode } from './node'
 import type { EdgeComponent, EdgeTextProps } from './components'
-import type { EdgeEventsHandler } from './hooks'
 
 /** Edge markers */
 export enum MarkerType {
@@ -145,8 +144,6 @@ export type GraphEdge<EdgeType extends Edge = Edge> = EdgeType & {
   selected: boolean
   sourceNode: GraphNode
   targetNode: GraphNode
-  /** @deprecated will be removed in the next major version */
-  events: Partial<EdgeEventsHandler>
 } & EdgePositions
 
 /**

--- a/packages/core/src/types/flow.ts
+++ b/packages/core/src/types/flow.ts
@@ -83,16 +83,6 @@ export interface FlowExportObject {
   nodes: Node[]
   /** exported edges */
   edges: Edge[]
-  /**
-   * exported viewport position
-   * @deprecated use {@link FlowExportObject.viewport} instead
-   */
-  position: [x: number, y: number]
-  /**
-   * exported zoom level
-   * @deprecated use {@link FlowExportObject.viewport} instead
-   */
-  zoom: number
   /** exported viewport (position + zoom) */
   viewport: Viewport
 }

--- a/packages/core/src/types/node.ts
+++ b/packages/core/src/types/node.ts
@@ -100,7 +100,7 @@ export type GraphNode<NodeType extends Node = Node> = InternalNodeBase<NodeType>
  * The enriched, store-internal node — what `nodeLookup`/`getInternalNode(id)`/`useInternalNode(id)` return.
  * Carries the user `Node` (`internals.userNode`) plus the store-computed `internals.{positionAbsolute, z,
  * handleBounds}` and authoritative `measured`. Alias of {@link GraphNode}; named to mirror xyflow/react's
- * `InternalNode` so the public split (`getNode`/`v-model` = user `Node`, `getInternalNode` = `InternalNode`)
+ * `InternalNode` so the public split (`findNode`/`v-model` = user `Node`, `getInternalNode` = `InternalNode`)
  * reads the same across frameworks.
  */
 export type InternalNode<NodeType extends Node = Node> = GraphNode<NodeType>

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -201,7 +201,7 @@ export type FindNode<NodeType extends Node = Node> = (id: string | undefined | n
 /**
  * Returns the enriched {@link InternalNode} (`internals.{positionAbsolute, z, handleBounds, userNode}` +
  * authoritative `measured`) for an id, mirroring xyflow/react's `getInternalNode`. This is the accessor
- * for store-computed data; `findNode`/`getNode` expose the user-facing node.
+ * for store-computed data; `findNode` exposes the user-facing node.
  */
 export type GetInternalNode<NodeType extends Node = Node> = (id: string | undefined | null) => GraphNode<NodeType> | undefined
 
@@ -327,16 +327,6 @@ export interface Getters<NodeType extends Node = Node, EdgeType extends Edge = E
   // pointing users at the helpers (updateNode/updateNodeData/applyNodeChanges/setNodes); see #40.
   /** all visible edges */
   getEdges: GraphEdge<EdgeType>[]
-  /**
-   * returns a node by id
-   * @deprecated use {@link Actions.findNode} instead
-   */
-  getNode: (id: string) => DeepReadonly<NodeType> | undefined
-  /**
-   * returns an edge by id
-   * @deprecated use {@link Actions.findEdge} instead
-   */
-  getEdge: (id: string) => GraphEdge<EdgeType> | undefined
   /** returns all currently selected nodes (user-facing `Node`s) */
   getSelectedNodes: DeepReadonly<NodeType[]>
   /** returns all currently selected edges */


### PR DESCRIPTION
## What

2.0 cleanup of deprecated public APIs that each have a drop-in replacement. Scoped via an audit of all 19 `@deprecated` tags; this PR is the **clean / zero-internal-consumer** subset.

| Removed | Replacement |
|---|---|
| `getNode` / `getEdge` getters | `findNode(id)` / `findEdge(id)` (same return value; accept `string \| undefined \| null`) |
| `FlowExportObject.position` / `.zoom` | `FlowExportObject.viewport` (`{ x, y, zoom }`); `toObject()` stops emitting the old fields |
| `GraphEdge.events` | store event hooks (`onEdgeClick`, …) — the per-edge handler bag was vestigial (never read) |

Also: dropped the now-unused `edgeLookup` param from `useGetters` (+ its call site), pruned the unused `EdgeEventsHandler` import, and refreshed stale doc comments referencing `getNode`.

## Migration

- Migrated the only hand-written consumer: `examples/vite/src/SaveRestore/Controls.vue` (`flow.position`/`flow.zoom` → `flow.viewport`).
- No other hand-written usage of the removed APIs in examples/docs/tests.

## Held back (intentionally)

The standalone `applyChanges` / `applyNodeChanges` / `applyEdgeChanges` exports are **kept** — they have the exact `@xyflow/react`/`@xyflow/svelte` signature (`(changes, nodes) => result`) and are part of the public xyflow surface (plan Decision E: the pure util stays). `applyDefault` likewise stays (it gates the kept auto-apply-changes feature; revisited with the deferred middleware redesign).

## Verification

- `vue-tsc` ✓ · `eslint` 0 errors ✓ · declaration build ✓ · rolldown build ✓
- cypress component suite **120/120** ✓
- changeset: **major**

🤖 Generated with [Claude Code](https://claude.com/claude-code)