### PR TITLE
fix(core): forward includeHiddenNodes from fitView to fitViewport

### DIFF
--- a/.changeset/fitview-include-hidden-nodes.md
+++ b/.changeset/fitview-include-hidden-nodes.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Fix `fitView`'s `includeHiddenNodes` option being ignored. It was accepted in `FitViewParams` (and defaulted to `false`) but never forwarded to the underlying `fitViewport` call, so `fitView({ includeHiddenNodes: true })` (and `:fit-view-on-init` with it) silently excluded hidden nodes. It's now passed through, so hidden nodes (that have known dimensions) participate in the fit when requested.

--- a/packages/core/src/composables/useViewportHelper.ts
+++ b/packages/core/src/composables/useViewportHelper.ts
@@ -101,6 +101,9 @@ export function useViewportHelper<NodeType extends Node = Node, EdgeType extends
             duration: options.duration,
             minZoom: options.minZoom,
             maxZoom: options.maxZoom,
+            // `fitViewport` forwards options to `getFitViewNodes`, which reads `includeHiddenNodes`/`nodes`
+            // at runtime — but its type `Omit`s them, so pass via spread (same as `nodes`) to satisfy TS.
+            ...(options.includeHiddenNodes ? { includeHiddenNodes: true } : {}),
             // system expects `(NodeType | { id })[]`; we accept `string[]` for ergonomics.
             ...(options.nodes?.length ? { nodes: options.nodes.map((id) => ({ id })) } : {}),
           },

--- a/tests/cypress/component/1-store/viewport-helper/fitView.cy.ts
+++ b/tests/cypress/component/1-store/viewport-helper/fitView.cy.ts
@@ -33,6 +33,32 @@ describe('Viewport Helper: `fitView`', () => {
     })
   })
 
+  it('includes hidden nodes only when `includeHiddenNodes` is set', () => {
+    cy.vueFlow({
+      fitViewOnInit: false,
+      nodes: [
+        { id: 'visible', position: { x: 0, y: 0 }, data: {}, measured: { width: 50, height: 50 } },
+        // truly hidden (no DOM, never DOM-measured) — seed `measured` so it can participate in fitView
+        { id: 'hidden', position: { x: 2000, y: 2000 }, hidden: true, data: {}, measured: { width: 50, height: 50 } },
+      ],
+    })
+
+    cy.then(() => {
+      store = getStore()
+    })
+
+    cy.wrap(null).then(() => {
+      return store.fitView().then(() => {
+        const defaultZoom = store.viewport.value.zoom
+        return store.fitView({ includeHiddenNodes: true }).then(() => {
+          const withHiddenZoom = store.viewport.value.zoom
+          // including the far-away hidden node widens the bounds → zooms further out
+          expect(withHiddenZoom, 'zoom changed once the hidden node is included').to.be.lessThan(defaultZoom)
+        })
+      })
+    })
+  })
+
   it('does not fit view when no node exist', () => {
     cy.vueFlow({
       nodes: [],


### PR DESCRIPTION
You were right to question this — `includeHiddenNodes` is a real, working option in `@xyflow/system` (and RF/SF expose it), not a dead one to remove. It was just **silently broken** in vue-flow.

## The bug

`fitView` declares `includeHiddenNodes` in `FitViewParams` and even defaults it to `false`, but the `fitViewport(...)` call built its options object with `padding`/`duration`/`minZoom`/`maxZoom`/`nodes` and **omitted `includeHiddenNodes`** — so the user's value was dropped and hidden nodes were always excluded.

System's `getFitViewNodes` gates each node on `measured.width && measured.height && (options?.includeHiddenNodes || !n.hidden)`, so forwarding the flag makes hidden (but measured) nodes participate.

## The fix

Forward `includeHiddenNodes` into the `fitViewport` options. There's a system types-vs-runtime quirk worth noting: `fitViewport`'s options type is `Omit<…, 'nodes' | 'includeHiddenNodes'>`, yet at runtime it forwards `options` straight to `getFitViewNodes` which reads both. The existing `nodes` forwarding already works around this with a conditional **spread** (a direct property trips the excess-property check; a spread doesn't), so I used the same pattern for `includeHiddenNodes`.

## Verification

Guard added in `fitView.cy.ts`: a far-away hidden node (seeded with `measured` dims, since a truly hidden node has no DOM and is never measured) widens the fit — and thus lowers the zoom — only when `includeHiddenNodes: true`. Verified it **fails against the dropped-option behavior** (stash/rebuild) and passes with the fix. Full suite 149/149; `vue-tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)