### PR TITLE
fix(core): 2.0 audit micro-bugs (paneClickDistance, NODE_INVALID, nodesDraggable, Handle connectable, setState nodeExtent, a11y)

### DIFF
--- a/packages/core/src/components/A11y/A11yDescriptions.vue
+++ b/packages/core/src/components/A11y/A11yDescriptions.vue
@@ -15,8 +15,11 @@ export default {
 <template>
   <div :id="`${ARIA_NODE_DESC_KEY}-${id}`" style="display: none">
     Press enter or space to select a node.
-    {{ !disableKeyboardA11y ? 'You can then use the arrow keys to move the node around.' : '' }}
-    You can then use the arrow keys to move the node around, press delete to remove it and press escape to cancel.
+    {{
+      !disableKeyboardA11y
+        ? 'You can then use the arrow keys to move the node around, press delete to remove it and press escape to cancel.'
+        : ''
+    }}
   </div>
 
   <div :id="`${ARIA_EDGE_DESC_KEY}-${id}`" style="display: none">

--- a/packages/core/src/components/Handle/Handle.vue
+++ b/packages/core/src/components/Handle/Handle.vue
@@ -186,16 +186,19 @@ export default {
     class="vue-flow__handle"
     :class="[
       `vue-flow__handle-${position}`,
-      `vue-flow__handle-${handleId}`,
+      handleId && `vue-flow__handle-${handleId}`,
       noDragClassName,
       noPanClassName,
       type,
       {
-        connectable: isConnectable,
+        // use the resolved value (falls back to `nodesConnectable`), not the raw prop — XYHandle's DOM
+        // query targets `.connectable` to find drop targets, so an unset `:connectable` must still mark it
+        connectable: isHandleConnectable,
         connecting: isClickConnecting,
         connectablestart: isConnectableStart,
         connectableend: isConnectableEnd,
-        connectionindicator: isConnectable && ((isConnectableStart && !isConnecting) || (isConnectableEnd && isConnecting)),
+        connectionindicator:
+          isHandleConnectable && ((isConnectableStart && !isConnecting) || (isConnectableEnd && isConnecting)),
       },
     ]"
     @mousedown="onPointerDown"

--- a/packages/core/src/components/Handle/Handle.vue
+++ b/packages/core/src/components/Handle/Handle.vue
@@ -197,8 +197,7 @@ export default {
         connecting: isClickConnecting,
         connectablestart: isConnectableStart,
         connectableend: isConnectableEnd,
-        connectionindicator:
-          isHandleConnectable && ((isConnectableStart && !isConnecting) || (isConnectableEnd && isConnecting)),
+        connectionindicator: isHandleConnectable && ((isConnectableStart && !isConnecting) || (isConnectableEnd && isConnecting)),
       },
     ]"
     @mousedown="onPointerDown"

--- a/packages/core/src/composables/useUpdateNodePositions.ts
+++ b/packages/core/src/composables/useUpdateNodePositions.ts
@@ -24,7 +24,7 @@ export function useUpdateNodePositions() {
 
     const nodeUpdates: NodeDragItem[] = []
     for (const node of getSelectedNodes.value) {
-      if (node.draggable || (nodesDraggable && typeof node.draggable === 'undefined')) {
+      if (node.draggable || (nodesDraggable.value && typeof node.draggable === 'undefined')) {
         // `getSelectedNodes` returns user `Node`s — resolve the enriched InternalNode for internals/measured
         const internalNode = getInternalNode(node.id)
         if (!internalNode) {

--- a/packages/core/src/container/ZoomPane/ZoomPane.vue
+++ b/packages/core/src/container/ZoomPane/ZoomPane.vue
@@ -33,6 +33,7 @@ const {
   noWheelClassName,
   panActivationKeyCode,
   selectionKeyCode,
+  paneClickDistance,
   connectionStartHandle,
 } = useVueFlow()
 
@@ -95,6 +96,7 @@ onMounted(() => {
         noPanClassName,
         userSelectionActive,
         noWheelClassName,
+        paneClickDistance,
         connectionStartHandle,
       ],
       () => {
@@ -111,7 +113,7 @@ onMounted(() => {
           noPanClassName: noPanClassName.value,
           userSelectionActive: userSelectionActive.value,
           noWheelClassName: noWheelClassName.value,
-          paneClickDistance: 0,
+          paneClickDistance: paneClickDistance.value,
           onTransformChange: (nextTransform) => {
             emits.viewportChange({ x: nextTransform[0], y: nextTransform[1], zoom: nextTransform[2] })
             transform.value = nextTransform

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -982,6 +982,11 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
       if (isDef(opts.translateExtent)) {
         setTranslateExtent(opts.translateExtent)
       }
+      // route through the setter (recomputes absolute positions) instead of the raw generic-loop
+      // assignment — runs after `setNodes`, so preloaded nodes get re-clamped to the extent
+      if (isDef(opts.nodeExtent)) {
+        setNodeExtent(opts.nodeExtent)
+      }
     }
 
     for (const o of Object.keys(opts)) {

--- a/packages/core/src/store/state.ts
+++ b/packages/core/src/store/state.ts
@@ -124,6 +124,7 @@ export const storeOptionsToSkip: (keyof Partial<FlowProps & Omit<State, 'nodes' 
   'maxZoom',
   'minZoom',
   'translateExtent',
+  'nodeExtent',
   'hooks',
   'defaultEdgeOptions',
 ]

--- a/packages/core/src/utils/store.ts
+++ b/packages/core/src/utils/store.ts
@@ -123,7 +123,7 @@ export function adoptNodes<NodeType extends Node = Node>(
 
     if (!isNode(node)) {
       triggerError(
-        new VueFlowError(ErrorCode.NODE_INVALID, (node as undefined | Record<any, any>)?.id) || `[ID UNKNOWN|INDEX ${i}]`,
+        new VueFlowError(ErrorCode.NODE_INVALID, (node as undefined | Record<any, any>)?.id ?? `[ID UNKNOWN|INDEX ${i}]`),
       )
       continue
     }

--- a/tests/cypress/component/1-store/state/setState.cy.ts
+++ b/tests/cypress/component/1-store/state/setState.cy.ts
@@ -77,4 +77,21 @@ describe('Store Action: `setState`', () => {
     })
     expect(Object.keys(store.getEdgeTypes.value)).to.contain('custom')
   })
+
+  it('re-clamps preloaded nodes to a nodeExtent passed in the same setState call', () => {
+    // regression: setState set nodeExtent via the generic loop (no recompute), so nodes adopted by the
+    // earlier setNodes call were never clamped to the extent
+    store.setState({
+      nodes: [{ id: '1', position: { x: 500, y: 500 } }],
+      nodeExtent: [
+        [0, 0],
+        [100, 100],
+      ],
+    })
+
+    cy.tryAssertion(() => {
+      const internal = store.getInternalNode('1')
+      expect(internal?.internals.positionAbsolute).to.deep.equal({ x: 100, y: 100 })
+    })
+  })
 })

--- a/tests/cypress/component/2-vue-flow/customNode.cy.ts
+++ b/tests/cypress/component/2-vue-flow/customNode.cy.ts
@@ -42,4 +42,13 @@ describe('Check if custom nodes are rendered', () => {
 
     cy.get('.vue-flow__node-custom').should('have.css', 'transform', 'matrix(1, 0, 0, 1, 300, 300)')
   })
+
+  it('marks handles connectable by default (no explicit :connectable) so they are valid drop targets', () => {
+    // regression: the `connectable` class used the raw (undefined) prop instead of the resolved value;
+    // XYHandle's DOM query targets `.connectable` to find drop targets
+    cy.get('.vue-flow__node-custom .vue-flow__handle').should('have.length', 3).and('have.class', 'connectable')
+
+    // and no accidental `vue-flow__handle-null` when a handle id is set
+    cy.get('.vue-flow__handle-null').should('not.exist')
+  })
 })


### PR DESCRIPTION
Six small, independent bugs surfaced by the 2.0 audit. Each is isolated and low-risk; two get regression guards. Branches off `release/2.0.0` (lines don't overlap the edge-split/parity PRs, so it merges in any order).

## Fixes

1. **`paneClickDistance` dead-wired** — ZoomPane passed a literal `paneClickDistance: 0` into the panZoom `update()`, which re-runs on many state changes and stomped whatever `setPaneClickDistance` set. Now wires `state.paneClickDistance` (added to the watch deps so changes re-apply).

2. **`NODE_INVALID` error fallback was dead** — `new VueFlowError(NODE_INVALID, node?.id) || '[ID UNKNOWN…]'` applied the `||` to the Error instance (always truthy), so an invalid node always reported `id: undefined`. Moved the fallback inside as the id arg (`?? '[ID UNKNOWN|INDEX i]'`).

3. **`nodesDraggable` missing `.value`** — `useUpdateNodePositions` tested the ref object (always truthy) instead of `.value`, so keyboard-moving co-selected nodes with `draggable: undefined` ignored `nodes-draggable={false}`.

4. **`setState` didn't re-clamp to `nodeExtent`** — `nodeExtent` was assigned via the generic loop (no `recomputeAbsolutePositions`) *after* `setNodes`, so nodes preloaded via `setState({ nodes, nodeExtent })` (e.g. a provider) weren't clamped. Routed through `setNodeExtent`. *(Latent today; fixed for correctness.)*

5. **Handle `connectable` class used the raw prop** — `connectable`/`connectionindicator` bound the raw `isConnectable` prop (undefined unless explicitly passed) instead of the resolved `isHandleConnectable` (which falls back to `nodesConnectable`). A custom node's `<Handle>` without `:connectable` got no `.connectable` class — and XYHandle's DOM query targets `.connectable` to find drop targets, so connections to those handles silently failed. Also dropped the accidental `vue-flow__handle-null` class when a handle has no id.

6. **A11y description duplicated** — the node keyboard-instructions sentence rendered twice, and the full version rendered even when `disableKeyboardA11y` was set. Deduped and gated on `!disableKeyboardA11y`.

## Regression guards
- `customNode.cy.ts`: a custom node's handles carry `.connectable` by default and no `vue-flow__handle-null`.
- `setState.cy.ts`: `setState({ nodes, nodeExtent })` clamps the preloaded node.

## Deferred (not in this PR)
`getSelectionChanges`' in-place `mutateItem` writes onto markRaw'd lookup nodes can desync the lookup from the user nodes under `applyDefault: false`. That's a selection-timing behavior change (the in-place write is a deliberate "deselect-previous-immediately" hack) and needs dedicated drag/multi-select tests — worth its own PR.

## Verification
`vue-tsc` clean; full cypress suite 145/145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)