### PR TITLE
fix(core): v-model loop, child-drag offset, updateEdge connection lookup

### DIFF
--- a/packages/core/src/composables/useWatchProps.ts
+++ b/packages/core/src/composables/useWatchProps.ts
@@ -1,5 +1,5 @@
 import type { Ref, ToRefs } from 'vue'
-import { effectScope, isRef, toRef, watch } from 'vue'
+import { effectScope, isRef, toRaw, toRef, watch } from 'vue'
 import type { Connection, Edge, FlowProps, Node, VueFlowStore } from '../types'
 import { isDef } from '../utils'
 
@@ -39,13 +39,19 @@ function syncModelArray<ModelItem, StoreItem>(
 
   watch(
     [model, () => model.value?.length],
-    () => {
-      const next = model.value
-      if (!Array.isArray(next) || next === lastSnapshot) {
+    ([next]) => {
+      if (!Array.isArray(next)) {
         return
       }
 
-      setItems(next)
+      // compare raw identities: a deep model `ref` hands our own snapshot back as its reactive proxy,
+      // which would fail a plain `===` and loop snapshot → setItems → snapshot forever
+      const nextRaw = toRaw(next)
+      if (nextRaw === lastSnapshot) {
+        return
+      }
+
+      setItems(nextRaw)
     },
     { immediate: true },
   )

--- a/packages/core/src/env.d.ts
+++ b/packages/core/src/env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="vite/client" />
-/// <reference types="vue/macros-global" />
 
 declare module '*.vue' {
   import type { DefineComponent } from 'vue'

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -262,16 +262,9 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
       }
 
       if (changed) {
+        // drag items already carry the parent-RELATIVE position: XYDrag's `calculateNodePosition` and the
+        // keyboard path's `calcNextPosition` both subtract the parent offset before handing items here.
         change.position = node.position
-
-        if (node.parentId) {
-          const parentNode = getInternalNode(node.parentId)
-
-          change.position = {
-            x: change.position.x - (parentNode?.internals.positionAbsolute?.x ?? 0),
-            y: change.position.y - (parentNode?.internals.positionAbsolute?.y ?? 0),
-          }
-        }
 
         if (expandParentId) {
           // pin the child's relative position to >= 0; the parent grows to contain it instead

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -673,7 +673,9 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
 
       commitEdges(state.edges.map((edge, index) => (index === prevEdgeIndex ? validEdge : edge)))
 
-      updateConnectionLookup(state.connectionLookup, edgeLookup, [validEdge])
+      // rebuild from ALL edges — `updateConnectionLookup` clears the lookup before repopulating, so
+      // passing only the updated edge would drop every other edge's connections
+      updateConnectionLookup(state.connectionLookup, edgeLookup, state.edges)
 
       return validEdge
     }

--- a/packages/core/src/store/createStore.ts
+++ b/packages/core/src/store/createStore.ts
@@ -1,5 +1,5 @@
 import type { Ref } from 'vue'
-import { reactive, ref, toRefs, watch } from 'vue'
+import { reactive, shallowRef, toRaw, toRefs, watch } from 'vue'
 import type { Edge, EdgeLookup, FlowProps, GraphEdge, GraphNode, Node, NodeLookup, VueFlowStore } from '../types'
 import { useActions } from './actions'
 import { useGetters } from './getters'
@@ -32,10 +32,13 @@ export function createVueFlowStore<NodeType extends Node = Node, EdgeType extend
 ): VueFlowStore<NodeType, EdgeType> {
   // nodes/edges are backed by (optionally injected) signal refs — the single source of truth. When
   // `<VueFlow>` passes its v-model refs, mutating the store *is* the v-model update (svelte's
-  // bindable-prop proxy), so no separate sync layer is needed. Default: internal `ref`s (deep-reactive,
-  // matching the previous `reactive(state).nodes` behaviour).
-  const nodesSignal = signals?.nodes ?? ref<NodeType[]>([])
-  const edgesSignal = signals?.edges ?? ref<GraphEdge<EdgeType>[]>([])
+  // bindable-prop proxy), so no separate sync layer is needed. Default: internal `shallowRef`s — the
+  // arrays are only ever reassigned whole (immutable commits), and `shallowRef` keeps the fallback's
+  // type at `Ref<NodeType[]>` exactly (a deep `ref` would unwrap to `Ref<UnwrapRefSimple<NodeType>[]>`,
+  // which TS can't reconcile with the injected signal's type over an unresolved generic). The explicit
+  // `| undefined` reflects an injected-but-unbound `defineModel` ref.
+  const nodesSignal: Ref<NodeType[] | undefined> = signals?.nodes ?? shallowRef([])
+  const edgesSignal: Ref<GraphEdge<EdgeType>[] | undefined> = signals?.edges ?? shallowRef([])
 
   // The array references the store itself last wrote (through the `state.nodes`/`.edges` setters below).
   // The single-source binding watch (further down) uses these to tell its own writes apart from an
@@ -56,7 +59,7 @@ export function createVueFlowStore<NodeType extends Node = Node, EdgeType extend
   Object.defineProperty(state, 'nodes', {
     get: () => nodesSignal.value ?? emptyNodes,
     set: (value: NodeType[]) => {
-      lastWriteNodes = value
+      lastWriteNodes = toRaw(value)
       nodesSignal.value = value
     },
     enumerable: true,
@@ -65,7 +68,7 @@ export function createVueFlowStore<NodeType extends Node = Node, EdgeType extend
   Object.defineProperty(state, 'edges', {
     get: () => edgesSignal.value ?? emptyEdges,
     set: (value: GraphEdge<EdgeType>[]) => {
-      lastWriteEdges = value
+      lastWriteEdges = toRaw(value)
       edgesSignal.value = value
     },
     enumerable: true,
@@ -119,17 +122,21 @@ export function createVueFlowStore<NodeType extends Node = Node, EdgeType extend
   // user land) so the lookups rebuild. The store's own writes are recorded in `lastWriteNodes`; a user
   // reassignment writes the signal directly, bypassing the setter, so we re-adopt only then (mirrors
   // svelte-flow re-running `adoptUserNodes` via `$derived` on a reference change — no pause/resume).
+  // Identity must be compared on the RAW arrays: a parent binding the v-model to a deep `ref` hands our
+  // own write back as its reactive proxy, which would fail a plain `!==` and loop `setNodes` forever.
   if (signals?.nodes) {
-    watch(nodesSignal, () => {
-      if (nodesSignal.value && nodesSignal.value !== lastWriteNodes) {
-        actions.setNodes(nodesSignal.value as NodeType[])
+    watch(nodesSignal, (next) => {
+      const nextRaw = next && toRaw(next)
+      if (nextRaw && nextRaw !== lastWriteNodes) {
+        actions.setNodes(nextRaw)
       }
     })
   }
   if (signals?.edges) {
-    watch(edgesSignal, () => {
-      if (edgesSignal.value && edgesSignal.value !== lastWriteEdges) {
-        actions.setEdges(edgesSignal.value as unknown as EdgeType[])
+    watch(edgesSignal, (next) => {
+      const nextRaw = next && toRaw(next)
+      if (nextRaw && nextRaw !== lastWriteEdges) {
+        actions.setEdges(nextRaw as unknown as EdgeType[])
       }
     })
   }

--- a/tests/cypress/component/1-store/edges/updateEdge.cy.ts
+++ b/tests/cypress/component/1-store/edges/updateEdge.cy.ts
@@ -36,4 +36,27 @@ describe('Store Action: `updateEdge`', () => {
     expect(storedEdge.source).to.equal(nodes[0].id)
     expect(storedEdge.target).to.equal(nodes[1].id)
   })
+
+  // regression: `updateEdge` used to rebuild the connection lookup from ONLY the updated edge
+  // (`updateConnectionLookup` clears it first), erasing every other edge's connections
+  it('keeps other edges in the connection lookup', () => {
+    const edgeToUpdate = store.edges.value.find((edge) => edge.source === '2' && edge.target === '3')
+
+    if (!edgeToUpdate) {
+      throw new Error('Edge 2->3 not found in store')
+    }
+
+    store.updateEdge(edgeToUpdate, {
+      sourceHandle: null,
+      targetHandle: null,
+      source: '2',
+      target: '4',
+    })
+
+    const lookup = store.connectionLookup.value
+
+    expect(lookup.get('1-source')?.size, 'connections of untouched edge 1->2').to.equal(1)
+    expect(lookup.get('3-source')?.size, 'connections of untouched edge 3->4').to.equal(1)
+    expect(lookup.get('4-target')?.size, 'connections of node 4 after reconnect').to.equal(2)
+  })
 })

--- a/tests/cypress/component/1-store/nodes/updateNodePositions.cy.ts
+++ b/tests/cypress/component/1-store/nodes/updateNodePositions.cy.ts
@@ -1,0 +1,64 @@
+import type { VueFlowStore } from '@vue-flow/core'
+import { getStore } from '../../../support/component'
+
+/**
+ * Regression: drag items arrive with parent-RELATIVE positions (XYDrag's `calculateNodePosition` and the
+ * keyboard path's `calcNextPosition` both subtract the parent offset already). `updateNodePositions` used
+ * to subtract the parent's `positionAbsolute` a second time, so dragging a child of a parent that isn't
+ * at the origin landed at `position - parentAbsolute`.
+ */
+describe('Store Action: `updateNodePositions`', () => {
+  let store: VueFlowStore
+
+  beforeEach(() => {
+    cy.vueFlow({
+      nodes: [
+        {
+          id: 'parent',
+          type: 'default',
+          position: { x: 100, y: 100 },
+          data: { label: 'Parent' },
+          style: { width: '300px', height: '300px' },
+        },
+        {
+          id: 'child',
+          type: 'default',
+          parentId: 'parent',
+          position: { x: 20, y: 60 },
+          data: { label: 'Child' },
+        },
+      ],
+    })
+
+    cy.then(() => {
+      store = getStore()
+    })
+  })
+
+  it('keeps a child drag item parent-relative (no double parent-offset subtraction)', () => {
+    // the exact shape `useDrag` forwards from XYDrag: position is parent-relative,
+    // internals.positionAbsolute is the new absolute position
+    store.updateNodePositions(
+      [
+        {
+          id: 'child',
+          position: { x: 30, y: 70 },
+          distance: { x: 10, y: 10 },
+          measured: { width: 150, height: 36 },
+          internals: { positionAbsolute: { x: 130, y: 170 } },
+          parentId: 'parent',
+        },
+      ],
+      true,
+      true,
+    )
+
+    cy.tryAssertion(() => {
+      const child = store.findNode('child')
+      expect(child?.position).to.deep.equal({ x: 30, y: 70 })
+
+      const internalChild = store.getInternalNode('child')
+      expect(internalChild?.internals.positionAbsolute).to.deep.equal({ x: 130, y: 170 })
+    })
+  })
+})

--- a/tests/cypress/component/2-vue-flow/vmodel.cy.ts
+++ b/tests/cypress/component/2-vue-flow/vmodel.cy.ts
@@ -1,0 +1,68 @@
+import { defineComponent, h, ref } from 'vue'
+import type { Edge, Node } from '@vue-flow/core'
+import { VueFlow } from '@vue-flow/core'
+
+/**
+ * Regression: binding `v-model:nodes`/`v-model:edges` to plain (deep) `ref`s — the documented default —
+ * hands the store's own writes back as reactive proxies. The store's single-source identity guard must
+ * compare RAW identities, or every store write loops `setNodes` until Vue aborts the flush
+ * ("Maximum recursive updates exceeded"; unbounded in prod builds).
+ *
+ * `cy.vueFlow()` mounts with plain props (no `onUpdate:*`), which never binds the model — so this spec
+ * mounts a real parent component with both models wired up.
+ */
+describe('v-model backed by deep refs', () => {
+  it('does not loop store writes back through the model', () => {
+    let nodeUpdates = 0
+    let edgeUpdates = 0
+
+    const Wrapper = defineComponent({
+      setup() {
+        const nodes = ref<Node[]>([
+          { id: '1', type: 'default', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
+          { id: '2', type: 'default', position: { x: 200, y: 0 }, data: { label: 'Node 2' } },
+        ])
+
+        const edges = ref<Edge[]>([{ id: 'e1-2', source: '1', target: '2' }])
+
+        return () =>
+          h(VueFlow, {
+            id: 'vmodel-test',
+            style: { height: '100vh', width: '100vw' },
+            nodes: nodes.value,
+            edges: edges.value,
+            'onUpdate:nodes': (next: Node[]) => {
+              nodeUpdates++
+              nodes.value = next
+            },
+            'onUpdate:edges': (next: Edge[]) => {
+              edgeUpdates++
+              edges.value = next
+            },
+          })
+      },
+    })
+
+    cy.mount(Wrapper)
+
+    cy.get('.vue-flow__node').should('have.length', 2)
+    cy.get('.vue-flow__edge').should('have.length', 1)
+
+    // adoption + dimension updates produce a handful of model writes; a runaway loop produces
+    // 100+ before Vue's dev-only recursion guard aborts the flush
+    cy.then(() => {
+      expect(nodeUpdates, 'update:nodes emissions after mount').to.be.lessThan(10)
+      expect(edgeUpdates, 'update:edges emissions after mount').to.be.lessThan(10)
+    })
+
+    // pre-fix, a single selection change alone produced 100+ writes and a recursion abort
+    cy.get('.vue-flow__node').first().click()
+
+    cy.get('.vue-flow__node').first().should('have.class', 'selected')
+
+    cy.then(() => {
+      expect(nodeUpdates, 'update:nodes emissions after select').to.be.lessThan(15)
+      expect(edgeUpdates, 'update:edges emissions after select').to.be.lessThan(15)
+    })
+  })
+})


### PR DESCRIPTION
Three release blockers found by the 2.0 pre-release audit, each with a regression spec that was verified to fail against the pre-fix source.

## v-model raw-vs-proxy infinite re-adopt loop
Binding `v-model:nodes`/`v-model:edges` to a plain (deep) `ref` — the documented default — hands the store's own write back as its **reactive proxy**, so the single-source identity guards (`lastWriteNodes` in `createStore`, `lastSnapshot` in `syncModelArray`) always failed and looped `setNodes`/`setEdges` until Vue aborted the flush (`Maximum recursive updates exceeded`; unbounded in prod builds where the recursion guard is DEV-only). Guards now compare `toRaw` identities. The internal fallback signals became typed `shallowRef`s, which also removes the casts around the signal union.

The new `vmodel.cy.ts` spec mounts a real parent with both models wired up — `cy.vueFlow()` mounts plain props and never binds the model, which is why the suite missed this.

## Child-drag parent-offset double-subtract
Drag items arrive with parent-**relative** positions (XYDrag's `calculateNodePosition` and the keyboard path's `calcNextPosition` both subtract the parent offset already). `updateNodePositions` subtracted the parent's `positionAbsolute` a second time — a leftover from the pre-XYDrag convention — so dragging a child of any non-origin parent landed at `position - parentAbsolute`, and the `expandParent` clamp was corrupted the same way. The subtraction is removed; `updateNodePositions.cy.ts` pins the relative/absolute contract.

## `updateEdge` wiped the connection lookup
`updateConnectionLookup` clears the lookup before repopulating, and `updateEdge` passed only the reconnected edge — erasing every other edge's connections (`useNodeConnections`/`getHandleConnections` broke until the next full `setEdges`). It now rebuilds from `state.edges`.

Also rides along: removal of the stale `vue/macros-global` type reference (gone since Vue 3.4).

## Verification
- All three new regression specs fail on `release/2.0.0` without the fixes (verified by stash/rebuild/run) and pass with them
- Affected suites green: vmodel, updateNodePositions, updateEdge (store + component), drag, expand-parent, provider, basic — 18/18
- `vue-tsc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)