### PR TITLE
refactor(core)!: dead-code sweep (2.0 cleanup)

### DIFF
--- a/.changeset/dead-code-sweep.md
+++ b/.changeset/dead-code-sweep.md
@@ -1,0 +1,13 @@
+---
+"@vue-flow/core": major
+---
+
+Remove dead code and unused public surface (2.0 cleanup).
+
+Removed public API (all were unused / never emitted):
+
+- `ErrorCode.EDGE_ORPHANED` and `ErrorCode.EDGE_SOURCE_TARGET_SAME` — never constructed anywhere; they described behavior that no longer exists.
+- Unused exported types: `MaybeElement`, `XYZPosition`, `Box`, `NodeBounds`, `NodeHandle`, `ConnectionHandle` (distinct from the still-present `ConnectingHandle`).
+- `IsValidParams.nodeLookup` — `isValidHandle` reads the node lookup from a separate argument; the field was redundant.
+
+Internal-only cleanup (no API change): dropped the unused `on` half of `useNodeHooks`/`useEdgeHooks` (the `NodeEventsOn`/`EdgeEventsOn` types are kept), an unreachable guard in the connection line, a dead parameter in an internal handle helper, and a shadowed no-op. Stale `@deprecated`/JSDoc wording (`onPaneReady`, "removed in the next major", "global storage") was corrected — `applyDefault` and `autoConnect` are no longer tagged `@deprecated` (they are kept).

--- a/docs/src/guide/troubleshooting.md
+++ b/docs/src/guide/troubleshooting.md
@@ -87,17 +87,9 @@ const edges = ref([
 - **Description:** An edge's type has no corresponding component defined.
 - **Fix:** Define a component for every edge-type you use to ensure correct rendering of your custom edges.
 
-### EDGE_SOURCE_TARGET_SAME
-- **Description:** An edge's source and target are the same node.
-- **Fix:** If this is intentional, you can ignore this error. Otherwise, ensure the source and target nodes are different.
-
 ### EDGE_SOURCE_TARGET_MISSING
 - **Description:** Both, the source *and* target nodes are missing from an edge.
 - **Fix:** Ensure both the source and target nodes exist and are correctly set for each edge.
-
-### EDGE_ORPHANED
-- **Description:** An edge has lost its source or target node, likely due to node deletion.
-- **Fix:** If you intentionally orphaned the edge, you can ignore this error. Otherwise, ensure the source and target nodes exist or that you clean up edges before they are orphaned.
 
 ## Evaluating Errors During Runtime
 

--- a/packages/core/src/components/ConnectionLine/index.ts
+++ b/packages/core/src/components/ConnectionLine/index.ts
@@ -60,10 +60,6 @@ const ConnectionLine = defineComponent({
         handleBounds = [...handleBounds, ...oppositeBounds]
       }
 
-      if (!handleBounds) {
-        return null
-      }
-
       const fromHandle = (startHandleId ? handleBounds.find((d) => d.id === startHandleId) : handleBounds[0]) ?? null
       const fromPosition = fromHandle?.position ?? Position.Top
       const { x: fromX, y: fromY } = getHandlePosition(fromNode.value, fromHandle, fromPosition)

--- a/packages/core/src/composables/useEdgeHooks.ts
+++ b/packages/core/src/composables/useEdgeHooks.ts
@@ -1,4 +1,4 @@
-import type { EdgeEventsEmit, EdgeEventsOn, VueFlowStore } from '../types'
+import type { EdgeEventsEmit, VueFlowStore } from '../types'
 import { createExtendedEventHook } from '../utils'
 
 function createEdgeHooks() {
@@ -20,7 +20,7 @@ function createEdgeHooks() {
  *
  * @internal
  */
-export function useEdgeHooks(emits: VueFlowStore['emits']): { emit: EdgeEventsEmit; on: EdgeEventsOn } {
+export function useEdgeHooks(emits: VueFlowStore['emits']): { emit: EdgeEventsEmit } {
   const edgeHooks = createEdgeHooks()
 
   edgeHooks.doubleClick.on((event) => {
@@ -62,10 +62,9 @@ export function useEdgeHooks(emits: VueFlowStore['emits']): { emit: EdgeEventsEm
   return Object.entries(edgeHooks).reduce(
     (hooks, [key, value]) => {
       hooks.emit[key as keyof EdgeEventsEmit] = value.trigger
-      hooks.on[key as keyof EdgeEventsOn] = value.on
 
       return hooks
     },
-    { emit: {} as EdgeEventsEmit, on: {} as EdgeEventsOn },
+    { emit: {} as EdgeEventsEmit },
   )
 }

--- a/packages/core/src/composables/useHandle.ts
+++ b/packages/core/src/composables/useHandle.ts
@@ -248,7 +248,6 @@ export function useHandle({
         doc,
         lib: 'vue',
         flowId,
-        nodeLookup,
       },
       edges.value,
       nodes.value,

--- a/packages/core/src/composables/useNodeHooks.ts
+++ b/packages/core/src/composables/useNodeHooks.ts
@@ -1,4 +1,4 @@
-import type { NodeEventsEmit, NodeEventsOn, VueFlowStore } from '../types'
+import type { NodeEventsEmit, VueFlowStore } from '../types'
 import { createExtendedEventHook } from '../utils'
 
 function createNodeHooks() {
@@ -20,7 +20,7 @@ function createNodeHooks() {
  *
  * @internal
  */
-export function useNodeHooks(emits: VueFlowStore['emits']): { emit: NodeEventsEmit; on: NodeEventsOn } {
+export function useNodeHooks(emits: VueFlowStore['emits']): { emit: NodeEventsEmit } {
   const nodeHooks = createNodeHooks()
 
   nodeHooks.doubleClick.on((event) => {
@@ -62,9 +62,8 @@ export function useNodeHooks(emits: VueFlowStore['emits']): { emit: NodeEventsEm
   return Object.entries(nodeHooks).reduce(
     (hooks, [key, value]) => {
       hooks.emit[key as keyof NodeEventsEmit] = value.trigger
-      hooks.on[key as keyof NodeEventsOn] = value.on
       return hooks
     },
-    { emit: {} as NodeEventsEmit, on: {} as NodeEventsOn },
+    { emit: {} as NodeEventsEmit },
   )
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,9 +53,8 @@ export {
 export { isNode, isEdge, isGraphNode, connectionExists } from './utils/graph'
 
 /**
- * @deprecated - Use store instance and call `applyChanges` with template-ref or the one received by `onPaneReady` instead
- * Intended for options API
- * In composition API you can access apply utilities from `useVueFlow`
+ * @deprecated Prefer the store instance's `applyChanges`/`applyNodeChanges`/`applyEdgeChanges` (from
+ * `useVueFlow`, or the instance received by `onInit`). Kept for the options API.
  */
 export { applyChanges, applyEdgeChanges, applyNodeChanges } from './utils/changes'
 

--- a/packages/core/src/types/flow.ts
+++ b/packages/core/src/types/flow.ts
@@ -21,8 +21,6 @@ import type { VueFlowStore } from './store'
 // todo: should be object type
 export type ElementData = any
 
-export type MaybeElement = Node | Edge | Connection | Element
-
 export interface CustomThemeVars {
   [key: string]: string | number | undefined
 }
@@ -51,16 +49,9 @@ export interface XYPosition {
   y: number
 }
 
-export type XYZPosition = XYPosition & { z: number }
-
 export interface Dimensions {
   width: number
   height: number
-}
-
-export interface Box extends XYPosition {
-  x2: number
-  y2: number
 }
 
 export interface Rect extends Dimensions, XYPosition {}
@@ -143,12 +134,10 @@ export interface FlowProps<NodeType extends Node = Node, EdgeType extends Edge =
   connectOnClick?: boolean
   /**
    * apply default change handlers for position, dimensions, adding/removing nodes. set this to false if you want to apply the changes manually
-   * @deprecated - will be removed in the next major version, changes will not be auto applied in the future
    */
   applyDefault?: boolean
   /**
    * automatically create an edge when connection is triggered
-   * @deprecated - will be removed in the next major version
    */
   autoConnect?: boolean | Connector
   noDragClassName?: string

--- a/packages/core/src/types/handle.ts
+++ b/packages/core/src/types/handle.ts
@@ -2,7 +2,6 @@ import type { Dimensions, Position, XYPosition } from './flow'
 import type { Connection, ConnectionMode } from './connection'
 import type { GraphNode, Node } from './node'
 import type { Edge } from './edge'
-import type { NodeLookup } from './store'
 
 export type HandleType = 'source' | 'target'
 
@@ -10,12 +9,6 @@ export interface HandleElement extends XYPosition, Dimensions {
   id?: string | null
   position: Position
   type: HandleType
-  nodeId: string
-}
-
-export interface ConnectionHandle extends XYPosition {
-  id: string | null
-  type: HandleType | null
   nodeId: string
 }
 
@@ -70,7 +63,6 @@ export interface IsValidParams {
   doc: Document | ShadowRoot
   lib: string
   flowId: string | null
-  nodeLookup: NodeLookup
 }
 
 export interface Result {

--- a/packages/core/src/types/node.ts
+++ b/packages/core/src/types/node.ts
@@ -1,7 +1,7 @@
 import type { InternalNodeBase, NodeBase } from '@xyflow/system'
 import type { HTMLAttributes } from 'vue'
-import type { Position, Styles, XYPosition } from './flow'
-import type { HandleElement, HandleType } from './handle'
+import type { Styles } from './flow'
+import type { HandleElement } from './handle'
 
 /** Defined as [[x-from, y-from], [x-to, y-to]] */
 export type CoordinateExtent = [extentFrom: [fromX: number, fromY: number], extentTo: [toX: number, toY: number]]
@@ -24,28 +24,6 @@ export interface CoordinateExtentRange {
  * system d.ts (its `Optional<T, K>` utility trips vuejs/core#14236). Structurally identical to system's.
  */
 export type NodeOrigin = [number, number]
-
-/**
- * Bounding box for a node — system shape.
- *
- * Locally defined; see {@link NodeOrigin}.
- */
-export type NodeBounds = XYPosition & { width: number | null; height: number | null }
-
-/**
- * Handle data attached to a node — system shape.
- *
- * Locally defined; see {@link NodeOrigin}.
- */
-export interface NodeHandle {
-  id?: string | null
-  position: Position
-  type: HandleType
-  x: number
-  y: number
-  width?: number
-  height?: number
-}
 
 export interface NodeHandleBounds {
   source: HandleElement[] | null

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -315,7 +315,7 @@ export interface Actions<NodeType extends Node = Node, EdgeType extends Edge = E
   /** reset state to defaults */
   $reset: () => void
 
-  /** remove store instance from global storage and destroy it (will invalidate effect scopes) */
+  /** destroy the store instance (invalidates its effect scopes); runs the `onDestroy` hook if one was set */
   $destroy: () => void
 }
 

--- a/packages/core/src/utils/changes.ts
+++ b/packages/core/src/utils/changes.ts
@@ -126,12 +126,12 @@ export function applyChanges<
   return next
 }
 
-/** @deprecated Use store instance and call `applyChanges` with template-ref or the one received by `onPaneReady` instead */
+/** @deprecated Prefer the store instance's apply methods (from `useVueFlow` or the `onInit` instance). */
 export function applyEdgeChanges(changes: EdgeChange[], edges: Edge[]) {
   return applyChanges(changes, edges)
 }
 
-/** @deprecated Use store instance and call `applyChanges` with template-ref or the one received by `onPaneReady` instead */
+/** @deprecated Prefer the store instance's apply methods (from `useVueFlow` or the `onInit` instance). */
 export function applyNodeChanges(changes: NodeChange[], nodes: GraphNode[]) {
   return applyChanges(changes, nodes)
 }

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -11,9 +11,7 @@ export enum ErrorCode {
   EDGE_SOURCE_MISSING = 'EDGE_SOURCE_MISSING',
   EDGE_TARGET_MISSING = 'EDGE_TARGET_MISSING',
   EDGE_TYPE_MISSING = 'EDGE_TYPE_MISSING',
-  EDGE_SOURCE_TARGET_SAME = 'EDGE_SOURCE_TARGET_SAME',
   EDGE_SOURCE_TARGET_MISSING = 'EDGE_SOURCE_TARGET_MISSING',
-  EDGE_ORPHANED = 'EDGE_ORPHANED',
 
   USE_VUE_FLOW_OUTSIDE_PROVIDER = 'USE_VUE_FLOW_OUTSIDE_PROVIDER',
 }
@@ -34,12 +32,8 @@ const messages = {
   [ErrorCode.EDGE_TARGET_MISSING]: (id: string, target: string) =>
     `Edge target is missing\nEdge id: ${id} \nTarget id: ${target}`,
   [ErrorCode.EDGE_TYPE_MISSING]: (type: string) => `Edge type is missing\nType: ${type}`,
-  [ErrorCode.EDGE_SOURCE_TARGET_SAME]: (id: string, source: string, target: string) =>
-    `Edge source and target are the same\nEdge id: ${id} \nSource id: ${source} \nTarget id: ${target}`,
   [ErrorCode.EDGE_SOURCE_TARGET_MISSING]: (id: string, source: string, target: string) =>
     `Edge source or target is missing\nEdge id: ${id} \nSource id: ${source} \nTarget id: ${target}`,
-  [ErrorCode.EDGE_ORPHANED]: (id: string) =>
-    `Edge was orphaned (suddenly missing source or target) and has been removed\nEdge id: ${id}`,
   [ErrorCode.EDGE_NOT_FOUND]: (id: string) => `Edge not found\nEdge id: ${id}`,
   [ErrorCode.USE_VUE_FLOW_OUTSIDE_PROVIDER]: () =>
     `useVueFlow() was called without a <VueFlow> or <VueFlowProvider> ancestor (or outside a component setup). Render one of them above the call, or wrap your components in <VueFlowProvider> to share a store.`,

--- a/packages/core/src/utils/handle.ts
+++ b/packages/core/src/utils/handle.ts
@@ -4,10 +4,8 @@ import type { Actions, Connection, Edge, HandleElement, HandleType, IsValidParam
 
 const alwaysValid = () => true
 
-export function getHandleType(reconnectHandleType: HandleType | undefined, handleDomNode: Element | null): HandleType | null {
-  if (reconnectHandleType) {
-    return reconnectHandleType
-  } else if (handleDomNode?.classList.contains('target')) {
+function getHandleType(handleDomNode: Element | null): HandleType | null {
+  if (handleDomNode?.classList.contains('target')) {
     return 'target'
   } else if (handleDomNode?.classList.contains('source')) {
     return 'source'
@@ -76,7 +74,7 @@ export function isValidHandle(
   }
 
   if (handleToCheck) {
-    const handleType = getHandleType(undefined, handleToCheck)
+    const handleType = getHandleType(handleToCheck)
     const handleNodeId = handleToCheck.getAttribute('data-nodeid')
     const handleId = handleToCheck.getAttribute('data-handleid')
     const connectable = handleToCheck.classList.contains('connectable')


### PR DESCRIPTION
Removes verified-dead code + unused public surface from the 2.0 audit. Every candidate was grep-confirmed to have zero references across `packages/core/src`, `index.ts`, `examples/`, `docs/`, and `tests/` before removal (a finder pass produced the evidence; I re-verified against the current post-refactor code, since the original audit predated the edge-split/parity/event-payload work — a few items it flagged were already gone, e.g. `ConnectionInProgress`, the `vue/macros-global` ref).

## Removed — public (breaking)
- **ErrorCodes** `EDGE_ORPHANED` + `EDGE_SOURCE_TARGET_SAME` (+ their message entries + troubleshooting-guide sections). Never constructed anywhere; they described behavior that no longer exists. Since they were never emitted, no `catch` on them could ever have fired.
- **Unused exported types**: `MaybeElement`, `XYZPosition`, `Box`, `NodeBounds`, `NodeHandle`, `ConnectionHandle` (distinct from the still-present `ConnectingHandle`). Zero consumers anywhere — v1 leftovers.
- **`IsValidParams.nodeLookup`** — redundant; `isValidHandle` reads the lookup from a separate positional argument (the field was set at the call site but never read off the object).

## Removed/fixed — internal (no API change)
- The `on` half of `useNodeHooks`/`useEdgeHooks` — never destructured (both wrappers use only `{ emit }`). The `NodeEventsOn`/`EdgeEventsOn` **types** are kept (public + documented).
- Unreachable `if (!handleBounds)` guard in `ConnectionLine` (`handleBounds` is always an array).
- Dead `reconnectHandleType` param + branch in the internal `getHandleType` (its sole caller always passed `undefined`); also un-exported it.
- The shadowed no-op `$destroy: () => {}` in actions is **kept** (it's required by the `Actions` return type; the real one in `createStore` overrides it) — only its stale "global storage" JSDoc was corrected.

## Comment/wording
- `onPaneReady` → `onInit` in the deprecated `applyChanges`/`applyNodeChanges`/`applyEdgeChanges` JSDoc (the hook is `init`).
- Dropped the false `@deprecated - will be removed in the next major version` on `applyDefault`/`autoConnect` — this *is* the next major and they're deliberately kept.

## Verification
`vue-tsc` clean in core + examples; eslint clean on all touched files (caught + fixed the now-unused imports the type removals left behind); full cypress suite **146/146**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)