### PR TITLE
fix(core): stop in-place selection mutation of the node lookup

### DIFF
--- a/.changeset/selection-no-inplace-mutate.md
+++ b/.changeset/selection-no-inplace-mutate.md
@@ -1,0 +1,7 @@
+---
+"@vue-flow/core": patch
+---
+
+Fix node selection desyncing the internal lookup under `applyDefault: false`. `getSelectionChanges` mutated the lookup node's `selected` in place as a synchronous "deselect the previous node" hack. With markRaw'd nodes that mutation didn't re-render, and with `applyDefault: false` (no auto-apply) it left the lookup's `selected` permanently out of sync with the user node — so `XYDrag` (which reads `selected` from the lookup) could pick up nodes the user's state considered unselected.
+
+The mutation is removed: selection now flows purely through the change pipeline (the synchronous `applyNodeChanges` re-adopt already produces the deselect-previous behavior). No change for `applyDefault: true`; under `applyDefault: false` the store no longer half-applies selection — you apply the emitted `select` changes yourself, as intended for controlled flow.

--- a/packages/core/src/container/Pane/Pane.vue
+++ b/packages/core/src/container/Pane/Pane.vue
@@ -191,7 +191,7 @@ function onPointerMove(event: PointerEvent) {
   }
 
   if (!areSetsEqual(prevSelectedNodeIds, selectedNodeIds.value)) {
-    const changes = getSelectionChanges(nodeLookup, selectedNodeIds.value, true) as NodeChange[]
+    const changes = getSelectionChanges(nodeLookup, selectedNodeIds.value) as NodeChange[]
     emits.nodesChange(changes)
   }
 

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -496,7 +496,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
       return
     }
 
-    state.hooks.nodesChange.trigger(getSelectionChanges(nodeLookup, new Set(nodes.map((n) => n.id)), true))
+    state.hooks.nodesChange.trigger(getSelectionChanges(nodeLookup, new Set(nodes.map((n) => n.id))))
     state.hooks.edgesChange.trigger(getSelectionChanges(edgeLookup))
   }
 
@@ -508,7 +508,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
     }
 
     state.hooks.edgesChange.trigger(getSelectionChanges(edgeLookup, new Set(edges.map((e) => e.id))))
-    state.hooks.nodesChange.trigger(getSelectionChanges(nodeLookup, new Set(), true))
+    state.hooks.nodesChange.trigger(getSelectionChanges(nodeLookup, new Set()))
   }
 
   const removeSelectedNodes: Actions<NodeType>['removeSelectedNodes'] = (nodes) => {

--- a/packages/core/src/utils/changes.ts
+++ b/packages/core/src/utils/changes.ts
@@ -172,7 +172,6 @@ export function createEdgeRemoveChange(id: string): EdgeRemoveChange {
 export function getSelectionChanges(
   items: Map<string, any>,
   selectedIds: Set<string> = new Set(),
-  mutateItem = false,
 ): NodeSelectionChange[] | EdgeSelectionChange[] {
   const changes: NodeSelectionChange[] | EdgeSelectionChange[] = []
 
@@ -181,12 +180,6 @@ export function getSelectionChanges(
 
     // we don't want to set all items to selected=false on the first selection
     if (!(item.selected === undefined && !willBeSelected) && item.selected !== willBeSelected) {
-      if (mutateItem) {
-        // this hack is needed for nodes. When the user dragged a node, it's selected.
-        // When another node gets dragged, we need to deselect the previous one,
-        // in order to have only one selected node at a time - the onNodesChange callback comes too late here :/
-        item.selected = willBeSelected
-      }
       changes.push(createSelectionChange(item.id, willBeSelected))
     }
   }

--- a/tests/cypress/component/1-store/nodes/selectionSync.cy.ts
+++ b/tests/cypress/component/1-store/nodes/selectionSync.cy.ts
@@ -1,0 +1,48 @@
+import type { VueFlowStore } from '@vue-flow/core'
+import { getStore } from '../../../support/component'
+
+const nodes = [
+  { id: '1', position: { x: 0, y: 0 }, data: {} },
+  { id: '2', position: { x: 200, y: 0 }, data: {} },
+]
+
+describe('selection sync (getSelectionChanges no longer mutates the lookup in place)', () => {
+  it('single-select replaces the previous selection (applyDefault: true)', () => {
+    cy.vueFlow({ nodes })
+
+    cy.then(() => {
+      const store = getStore()
+
+      store.addSelectedNodes([store.getNode('1')!])
+      expect(store.getNode('1')?.selected, 'node 1 selected').to.eq(true)
+
+      // selecting node 2 (not multi-select) must deselect node 1 — driven by the synchronous
+      // re-adopt, no in-place lookup mutation
+      store.addSelectedNodes([store.getNode('2')!])
+
+      expect(store.getNode('2')?.selected, 'node 2 selected').to.eq(true)
+      expect(!!store.getNode('1')?.selected, 'node 1 deselected').to.eq(false)
+
+      // lookup InternalNode and user node agree (no desync)
+      expect(store.getInternalNode('1')?.selected).to.eq(store.getNode('1')?.selected)
+      expect(store.getInternalNode('2')?.selected).to.eq(store.getNode('2')?.selected)
+    })
+  })
+
+  it('does not desync the lookup from the user node under applyDefault: false', () => {
+    cy.vueFlow({ nodes, applyDefault: false })
+
+    cy.then(() => {
+      const store = getStore()
+
+      // with applyDefault:false and no user change handler, the emitted select change is NOT applied —
+      // selection state must not change, and the lookup must stay consistent with the user node
+      store.addSelectedNodes([store.getNode('1')!])
+
+      expect(!!store.getNode('1')?.selected, 'user node unchanged (change not applied)').to.eq(false)
+      // the bug this guards: the old in-place mutation set the InternalNode's `selected` while the user
+      // node stayed false → permanent lookup/user desync (and XYDrag read the stale lookup value)
+      expect(store.getInternalNode('1')?.selected, 'lookup matches user node').to.eq(store.getNode('1')?.selected)
+    })
+  })
+})


### PR DESCRIPTION
The last deferred item from the 2.0 audit. `getSelectionChanges` mutated the lookup node's `selected` **in place** — a "deselect the previous node synchronously" hack (its comment: *"the onNodesChange callback comes too late here"*).

## Why it's wrong now

I traced the timing: `nodesChange.trigger` invokes its listeners synchronously, and the default handler calls `applyNodeChanges` → `commitNodes` → re-adopt **synchronously**. So:

- **`applyDefault: true`** — the re-adopt rebuilds the lookup entries (with correct `selected`) within the same `trigger` call and *overwrites* the mutated entry. The in-place mutation is **redundant** — the deselect-previous behavior comes from the re-adopt, not the hack. (The "callback comes too late" concern is obsolete against the current synchronous pipeline.)
- **`applyDefault: false`** — the handler isn't registered, so there's no re-adopt. The in-place write was then the *only* lookup mutation: with `markRaw`'d nodes it doesn't even re-render, and it left the lookup's `selected` **permanently out of sync** with the user node. `XYDrag` reads `selected` off the lookup, so multi-drag could grab nodes the user's state considered unselected.

## Fix

`getSelectionChanges` is now pure (dropped the `mutateItem` param — internal-only, not exported). The three call sites (`addSelectedNodes`, the edge-select node-deselect path, `Pane` box-select) drop the flag. Selection flows entirely through the change pipeline now, matching React Flow.

Behavior: identical for `applyDefault: true`; under `applyDefault: false` the store no longer half-applies selection — you apply the emitted `select` changes yourself (correct controlled-flow).

## Verification

- Guard `selectionSync.cy.ts`: single-select replaces the previous selection (`applyDefault: true`); and no lookup/user `selected` desync under `applyDefault: false`. The second test **fails against the old in-place mutation** (verified by stash/rebuild) and passes with the fix.
- All selection/drag specs (basic, drag, addSelectedNodes, deleteKeyCode, selectionKeyCode, addSelectedElements) pass; full suite **148/148**; `vue-tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)