### PR TITLE
build(core): silence third-party INVALID_ANNOTATION warnings

### DIFF
--- a/packages/core/vite.config.iife.ts
+++ b/packages/core/vite.config.iife.ts
@@ -22,6 +22,17 @@ export default defineConfig({
       // make sure to externalize deps that shouldn't be bundled
       // into your library
       external: ['vue'],
+      // we bundle @vueuse/core on purpose; its prebuilt dist ships `#__PURE__` annotations in
+      // positions Rolldown can't read, so drop that third-party-only noise (keep our own warnings)
+      onwarn(warning, warn) {
+        if (
+          warning.code === 'INVALID_ANNOTATION' &&
+          (warning.id?.includes('node_modules') || warning.message?.includes('node_modules'))
+        ) {
+          return
+        }
+        warn(warning)
+      },
       output: {
         format: 'iife',
         dir: './dist',

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -22,6 +22,17 @@ export default defineConfig({
       // make sure to externalize deps that shouldn't be bundled
       // into your library
       external: ['vue'],
+      // we bundle @vueuse/core on purpose; its prebuilt dist ships `#__PURE__` annotations in
+      // positions Rolldown can't read, so drop that third-party-only noise (keep our own warnings)
+      onwarn(warning, warn) {
+        if (
+          warning.code === 'INVALID_ANNOTATION' &&
+          (warning.id?.includes('node_modules') || warning.message?.includes('node_modules'))
+        ) {
+          return
+        }
+        warn(warning)
+      },
       output: {
         format: 'esm',
         dir: './dist',


### PR DESCRIPTION
## What

The library build emitted Rolldown `[INVALID_ANNOTATION]` warnings pointing at `@vueuse/core`'s prebuilt `dist/index.js`:

```
[INVALID_ANNOTATION] A comment "/* #__PURE__ */" ... contains an annotation that Rolldown cannot interpret due to the position of the comment.
  @vueuse/core/dist/index.js:3362 — comment on its own line
  @vueuse/core/dist/index.js:5780 — `(/* #__PURE__ */ {`
```

## Why it happens (not a vue-flow bug)

These are **not** from our source or types. We intentionally **inline** `@vueuse/core` and `@xyflow/system` into the published bundle (the lib build externalizes only `vue`) so consumers install just `@vue-flow/core`. Because `@vueuse/core` is bundled, Rolldown parses its prebuilt output, which carries `#__PURE__` annotations in two spots Rolldown considers mis-positioned. Rolldown simply **ignores** those annotations — no runtime, correctness, or output-size impact; it's pure log noise originating in a third-party prebuilt file.

## Fix

Scoped `onwarn` in both `vite.config.ts` (es/cjs) and `vite.config.iife.ts` that drops `INVALID_ANNOTATION` warnings originating from `node_modules` and forwards everything else — so our own annotation warnings still surface. Bundling behavior is unchanged (we still inline @vueuse/core + @xyflow/system on purpose).

Verified: both builds run clean (no `INVALID_ANNOTATION` lines), `dist` output unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)