### PR TITLE
refactor(core)!: node event payloads emit the user Node

### DIFF
--- a/.changeset/node-event-payloads-user-node.md
+++ b/.changeset/node-event-payloads-user-node.md
@@ -1,0 +1,18 @@
+---
+"@vue-flow/core": major
+---
+
+Node event payloads now carry the user `Node` instead of the enriched `InternalNode` (xyflow/react + svelte parity).
+
+`nodeClick`/`nodeMouseEnter`/`nodeMouseMove`/`nodeMouseLeave`/`nodeContextMenu`/`nodeDoubleClick`, `nodeDragStart`/`nodeDrag`/`nodeDragStop`, `selectionDragStart`/`selectionDrag`/`selectionDragStop`, `selectionContextMenu`, the minimap node events, and `nodesInitialized` all emit user `Node`s now.
+
+If a handler read store-computed fields off the event node (`node.internals.positionAbsolute`, `node.internals.z`, `node.internals.handleBounds`, authoritative `node.measured`), resolve the enriched node from the id instead:
+
+```ts
+onNodeDrag(({ node }) => {
+  const internal = getInternalNode(node.id) // or useInternalNode(() => node.id)
+  // internal.internals.positionAbsolute, internal.measured, …
+})
+```
+
+`nodesInitialized` is also now typed with a payload (`NodeType[]`) on the component emit, matching the hook.

--- a/packages/core/src/components/MiniMap/MiniMap.vue
+++ b/packages/core/src/components/MiniMap/MiniMap.vue
@@ -177,31 +177,31 @@ function onSvgClick(event: MouseEvent) {
 }
 
 function onNodeClick(event: MouseEvent, node: GraphNode) {
-  const param = { event, node, connectedEdges: getConnectedEdges([node], edges.value) }
+  const param = { event, node: node.internals.userNode, connectedEdges: getConnectedEdges([node], edges.value) }
   emits.miniMapNodeClick(param)
   emit('nodeClick', param)
 }
 
 function onNodeDblClick(event: MouseEvent, node: GraphNode) {
-  const param = { event, node, connectedEdges: getConnectedEdges([node], edges.value) }
+  const param = { event, node: node.internals.userNode, connectedEdges: getConnectedEdges([node], edges.value) }
   emits.miniMapNodeDoubleClick(param)
   emit('nodeDblclick', param)
 }
 
 function onNodeMouseEnter(event: MouseEvent, node: GraphNode) {
-  const param = { event, node, connectedEdges: getConnectedEdges([node], edges.value) }
+  const param = { event, node: node.internals.userNode, connectedEdges: getConnectedEdges([node], edges.value) }
   emits.miniMapNodeMouseEnter(param)
   emit('nodeMouseenter', param)
 }
 
 function onNodeMouseMove(event: MouseEvent, node: GraphNode) {
-  const param = { event, node, connectedEdges: getConnectedEdges([node], edges.value) }
+  const param = { event, node: node.internals.userNode, connectedEdges: getConnectedEdges([node], edges.value) }
   emits.miniMapNodeMouseMove(param)
   emit('nodeMousemove', param)
 }
 
 function onNodeMouseLeave(event: MouseEvent, node: GraphNode) {
-  const param = { event, node, connectedEdges: getConnectedEdges([node], edges.value) }
+  const param = { event, node: node.internals.userNode, connectedEdges: getConnectedEdges([node], edges.value) }
   emits.miniMapNodeMouseLeave(param)
   emit('nodeMouseleave', param)
 }

--- a/packages/core/src/components/Nodes/NodeWrapper.ts
+++ b/packages/core/src/components/Nodes/NodeWrapper.ts
@@ -296,35 +296,35 @@ const NodeWrapper = defineComponent({
     function onMouseEnter(event: MouseEvent) {
       const node = nodeRef.value
       if (node && !dragging?.value) {
-        emit.mouseEnter({ event, node })
+        emit.mouseEnter({ event, node: node.internals.userNode })
       }
     }
 
     function onMouseMove(event: MouseEvent) {
       const node = nodeRef.value
       if (node && !dragging?.value) {
-        emit.mouseMove({ event, node })
+        emit.mouseMove({ event, node: node.internals.userNode })
       }
     }
 
     function onMouseLeave(event: MouseEvent) {
       const node = nodeRef.value
       if (node && !dragging?.value) {
-        emit.mouseLeave({ event, node })
+        emit.mouseLeave({ event, node: node.internals.userNode })
       }
     }
 
     function onContextMenu(event: MouseEvent) {
       const node = nodeRef.value
       if (node) {
-        emit.contextMenu({ event, node })
+        emit.contextMenu({ event, node: node.internals.userNode })
       }
     }
 
     function onDoubleClick(event: MouseEvent) {
       const node = nodeRef.value
       if (node) {
-        emit.doubleClick({ event, node })
+        emit.doubleClick({ event, node: node.internals.userNode })
       }
     }
 
@@ -335,6 +335,7 @@ const NodeWrapper = defineComponent({
       }
 
       if (isSelectable.value && (!selectNodesOnDrag.value || !isDraggable.value || nodeDragThreshold.value > 0)) {
+        // handleNodeClick needs the enriched InternalNode; the event payload gets the user node
         handleNodeClick(
           node,
           multiSelectionActive.value,
@@ -346,7 +347,7 @@ const NodeWrapper = defineComponent({
         )
       }
 
-      emit.click({ event, node })
+      emit.click({ event, node: node.internals.userNode })
     }
 
     function onKeyDown(event: KeyboardEvent) {

--- a/packages/core/src/components/NodesSelection/NodesSelection.vue
+++ b/packages/core/src/components/NodesSelection/NodesSelection.vue
@@ -3,7 +3,7 @@ import { computed, onMounted, ref } from 'vue'
 import { getNodesBounds } from '@xyflow/system'
 import { useDrag, useUpdateNodePositions, useVueFlow } from '../../composables'
 import { arrowKeyDiffs } from '../../utils'
-import type { GraphNode } from '../../types'
+import type { GraphNode, Node } from '../../types'
 
 const { emits, viewport, getSelectedNodes, nodeLookup, noPanClassName, disableKeyboardA11y, userSelectionActive } = useVueFlow()
 
@@ -44,16 +44,7 @@ const innerStyle = computed(() => ({
 }))
 
 function onContextMenu(event: MouseEvent) {
-  // resolve the enriched InternalNodes for the event payload (`getSelectedNodes` is user-facing)
-  const nodes = getSelectedNodes.value.reduce<GraphNode[]>((acc, node) => {
-    const internalNode = nodeLookup.get(node.id)
-    if (internalNode) {
-      acc.push(internalNode)
-    }
-    return acc
-  }, [])
-
-  emits.selectionContextMenu({ event, nodes })
+  emits.selectionContextMenu({ event, nodes: [...getSelectedNodes.value] as unknown as Node[] })
 }
 
 function onKeyDown(event: KeyboardEvent) {

--- a/packages/core/src/composables/useDrag.ts
+++ b/packages/core/src/composables/useDrag.ts
@@ -2,7 +2,7 @@ import type { CoordinateExtent, EdgeBase, InternalNodeBase, NodeBase, NodeDragIt
 import { XYDrag, infiniteExtent, isCoordinateExtent } from '@xyflow/system'
 import type { MaybeRefOrGetter, Ref } from 'vue'
 import { shallowRef, toValue, watchEffect } from 'vue'
-import type { NodeDragEvent, NodeDragItem } from '../types'
+import type { Node, NodeDragEvent, NodeDragItem } from '../types'
 import { useVueFlow } from '.'
 
 interface UseDragParams {
@@ -119,38 +119,19 @@ export function useDrag(params: UseDragParams) {
         },
         autoPanSpeed: autoPanSpeed.value,
       }),
+      // XYDrag hands user nodes (the InternalNode's `userNode`, spread with the live drag position +
+      // `dragging`), which is exactly the event payload — emit them directly, no lookup round-trip
       onDragStart: (event, _dragItems, node, nodes) => {
         dragFired = true
         dragging.value = true
-        const graphNode = getInternalNode(node.id)
-        if (graphNode) {
-          onStart({
-            event,
-            node: graphNode,
-            nodes: nodes.map((n) => getInternalNode(n.id)!).filter(Boolean),
-          })
-        }
+        onStart({ event, node: node as Node, nodes: nodes as Node[] })
       },
       onDrag: (event, _dragItems, node, nodes) => {
-        const graphNode = getInternalNode(node.id)
-        if (graphNode) {
-          onDrag({
-            event,
-            node: graphNode,
-            nodes: nodes.map((n) => getInternalNode(n.id)!).filter(Boolean),
-          })
-        }
+        onDrag({ event, node: node as Node, nodes: nodes as Node[] })
       },
       onDragStop: (event, _dragItems, node, nodes) => {
         dragging.value = false
-        const graphNode = getInternalNode(node.id)
-        if (graphNode) {
-          onStop({
-            event,
-            node: graphNode,
-            nodes: nodes.map((n) => getInternalNode(n.id)!).filter(Boolean),
-          })
-        }
+        onStop({ event, node: node as Node, nodes: nodes as Node[] })
       },
     })
 

--- a/packages/core/src/container/NodeRenderer/NodeRenderer.vue
+++ b/packages/core/src/container/NodeRenderer/NodeRenderer.vue
@@ -15,8 +15,7 @@ watch(
   (isInit) => {
     if (isInit) {
       nextTick(() => {
-        // emit the enriched InternalNodes (the event payload stays rich; `getNodes` is user-facing)
-        emits.nodesInitialized(Array.from(nodeLookup.values()))
+        emits.nodesInitialized(Array.from(nodeLookup.values(), (node) => node.internals.userNode))
       })
     }
   },

--- a/packages/core/src/types/flow.ts
+++ b/packages/core/src/types/flow.ts
@@ -3,7 +3,7 @@ import type { KeyFilter } from '@vueuse/core'
 import type { PanOnScrollMode, Viewport } from '@xyflow/system'
 import type { VueFlowError } from '../utils'
 import type { DefaultEdgeOptions, Edge, EdgeProps, EdgeReconnectable } from './edge'
-import type { CoordinateExtent, CoordinateExtentRange, GraphNode, Node, NodeProps } from './node'
+import type { CoordinateExtent, CoordinateExtentRange, Node, NodeProps } from './node'
 import type {
   Connection,
   ConnectionLineOptions,
@@ -173,7 +173,7 @@ export interface FlowProps<NodeType extends Node = Node, EdgeType extends Edge =
 export interface FlowEmits<NodeType extends Node = Node, EdgeType extends Edge = Edge> {
   (event: 'nodesChange', changes: NodeChange<NodeType>[]): void
   (event: 'edgesChange', changes: EdgeChange<EdgeType>[]): void
-  (event: 'nodesInitialized'): void
+  (event: 'nodesInitialized', nodes: NodeType[]): void
   (event: 'miniMapNodeClick', nodeMouseEvent: NodeMouseEvent<NodeType>): void
   (event: 'miniMapNodeDoubleClick', nodeMouseEvent: NodeMouseEvent<NodeType>): void
   (event: 'miniMapNodeMouseEnter', nodeMouseEvent: NodeMouseEvent<NodeType>): void
@@ -200,7 +200,7 @@ export interface FlowEmits<NodeType extends Node = Node, EdgeType extends Edge =
   (event: 'selectionDragStart', selectionEvent: NodeDragEvent<NodeType>): void
   (event: 'selectionDrag', selectionEvent: NodeDragEvent<NodeType>): void
   (event: 'selectionDragStop', selectionEvent: NodeDragEvent<NodeType>): void
-  (event: 'selectionContextMenu', selectionEvent: { event: MouseEvent; nodes: GraphNode[] }): void
+  (event: 'selectionContextMenu', selectionEvent: { event: MouseEvent; nodes: NodeType[] }): void
   (event: 'selectionStart', selectionEvent: MouseEvent): void
   (event: 'selectionEnd', selectionEvent: MouseEvent): void
   (event: 'viewportChangeStart', viewport: Viewport): void

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -1,7 +1,7 @@
 import type { Viewport } from '@xyflow/system'
 import type { EventHookExtended, EventHookOn, EventHookTrigger, VueFlowError } from '../utils'
 import type { Edge } from './edge'
-import type { GraphNode, Node } from './node'
+import type { Node } from './node'
 import type { Connection, OnConnectStartParams } from './connection'
 import type { EdgeChange, NodeChange } from './changes'
 import type { VueFlowStore } from './store'
@@ -10,13 +10,13 @@ export type MouseTouchEvent = MouseEvent | TouchEvent
 
 export interface NodeMouseEvent<NodeType extends Node = Node> {
   event: MouseTouchEvent
-  node: GraphNode<NodeType>
+  node: NodeType
 }
 
 export interface NodeDragEvent<NodeType extends Node = Node> {
   event: MouseTouchEvent
-  node: GraphNode<NodeType>
-  nodes: GraphNode<NodeType>[]
+  node: NodeType
+  nodes: NodeType[]
 }
 
 export interface EdgeMouseEvent<EdgeType extends Edge = Edge> {
@@ -42,7 +42,7 @@ export interface FlowEvents<NodeType extends Node = Node, EdgeType extends Edge 
   nodeDragStart: NodeDragEvent<NodeType>
   nodeDrag: NodeDragEvent<NodeType>
   nodeDragStop: NodeDragEvent<NodeType>
-  nodesInitialized: GraphNode[]
+  nodesInitialized: NodeType[]
   updateNodeInternals: string[]
   miniMapNodeClick: NodeMouseEvent<NodeType>
   miniMapNodeDoubleClick: NodeMouseEvent<NodeType>
@@ -65,7 +65,7 @@ export interface FlowEvents<NodeType extends Node = Node, EdgeType extends Edge 
   selectionDragStart: NodeDragEvent<NodeType>
   selectionDrag: NodeDragEvent<NodeType>
   selectionDragStop: NodeDragEvent<NodeType>
-  selectionContextMenu: { event: MouseEvent; nodes: GraphNode[] }
+  selectionContextMenu: { event: MouseEvent; nodes: NodeType[] }
   selectionStart: MouseEvent
   selectionEnd: MouseEvent
   viewportChangeStart: Viewport

--- a/tests/cypress/component/2-vue-flow/eventPayloads.cy.ts
+++ b/tests/cypress/component/2-vue-flow/eventPayloads.cy.ts
@@ -1,0 +1,42 @@
+import type { VueFlowStore } from '@vue-flow/core'
+import { getStore } from '../../support/component'
+
+// xyflow parity: node event payloads carry the USER node (no `internals`), not the enriched
+// InternalNode. The enriched node stays reachable via getInternalNode(id).
+describe('node event payloads are user nodes', () => {
+  let store: VueFlowStore
+
+  beforeEach(() => {
+    cy.vueFlow({
+      fitViewOnInit: false,
+      nodes: [
+        { id: '1', type: 'default', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
+        { id: '2', type: 'default', position: { x: 200, y: 0 }, data: { label: 'Node 2' } },
+      ],
+    })
+
+    cy.then(() => {
+      store = getStore()
+    })
+  })
+
+  it('onNodeClick delivers the user node, not the InternalNode', () => {
+    let payload: { node: any } | undefined
+    cy.then(() => {
+      store.onNodeClick((p) => {
+        payload = p
+      })
+    })
+
+    cy.get('[data-id="1"]').click()
+
+    cy.tryAssertion(() => {
+      expect(payload, 'nodeClick fired').to.not.be.undefined
+      expect(payload!.node.id).to.eq('1')
+      // the payload is the user node — no enriched `internals` field
+      expect('internals' in payload!.node, 'payload node has no internals').to.eq(false)
+      // ...but the enriched InternalNode is still reachable through the accessor
+      expect(store.getInternalNode('1')).to.have.property('internals')
+    })
+  })
+})


### PR DESCRIPTION
Closes the event-payload drift from the 2.0 audit (F13/F14). Builds on the merged edge-split (which already flipped *edge* event payloads to the user `Edge`) — this does the node side.

## What

Node events handed consumers the enriched `InternalNode` (`GraphNode`). xyflow/RF/SF deliver the **user node** — system's `getEventHandlerParams` returns `internals.userNode` (spread with the live drag position), and vue-flow's `useDrag` was actively converting that *back* to the InternalNode before emitting. All node event payloads now carry the user `Node`:

- `NodeMouseEvent.node` / `NodeDragEvent.node` + `.nodes`
- `nodeClick` / `nodeMouseEnter|Move|Leave` / `nodeContextMenu` / `nodeDoubleClick`
- `nodeDragStart|Drag|DragStop`, `selectionDragStart|Drag|DragStop`
- `selectionContextMenu.nodes`
- minimap node events
- `nodesInitialized` → `NodeType[]` (and `FlowEmits` now declares the payload — it was previously typed payloadless while the hook carried the array, the F14 mismatch)

`useDrag` emits the system-provided user nodes directly (no `getInternalNode` round-trip); `NodeWrapper`/`MiniMap`/`NodeRenderer`/`NodesSelection` emit `internals.userNode` / the user-node accessor.

## Why

This was the **one remaining channel that handed out mutable internals**, contradicting the DeepReadonly user-node accessor model the rest of 2.0 adopted. It also reverses the earlier #40 "keep events rich" decision — done deliberately, per the maintainer, for full xyflow parity.

## Migration

A handler reading store-computed fields off the event node resolves the enriched node by id:

```ts
onNodeDrag(({ node }) => {
  const internal = getInternalNode(node.id) // or useInternalNode(() => node.id)
  // internal.internals.positionAbsolute, internal.measured, internal.internals.z …
})
```

Drag-event nodes carry the live drag position (system spreads `{ ...userNode, position, dragging }`), so position is current without touching internals.

## Verification

- `vue-tsc` clean in core **and** examples/vite (no example read internals off an event node).
- Regression guard `eventPayloads.cy.ts`: `onNodeClick`'s payload node has no `internals`, while `getInternalNode(id)` still does.
- Full suite green modulo the pre-existing rotating synthetic-drag/browser-load flake (the two specs that flagged in the full run pass 3/3 + 7/7 in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)