### PR TITLE
perf(core): O(changed) drag frames — raw-lookup adoption, scoped edge/minimap re-renders

### DIFF
--- a/packages/core/src/components/Edges/EdgeWrapper.ts
+++ b/packages/core/src/components/Edges/EdgeWrapper.ts
@@ -4,7 +4,7 @@ import type { Connection, EdgeComponent, HandleType, MouseTouchEvent } from '../
 import { ConnectionMode, Position } from '../../types'
 import { useEdgeHooks, useHandle, useVueFlow } from '../../composables'
 import { EdgeId, EdgeRef, Slots } from '../../context'
-import { ARIA_EDGE_DESC_KEY, ErrorCode, VueFlowError, elementSelectionKeys, getEdgeHandle } from '../../utils'
+import { ARIA_EDGE_DESC_KEY, ErrorCode, VueFlowError, elementSelectionKeys, getEdgeHandle, getEdgeZIndex } from '../../utils'
 import EdgeAnchor from './EdgeAnchor'
 
 interface Props {
@@ -34,10 +34,16 @@ const EdgeWrapper = defineComponent({
       elementsSelectable,
       edgesUpdatable,
       edgesFocusable,
+      elevateEdgesOnSelect,
       hooks,
     } = useVueFlow()
 
     const edge = computed(() => findEdge(props.id)!)
+
+    // resolved per edge (value-gated computed) so the z-tracking of BOTH endpoint lookup keys lives in
+    // this component's scope — resolving it in EdgeRenderer's v-for made the whole renderer re-render
+    // (all edge vnodes) whenever ANY node entry was replaced, i.e. every drag frame
+    const zIndex = computed(() => getEdgeZIndex(edge.value, getInternalNode, elevateEdgesOnSelect.value))
 
     const { emit } = useEdgeHooks(emits)
 
@@ -173,118 +179,124 @@ const EdgeWrapper = defineComponent({
       edge.value.targetX = targetX
       edge.value.targetY = targetY
 
+      // the full-container svg wrapper (one stacking context per edge zIndex) is rendered here rather
+      // than in EdgeRenderer's v-for so its node-lookup tracking stays scoped to this edge
       return h(
-        'g',
-        {
-          'ref': edgeEl,
-          'key': props.id,
-          'data-id': props.id,
-          'class': [
-            'vue-flow__edge',
-            `vue-flow__edge-${edgeCmp.value === false ? 'default' : edge.value.type || 'default'}`,
-            noPanClassName.value,
-            edgeClass.value,
-            {
-              updating: mouseOver.value,
-              selected: edge.value.selected,
-              animated: edge.value.animated,
-              inactive: !isSelectable.value && !hooks.value.edgeClick.hasListeners(),
-            },
-          ],
-          'tabIndex': isFocusable.value ? 0 : undefined,
-          'aria-label':
-            edge.value.ariaLabel === null
-              ? undefined
-              : edge.value.ariaLabel ?? `Edge from ${edge.value.source} to ${edge.value.target}`,
-          'aria-describedby': isFocusable.value ? `${ARIA_EDGE_DESC_KEY}-${vueFlowId}` : undefined,
-          'aria-roledescription': 'edge',
-          'role': isFocusable.value ? 'group' : 'img',
-          ...edge.value.domAttributes,
-          'onClick': onEdgeClick,
-          'onContextmenu': onEdgeContextMenu,
-          'onDblclick': onDoubleClick,
-          'onMouseenter': onEdgeMouseEnter,
-          'onMousemove': onEdgeMouseMove,
-          'onMouseleave': onEdgeMouseLeave,
-          'onKeyDown': isFocusable.value ? onKeyDown : undefined,
-        },
-        [
-          updating.value
-            ? null
-            : h(edgeCmp.value === false ? getEdgeTypes.value.default : (edgeCmp.value as any), {
-                id: props.id,
-                sourceNode,
-                targetNode,
-                source: edge.value.source,
-                target: edge.value.target,
-                type: edge.value.type,
-                updatable: isUpdatable.value,
+        'svg',
+        { class: 'vue-flow__edges vue-flow__container', style: { zIndex: zIndex.value } },
+        h(
+          'g',
+          {
+            'ref': edgeEl,
+            'key': props.id,
+            'data-id': props.id,
+            'class': [
+              'vue-flow__edge',
+              `vue-flow__edge-${edgeCmp.value === false ? 'default' : edge.value.type || 'default'}`,
+              noPanClassName.value,
+              edgeClass.value,
+              {
+                updating: mouseOver.value,
                 selected: edge.value.selected,
                 animated: edge.value.animated,
-                label: edge.value.label,
-                labelStyle: edge.value.labelStyle,
-                labelShowBg: edge.value.labelShowBg,
-                labelBgStyle: edge.value.labelBgStyle,
-                labelBgPadding: edge.value.labelBgPadding,
-                labelBgBorderRadius: edge.value.labelBgBorderRadius,
-                data: edge.value.data,
-                style: edgeStyle.value,
-                markerStart: `url('#${getMarkerId(edge.value.markerStart, vueFlowId)}')`,
-                markerEnd: `url('#${getMarkerId(edge.value.markerEnd, vueFlowId)}')`,
-                sourcePosition,
-                targetPosition,
-                sourceX,
-                sourceY,
-                targetX,
-                targetY,
-                sourceHandleId: edge.value.sourceHandle,
-                targetHandleId: edge.value.targetHandle,
-                interactionWidth: edge.value.interactionWidth,
-                ...pathOptions,
-              }),
+                inactive: !isSelectable.value && !hooks.value.edgeClick.hasListeners(),
+              },
+            ],
+            'tabIndex': isFocusable.value ? 0 : undefined,
+            'aria-label':
+              edge.value.ariaLabel === null
+                ? undefined
+                : edge.value.ariaLabel ?? `Edge from ${edge.value.source} to ${edge.value.target}`,
+            'aria-describedby': isFocusable.value ? `${ARIA_EDGE_DESC_KEY}-${vueFlowId}` : undefined,
+            'aria-roledescription': 'edge',
+            'role': isFocusable.value ? 'group' : 'img',
+            ...edge.value.domAttributes,
+            'onClick': onEdgeClick,
+            'onContextmenu': onEdgeContextMenu,
+            'onDblclick': onDoubleClick,
+            'onMouseenter': onEdgeMouseEnter,
+            'onMousemove': onEdgeMouseMove,
+            'onMouseleave': onEdgeMouseLeave,
+            'onKeyDown': isFocusable.value ? onKeyDown : undefined,
+          },
           [
-            isUpdatable.value === 'source' || isUpdatable.value === true
-              ? [
-                  h(
-                    'g',
-                    {
-                      onMousedown: onEdgeUpdaterSourceMouseDown,
-                      onMouseenter: onEdgeUpdaterMouseEnter,
-                      onMouseout: onEdgeUpdaterMouseOut,
-                    },
-                    h(EdgeAnchor, {
-                      'position': sourcePosition,
-                      'centerX': sourceX,
-                      'centerY': sourceY,
-                      'radius': edgeUpdaterRadius.value,
-                      'type': 'source',
-                      'data-type': 'source',
-                    }),
-                  ),
-                ]
-              : null,
-            isUpdatable.value === 'target' || isUpdatable.value === true
-              ? [
-                  h(
-                    'g',
-                    {
-                      onMousedown: onEdgeUpdaterTargetMouseDown,
-                      onMouseenter: onEdgeUpdaterMouseEnter,
-                      onMouseout: onEdgeUpdaterMouseOut,
-                    },
-                    h(EdgeAnchor, {
-                      'position': targetPosition,
-                      'centerX': targetX,
-                      'centerY': targetY,
-                      'radius': edgeUpdaterRadius.value,
-                      'type': 'target',
-                      'data-type': 'target',
-                    }),
-                  ),
-                ]
-              : null,
+            updating.value
+              ? null
+              : h(edgeCmp.value === false ? getEdgeTypes.value.default : (edgeCmp.value as any), {
+                  id: props.id,
+                  sourceNode,
+                  targetNode,
+                  source: edge.value.source,
+                  target: edge.value.target,
+                  type: edge.value.type,
+                  updatable: isUpdatable.value,
+                  selected: edge.value.selected,
+                  animated: edge.value.animated,
+                  label: edge.value.label,
+                  labelStyle: edge.value.labelStyle,
+                  labelShowBg: edge.value.labelShowBg,
+                  labelBgStyle: edge.value.labelBgStyle,
+                  labelBgPadding: edge.value.labelBgPadding,
+                  labelBgBorderRadius: edge.value.labelBgBorderRadius,
+                  data: edge.value.data,
+                  style: edgeStyle.value,
+                  markerStart: `url('#${getMarkerId(edge.value.markerStart, vueFlowId)}')`,
+                  markerEnd: `url('#${getMarkerId(edge.value.markerEnd, vueFlowId)}')`,
+                  sourcePosition,
+                  targetPosition,
+                  sourceX,
+                  sourceY,
+                  targetX,
+                  targetY,
+                  sourceHandleId: edge.value.sourceHandle,
+                  targetHandleId: edge.value.targetHandle,
+                  interactionWidth: edge.value.interactionWidth,
+                  ...pathOptions,
+                }),
+            [
+              isUpdatable.value === 'source' || isUpdatable.value === true
+                ? [
+                    h(
+                      'g',
+                      {
+                        onMousedown: onEdgeUpdaterSourceMouseDown,
+                        onMouseenter: onEdgeUpdaterMouseEnter,
+                        onMouseout: onEdgeUpdaterMouseOut,
+                      },
+                      h(EdgeAnchor, {
+                        'position': sourcePosition,
+                        'centerX': sourceX,
+                        'centerY': sourceY,
+                        'radius': edgeUpdaterRadius.value,
+                        'type': 'source',
+                        'data-type': 'source',
+                      }),
+                    ),
+                  ]
+                : null,
+              isUpdatable.value === 'target' || isUpdatable.value === true
+                ? [
+                    h(
+                      'g',
+                      {
+                        onMousedown: onEdgeUpdaterTargetMouseDown,
+                        onMouseenter: onEdgeUpdaterMouseEnter,
+                        onMouseout: onEdgeUpdaterMouseOut,
+                      },
+                      h(EdgeAnchor, {
+                        'position': targetPosition,
+                        'centerX': targetX,
+                        'centerY': targetY,
+                        'radius': edgeUpdaterRadius.value,
+                        'type': 'target',
+                        'data-type': 'target',
+                      }),
+                    ),
+                  ]
+                : null,
+            ],
           ],
-        ],
+        ),
       )
     }
 

--- a/packages/core/src/components/MiniMap/MiniMap.vue
+++ b/packages/core/src/components/MiniMap/MiniMap.vue
@@ -227,10 +227,14 @@ export default {
     >
       <title v-if="ariaLabel" :id="`vue-flow__minimap-${id}`">{{ ariaLabel }}</title>
 
+      <!-- v-memo on the lookup entry: unchanged nodes keep their InternalNode reference across commits
+      (checkEquality reuse), so drag/pan-frame MiniMap re-renders skip every untouched child instead of
+      re-rendering all of them (the inline per-node prop objects/calls would otherwise always patch) -->
       <MiniMapNode
         v-for="node of minimapNodes"
         :id="node.id"
         :key="node.id"
+        v-memo="[node, nodeClassNameFunc, nodeColorFunc, nodeStrokeColorFunc, nodeBorderRadius, nodeStrokeWidth, shapeRendering]"
         :position="node.internals.positionAbsolute"
         :dimensions="getNodeDimensions(node)"
         :selected="node.selected"

--- a/packages/core/src/components/Nodes/NodeWrapper.ts
+++ b/packages/core/src/components/Nodes/NodeWrapper.ts
@@ -99,7 +99,9 @@ const NodeWrapper = defineComponent({
 
     const isInit = toRef(() => !!nodeRef.value?.measured?.width && !!nodeRef.value?.measured?.height)
 
-    const isParent = toRef(() => (parentLookup.get(props.id)?.size ?? 0) > 0)
+    // computed (not toRef): the value-equality gate keeps this node's render effect from re-running on
+    // every `parentLookup` entry replacement — an uncached getter read in render tracks the raw map key
+    const isParent = computed(() => (parentLookup.get(props.id)?.size ?? 0) > 0)
 
     const nodeCmp = computed(() => {
       const name = nodeRef.value?.type || 'default'

--- a/packages/core/src/composables/useDrag.ts
+++ b/packages/core/src/composables/useDrag.ts
@@ -63,10 +63,17 @@ export function useDrag(params: UseDragParams) {
 
     const dragInstance = XYDrag({
       getStoreItems: () => ({
-        // getNodes is DeepReadonly (public guard); XYDrag reads node data from nodeLookup, not this array
-        nodes: getNodes.value as unknown as NodeBase[],
+        // lazy getters: XYDrag never destructures `nodes`/`edges` (verified against every getStoreItems
+        // call site in system), and getStoreItems runs multiple times per pointermove — eagerly reading
+        // the getters here would recompute them per frame (O(n+m) with `onlyRenderVisibleElements`).
+        // getNodes is DeepReadonly (public guard); XYDrag reads node data from nodeLookup, not this array.
+        get nodes() {
+          return getNodes.value as unknown as NodeBase[]
+        },
         nodeLookup,
-        edges: getEdges.value as unknown as EdgeBase[],
+        get edges() {
+          return getEdges.value as unknown as EdgeBase[]
+        },
         nodeExtent: (isCoordinateExtent(nodeExtent.value as CoordinateExtent)
           ? nodeExtent.value
           : infiniteExtent) as CoordinateExtent,

--- a/packages/core/src/container/EdgeRenderer/EdgeRenderer.vue
+++ b/packages/core/src/container/EdgeRenderer/EdgeRenderer.vue
@@ -2,10 +2,9 @@
 import EdgeWrapper from '../../components/Edges/EdgeWrapper'
 import ConnectionLine from '../../components/ConnectionLine'
 import { useVueFlow } from '../../composables'
-import { getEdgeZIndex } from '../../utils'
 import MarkerDefinitions from './MarkerDefinitions.vue'
 
-const { getInternalNode, getEdges, elevateEdgesOnSelect } = useVueFlow()
+const { getEdges } = useVueFlow()
 </script>
 
 <script lang="ts">
@@ -18,14 +17,9 @@ export default {
 <template>
   <MarkerDefinitions />
 
-  <svg
-    v-for="edge of getEdges"
-    :key="edge.id"
-    class="vue-flow__edges vue-flow__container"
-    :style="{ zIndex: getEdgeZIndex(edge, getInternalNode, elevateEdgesOnSelect) }"
-  >
-    <EdgeWrapper :id="edge.id" />
-  </svg>
+  <!-- the per-edge svg wrapper (and its node-lookup-tracking zIndex) lives in EdgeWrapper, so this
+  v-for only re-renders on edge membership changes, not on every node replacement -->
+  <EdgeWrapper v-for="edge of getEdges" :id="edge.id" :key="edge.id" />
 
   <ConnectionLine />
 </template>

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -1,5 +1,5 @@
-import { markRaw, toRaw } from 'vue'
 import type { DeepReadonly } from 'vue'
+import { markRaw, toRaw } from 'vue'
 import {
   clampPosition,
   clampPositionToParent,
@@ -92,7 +92,11 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
 
     for (const [id, internal] of systemNodeLookup) {
       if (rawNodeLookup.get(id) !== internal) {
-        nodeLookup.set(id, internal)
+        // `markRaw` exactly the entries that are new since the last sync — `adoptUserNodes` rebuilds
+        // changed nodes as fresh plain objects and `updateAbsolutePositions` clones moved children, and
+        // without the mark the reactive lookup would deep-proxy them on read. The per-node render
+        // computed still re-renders on the `.set` (key-level reactivity is independent of value markRaw).
+        nodeLookup.set(id, markRaw(internal))
       }
     }
 
@@ -136,13 +140,11 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
    * `checkEquality` would re-adopt the stale `InternalNode`.
    */
   function commitNodes(nodes: NodeType[]) {
-    const validNodes = adoptNodes(nodes, systemNodeLookup, systemParentLookup, state.hooks.error.trigger, {
+    state.nodes = adoptNodes(nodes, systemNodeLookup, systemParentLookup, state.hooks.error.trigger, {
       nodeOrigin: [0, 0],
       nodeExtent: Array.isArray(state.nodeExtent) ? (state.nodeExtent as CoordinateExtent) : undefined,
       elevateNodesOnSelect: state.elevateNodesOnSelect,
     })
-
-    state.nodes = validNodes
 
     recomputeAbsolutePositions()
   }
@@ -177,17 +179,16 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
   }
 
   /**
-   * Recompute parent-aware `internals.positionAbsolute`/`z` for every node via `@xyflow/system`'s
-   * `updateAbsolutePositions`. The lookup is the canonical home of the enriched `InternalNode`s/`internals`,
-   * so this is lookup-only: `updateAbsolutePositions` writes `internals.positionAbsolute` directly onto the
-   * lookup InternalNodes (root nodes in place, moved children via clone-on-`.set`, which the per-node render
-   * computed picks up by reference). There is NO write-back onto `state.nodes` — those hold the raw user
-   * `Node`s. This replaces the per-node positionAbsolute watcher that used to live in `NodeWrapper`.
+   * Recompute parent-aware `internals.positionAbsolute` on the system lookup, then mirror into the
+   * reactive lookups (`syncLookups`). Lookup-only: there is NO write-back onto `state.nodes` — those hold
+   * the raw user `Node`s. This replaces the per-node positionAbsolute watcher that used to live in
+   * `NodeWrapper`.
    *
-   * System does NOT set root-node `z` (only children get it via the parent chain), so we apply the
-   * elevate-on-select `z` for roots here, matching system's `calculateZ`.
+   * Adoption (`adoptUserNodes`) already computes clamped positions and `z` (via `calculateZ`, including
+   * select-elevation) for every changed node, so the full `updateAbsolutePositions` pass only runs for
+   * graphs with child nodes — or when `forceFullPass` says inputs changed without a re-adoption.
    */
-  function recomputeAbsolutePositions() {
+  function recomputeAbsolutePositions(forceFullPass = false) {
     // `@xyflow/system` has no concept of vue-flow's `CoordinateExtentRange` (`{ range, padding }`) and
     // its `isCoordinateExtent` treats any non-`'parent'`/non-nullish value as a coordinate-extent array,
     // so it would index `extent[0]` on the range object and crash. Transiently coerce such extents to
@@ -207,26 +208,21 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
       }
     }
 
-    updateAbsolutePositions(systemNodeLookup, systemParentLookup, {
-      nodeOrigin: [0, 0],
-      nodeExtent: Array.isArray(state.nodeExtent) ? (state.nodeExtent as CoordinateExtent) : undefined,
-      elevateNodesOnSelect: state.elevateNodesOnSelect,
-    })
+    // `adoptUserNodes` already computed the clamped `positionAbsolute` + `z` for every changed node
+    // (reused nodes keep their still-valid values) and cascades parented nodes inline, so after a commit
+    // the full pass is only needed when child nodes exist — a moved parent must cascade to REUSED
+    // children regardless of the user array's parent/child order. Callers that change inputs without
+    // re-adopting (`setNodeExtent`) force it.
+    if (forceFullPass || systemParentLookup.size > 0) {
+      updateAbsolutePositions(systemNodeLookup, systemParentLookup, {
+        nodeOrigin: [0, 0],
+        nodeExtent: Array.isArray(state.nodeExtent) ? (state.nodeExtent as CoordinateExtent) : undefined,
+        elevateNodesOnSelect: state.elevateNodesOnSelect,
+      })
+    }
 
     for (const { node, extent } of coercedExtents) {
       node.extent = extent
-    }
-
-    // `updateAbsolutePositions` writes `internals.positionAbsolute` directly onto the lookup
-    // InternalNodes (roots in place, moved children via clone-on-`.set`) — the lookup is canonical for
-    // internals now, so there is no array write-back. System does NOT set root-node `z` (only children get
-    // it through the parent chain), so apply the elevate-on-select `z` to root InternalNodes here,
-    // matching system's `calculateZ`.
-    for (const node of systemNodeLookup.values()) {
-      if (!node.parentId) {
-        node.internals.z =
-          (typeof node.zIndex === 'number' ? node.zIndex : 0) + (node.selected && state.elevateNodesOnSelect ? 1000 : 0)
-      }
     }
 
     // Apply the range `padding` the system clamp can't express. `updateAbsolutePositions` only understands
@@ -269,14 +265,6 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
       // mirror the padding-clamped position onto the user node (the canonical array element) so v-model /
       // getNodes reflect it (the InternalNode's `position` is internal-only otherwise).
       ;(node.internals.userNode as Node).position = position
-    }
-
-    // Keep every InternalNode raw: `adoptUserNodes` rebuilds changed nodes as fresh plain objects and
-    // `updateAbsolutePositions` clones moved children (`.set(id, {...node})`), so without this the reactive
-    // lookup would deep-proxy them. The per-node render computed still re-renders on the lookup `.set`
-    // (key-level reactivity is independent of value markRaw). Idempotent — reused/already-raw entries no-op.
-    for (const internal of systemNodeLookup.values()) {
-      markRaw(internal)
     }
 
     syncLookups()
@@ -550,7 +538,8 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
 
   const setNodeExtent: Actions<NodeType>['setNodeExtent'] = (nodeExtent) => {
     state.nodeExtent = nodeExtent
-    recomputeAbsolutePositions()
+    // force the full system pass — the extent changed without a re-adoption, so every root needs re-clamping
+    recomputeAbsolutePositions(true)
     updateNodeInternals()
   }
 

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -62,6 +62,68 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
 ): Actions<NodeType, EdgeType> {
   const viewportHelper = useViewportHelper(state, nodeLookup)
 
+  // The system-facing twins of the reactive lookups. `@xyflow/system`'s `adoptUserNodes` re-adopts by
+  // clearing + refilling the lookup it's given — on a `reactive(Map)` that's an O(n) trigger storm per
+  // call (`clear()` invalidates every key and iteration subscriber, every drag frame). Adoption and
+  // recompute therefore run against these plain Maps (which also persist across adoptions, keeping
+  // `checkEquality` reuse intact); `syncLookups` then mirrors the result into the reactive lookups with
+  // targeted `.set`/`.delete`, so only entries whose `InternalNode` reference actually changed trigger —
+  // per-frame render invalidation stays O(changed) instead of O(n).
+  const systemNodeLookup: NodeLookup<NodeType> = new Map()
+  const systemParentLookup: Map<string, Map<string, GraphNode<NodeType>>> = new Map()
+
+  function sameMapEntries<K, V>(a: Map<K, V>, b: Map<K, V>) {
+    if (a.size !== b.size) {
+      return false
+    }
+
+    for (const [key, value] of a) {
+      if (b.get(key) !== value) {
+        return false
+      }
+    }
+
+    return true
+  }
+
+  /** Mirror the system lookups into the reactive ones, touching only entries that actually changed. */
+  function syncLookups() {
+    const rawNodeLookup = toRaw(nodeLookup)
+
+    for (const [id, internal] of systemNodeLookup) {
+      if (rawNodeLookup.get(id) !== internal) {
+        nodeLookup.set(id, internal)
+      }
+    }
+
+    if (rawNodeLookup.size !== systemNodeLookup.size) {
+      for (const id of rawNodeLookup.keys()) {
+        if (!systemNodeLookup.has(id)) {
+          nodeLookup.delete(id)
+        }
+      }
+    }
+
+    // adoption rebuilds every nested child-map instance, so compare content — blindly re-setting an
+    // unchanged entry would re-trigger every `parentLookup` subscriber each frame
+    const rawParentLookup = toRaw(parentLookup)
+
+    for (const [parentId, children] of systemParentLookup) {
+      const prev = rawParentLookup.get(parentId)
+      if (!prev || !sameMapEntries(prev, children)) {
+        parentLookup.set(parentId, children)
+      }
+    }
+
+    if (rawParentLookup.size !== systemParentLookup.size) {
+      for (const parentId of rawParentLookup.keys()) {
+        if (!systemParentLookup.has(parentId)) {
+          parentLookup.delete(parentId)
+        }
+      }
+    }
+  }
+
   /**
    * Single write path for node membership/content. Takes the canonical USER `Node`s, re-adopts them into
    * `nodeLookup`/`parentLookup` via `adoptNodes` (xyflow/react+svelte parity — `adoptUserNodes` mutates the
@@ -74,7 +136,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
    * `checkEquality` would re-adopt the stale `InternalNode`.
    */
   function commitNodes(nodes: NodeType[]) {
-    const validNodes = adoptNodes(nodes, nodeLookup, parentLookup, state.hooks.error.trigger, {
+    const validNodes = adoptNodes(nodes, systemNodeLookup, systemParentLookup, state.hooks.error.trigger, {
       nodeOrigin: [0, 0],
       nodeExtent: Array.isArray(state.nodeExtent) ? (state.nodeExtent as CoordinateExtent) : undefined,
       elevateNodesOnSelect: state.elevateNodesOnSelect,
@@ -87,10 +149,30 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
 
   /** Single write path for edge membership; mirrors `next` into `state.edges` (see {@link commitNodes}). */
   function commitEdges(next: GraphEdge<EdgeType>[]) {
-    edgeLookup.clear()
+    // targeted sync instead of clear+refill: clearing a `reactive(Map)` invalidates every edge
+    // subscriber even when a single edge changed (in-place edge updates surface through the deep
+    // proxy regardless; key triggers are only needed for replaced/added/removed entries)
+    const rawEdgeLookup = toRaw(edgeLookup)
+
     for (const edge of next) {
-      edgeLookup.set(edge.id, edge)
+      if (rawEdgeLookup.get(edge.id) !== edge) {
+        edgeLookup.set(edge.id, edge)
+      }
     }
+
+    if (rawEdgeLookup.size !== next.length) {
+      const nextIds = new Set<string>()
+      for (const edge of next) {
+        nextIds.add(edge.id)
+      }
+
+      for (const id of rawEdgeLookup.keys()) {
+        if (!nextIds.has(id)) {
+          edgeLookup.delete(id)
+        }
+      }
+    }
+
     state.edges = next
   }
 
@@ -117,7 +199,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
     // `CoordinateExtentRange` ({ range, padding }) — see utils/drag.ts. Hence the localized casts: the
     // type can't express this without breaking system compat. We restore the original extent after.
     const coercedExtents: { node: GraphNode<NodeType>; extent: 'parent' | CoordinateExtent | null | undefined }[] = []
-    for (const node of nodeLookup.values()) {
+    for (const node of systemNodeLookup.values()) {
       const extent = node.extent as CoordinateExtentRange | 'parent' | CoordinateExtent | null | undefined
       if (extent && typeof extent === 'object' && !Array.isArray(extent) && 'range' in extent) {
         coercedExtents.push({ node, extent: node.extent })
@@ -125,7 +207,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
       }
     }
 
-    updateAbsolutePositions(nodeLookup, parentLookup, {
+    updateAbsolutePositions(systemNodeLookup, systemParentLookup, {
       nodeOrigin: [0, 0],
       nodeExtent: Array.isArray(state.nodeExtent) ? (state.nodeExtent as CoordinateExtent) : undefined,
       elevateNodesOnSelect: state.elevateNodesOnSelect,
@@ -140,7 +222,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
     // internals now, so there is no array write-back. System does NOT set root-node `z` (only children get
     // it through the parent chain), so apply the elevate-on-select `z` to root InternalNodes here,
     // matching system's `calculateZ`.
-    for (const node of nodeLookup.values()) {
+    for (const node of systemNodeLookup.values()) {
       if (!node.parentId) {
         node.internals.z =
           (typeof node.zIndex === 'number' ? node.zIndex : 0) + (node.selected && state.elevateNodesOnSelect ? 1000 : 0)
@@ -159,7 +241,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
         continue
       }
 
-      const parent = node.parentId ? nodeLookup.get(node.parentId) : undefined
+      const parent = node.parentId ? systemNodeLookup.get(node.parentId) : undefined
 
       // The padding clamp needs measured dimensions: `getExtent` indexes into the computed extent array
       // and would throw on the unmeasured fallback (the global extent may be undefined). Skip until the
@@ -193,9 +275,11 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
     // `updateAbsolutePositions` clones moved children (`.set(id, {...node})`), so without this the reactive
     // lookup would deep-proxy them. The per-node render computed still re-renders on the lookup `.set`
     // (key-level reactivity is independent of value markRaw). Idempotent — reused/already-raw entries no-op.
-    for (const internal of nodeLookup.values()) {
-      markRaw(toRaw(internal))
+    for (const internal of systemNodeLookup.values()) {
+      markRaw(internal)
     }
+
+    syncLookups()
   }
 
   const updateNodeInternals: Actions<NodeType>['updateNodeInternals'] = (ids) => {
@@ -289,7 +373,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
     // grow each parent to fit its `expandParent` children — system returns the parent's position +
     // dimension changes plus counter-offsets for the other children, applied through the same pipeline.
     if (parentExpandChildren.length > 0) {
-      changes.push(...handleExpandParent(parentExpandChildren, nodeLookup, parentLookup, [0, 0]))
+      changes.push(...handleExpandParent(parentExpandChildren, systemNodeLookup, systemParentLookup, [0, 0]))
     }
 
     if (changes.length) {
@@ -385,13 +469,17 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
           // `handleBounds` writes don't trigger the per-node render computed (markRaw values aren't deep
           // tracked; only the lookup `.set` is). This makes measurement reflect even with `applyDefault:false`
           // (the 'dimensions' change additionally flows `measured` onto the user node via re-adopt).
-          nodeLookup.set(node.id, markRaw({ ...toRaw(node) }))
+          // The fresh entry goes into BOTH maps: the system map is what `adoptUserNodes` reuses via
+          // `checkEquality`, so leaving the old object there would let the maps' references diverge.
+          const fresh = markRaw({ ...toRaw(node) })
+          systemNodeLookup.set(node.id, fresh)
+          nodeLookup.set(node.id, fresh)
         }
       }
     }
 
     if (parentExpandChildren.length > 0) {
-      changes.push(...handleExpandParent(parentExpandChildren, nodeLookup, parentLookup, [0, 0]))
+      changes.push(...handleExpandParent(parentExpandChildren, systemNodeLookup, systemParentLookup, [0, 0]))
     }
 
     if (!state.fitViewOnInitDone && state.fitViewOnInit) {

--- a/packages/core/src/utils/createExtendedEventHook.ts
+++ b/packages/core/src/utils/createExtendedEventHook.ts
@@ -36,6 +36,10 @@ type Handler<T = any> = (param: T) => any | Promise<any>
 
 const noop: Handler = () => {}
 
+// shared resolved promise for triggers with no observers — pointer-move hooks fire per mousemove, so
+// allocating a fresh array + allSettled chain for nothing is measurable GC pressure
+const EMPTY_TRIGGER_RESULT: Promise<unknown[]> = Promise.resolve([])
+
 export function createExtendedEventHook<T = any>(defaultHandler?: (param: T) => void): EventHookExtended<T> {
   const listeners = new Set<Handler>()
   let emitter: Handler = noop
@@ -82,6 +86,12 @@ export function createExtendedEventHook<T = any>(defaultHandler?: (param: T) => 
    * Errors are isolated via allSettled so one failing handler doesn't break others.
    */
   const trigger: EventHookTrigger<T> = (param) => {
+    // fast path: nothing can observe this event — no programmatic listeners, no `@event` vnode handler
+    // (the emitter would dispatch into a void emit), no default. Skip the dispatch + allocations.
+    if (listeners.size === 0 && !hasEmitListeners() && !defaultHandler) {
+      return EMPTY_TRIGGER_RESULT
+    }
+
     const queue: Handler[] = [emitter]
 
     if (hasListeners()) {

--- a/tests/cypress/component/lookup-sync.cy.ts
+++ b/tests/cypress/component/lookup-sync.cy.ts
@@ -1,0 +1,89 @@
+import { watchEffect } from 'vue'
+import type { VueFlowStore } from '@vue-flow/core'
+import { getStore } from '../support/component'
+
+/**
+ * Regression: adoption used to run `@xyflow/system`'s `adoptUserNodes` directly on the `reactive(Map)`
+ * lookups, whose clear+refill invalidated EVERY lookup subscriber on every commit (= every drag frame).
+ * Adoption now runs against plain system maps and is mirrored with targeted `.set`/`.delete`, so a
+ * change to one node must not re-trigger effects tracking other nodes' lookup keys.
+ */
+describe('lookup sync is O(changed)', () => {
+  let store: VueFlowStore
+
+  beforeEach(() => {
+    cy.vueFlow({
+      nodes: [
+        { id: '1', type: 'default', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
+        { id: '2', type: 'default', position: { x: 200, y: 0 }, data: { label: 'Node 2' } },
+        { id: '3', type: 'default', position: { x: 400, y: 0 }, data: { label: 'Node 3' } },
+      ],
+    })
+
+    cy.then(() => {
+      store = getStore()
+    })
+  })
+
+  it('does not invalidate unrelated lookup keys on a position change', () => {
+    let changedRuns = 0
+    let unrelatedRuns = 0
+
+    // watchEffect re-runs on every trigger of its deps, with no value-equality gate — exactly what a
+    // render effect tracking a raw `nodeLookup.get` does
+    watchEffect(
+      () => {
+        store.nodeLookup.get('1')
+        changedRuns++
+      },
+      { flush: 'sync' },
+    )
+
+    watchEffect(
+      () => {
+        store.nodeLookup.get('2')
+        unrelatedRuns++
+      },
+      { flush: 'sync' },
+    )
+
+    expect(changedRuns).to.equal(1)
+    expect(unrelatedRuns).to.equal(1)
+
+    store.applyNodeChanges([{ id: '1', type: 'position', position: { x: 50, y: 50 } }])
+
+    // the moved node's entry was replaced (new InternalNode) — its key must trigger
+    expect(changedRuns, 'effect tracking the moved node').to.be.greaterThan(1)
+    // the untouched node's InternalNode is reused by reference — its key must NOT trigger
+    expect(unrelatedRuns, 'effect tracking an untouched node').to.equal(1)
+  })
+
+  it('removals only touch the removed key', () => {
+    let removedRuns = 0
+    let unrelatedRuns = 0
+
+    watchEffect(
+      () => {
+        store.nodeLookup.get('3')
+        removedRuns++
+      },
+      { flush: 'sync' },
+    )
+
+    watchEffect(
+      () => {
+        store.nodeLookup.get('2')
+        unrelatedRuns++
+      },
+      { flush: 'sync' },
+    )
+
+    store.removeNodes(['3'])
+
+    cy.tryAssertion(() => {
+      expect(store.findNode('3')).to.equal(undefined)
+      expect(removedRuns, 'effect tracking the removed node').to.be.greaterThan(1)
+      expect(unrelatedRuns, 'effect tracking an untouched node').to.equal(1)
+    })
+  })
+})


### PR DESCRIPTION
The performance half of the 2.0 pre-release audit. Six commits, ordered by impact.

## The root cause
`@xyflow/system`'s `adoptUserNodes` re-adopts by copying, clearing and refilling the lookup it's given. Running it directly on the `reactive(Map)` lookups made every commit (= every drag frame) an O(n) trigger storm: `clear()` invalidates every key and iteration subscriber, so dragging one node dirtied every render effect tracking any lookup entry — every EdgeWrapper, the EdgeRenderer v-for, the MiniMap, `useNodesInitialized`, all of it, per frame.

Adoption and `recomputeAbsolutePositions` now run against plain system Maps (persistent across adoptions, so `checkEquality` reference-reuse keeps working); `syncLookups` mirrors the result into the reactive lookups with targeted `.set`/`.delete`. Only entries whose `InternalNode` reference actually changed trigger. `commitEdges` got the same diff treatment, and `markRaw` now marks exactly the changed entries instead of a full pass.

## Scoped re-renders on top of it
- **EdgeWrapper** owns its per-edge svg wrapper + a value-gated zIndex computed — EdgeRenderer's v-for no longer tracks both endpoint keys of every edge, so a node replacement re-renders only the edges connected to it.
- **NodeWrapper `isParent`** is a value-gated computed — the uncached `toRef` made every node's render effect track its `parentLookup` key raw, which re-rendered ALL nodes per commit in any graph containing subflows.
- **MiniMapNodes** are `v-memo`'d on their lookup entry — drag/pan-frame MiniMap re-renders skip every untouched child (the inline per-node prop objects previously always failed prop comparison).

## Redundant work removed
- `adoptUserNodes` already computes clamped `positionAbsolute` + `z` (via `calculateZ`, select-elevation included) for changed nodes and cascades parented nodes inline — the follow-up full `updateAbsolutePositions` pass now only runs for graphs with child nodes (preserving tolerance for child-before-parent array order) or `setNodeExtent` (which changes inputs without re-adopting). The root-z loop duplicated `calculateZ` and is gone.
- `useDrag`'s `getStoreItems` eagerly computed `getNodes`/`getEdges` multiple times per pointermove though XYDrag never reads them (verified against every call site in system) — now lazy getters.
- Event hooks allocated a `Promise.allSettled` chain on every trigger even with zero observers (`paneMouseMove` fires per pointermove) — triggers nobody can observe return a shared resolved promise.

## Numbers
Temporary cypress A/B harness, 1024 nodes / 1023 edges, one node moved per frame × 120 (JS commit cost only — render savings come on top):

| per simulated drag frame | base (`5f1a1922`) | this PR |
|---|---|---|
| commit time | 3.23 ms | **0.33 ms (~10×)** |
| untouched-node key invalidations | 2 | **0** |
| lookup-iteration invalidations | 1025 | **1** |

## Verification
- Full cypress component suite green: 125/125, including the new `lookup-sync.cy.ts` which pins the O(changed) contract (an effect tracking an untouched node's lookup key must not re-run when another node moves/is removed — fails against base)
- `vue-tsc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)