### PR TITLE
feat(core): add controlled viewport (v-model:viewport)

### DIFF
--- a/.changeset/controlled-viewport.md
+++ b/.changeset/controlled-viewport.md
@@ -1,0 +1,11 @@
+---
+"@vue-flow/core": minor
+---
+
+Add a controlled `viewport` prop with `v-model:viewport` support, matching `xyflow/react`'s controlled viewport and `xyflow/svelte`'s `bind:viewport`.
+
+```vue
+<VueFlow v-model:viewport="viewport" />
+```
+
+The bound value two-way binds to the flow's canonical transform: setting it pans/zooms the flow (applied via the panzoom's `syncViewport`, so no extra pan/zoom events fire), and it updates as the user interacts (via `update:viewport`). `defaultViewport` remains the uncontrolled initial-viewport prop; use `viewport` when you want to own the viewport state.

--- a/docs/src/guide/vue-flow/config.md
+++ b/docs/src/guide/vue-flow/config.md
@@ -505,7 +505,21 @@ const edges = ref([
 
 - Details:
 
-  The default viewport when the component is mounted.
+  The default viewport when the component is mounted. Ignored once the user pans/zooms (uncontrolled).
+
+### viewport (optional)
+
+- Type: `Viewport`
+
+- Details:
+
+  Controlled viewport (`v-model:viewport`). Keeps the flow's transform in sync with the bound value —
+  set it to pan/zoom programmatically, and it updates as the user interacts. Use this instead of
+  `default-viewport` when you want to own the viewport state.
+
+  ```vue
+  <VueFlow v-model:viewport="viewport" />
+  ```
 
 ### translate-extent (optional)
 

--- a/packages/core/src/composables/useViewportSync.ts
+++ b/packages/core/src/composables/useViewportSync.ts
@@ -1,0 +1,58 @@
+import type { Ref } from 'vue'
+import { watch } from 'vue'
+import type { Viewport } from '@xyflow/system'
+import type { Edge, Node, VueFlowStore } from '../types'
+import { useVueFlow } from './useVueFlow'
+
+function sameViewport(a: Viewport | undefined, b: Viewport | undefined) {
+  return !!a && !!b && a.x === b.x && a.y === b.y && a.zoom === b.zoom
+}
+
+/**
+ * Two-way binds the `viewport` v-model to the store's canonical `transform`, matching xyflow/react's
+ * controlled viewport and svelte's `bind:viewport`.
+ *
+ * - **in** (model → store): applies an externally-set `viewport` to the panzoom via `syncViewport` (which
+ *   doesn't fire pan/zoom events) and mirrors it onto `transform`. Re-runs once the panzoom mounts so the
+ *   controlled value wins over `ZoomPane`'s `defaultViewport` seed.
+ * - **out** (store → model): writes `transform` changes back to the model so the binding stays in sync.
+ *
+ * Equality guards on both sides stop the round-trip from looping.
+ *
+ * @internal
+ */
+export function useViewportSync<NodeType extends Node = Node, EdgeType extends Edge = Edge>(
+  model: Ref<Viewport | undefined>,
+  vfInstance: VueFlowStore<NodeType, EdgeType> = useVueFlow<NodeType, EdgeType>(),
+) {
+  const { transform, panZoom } = vfInstance
+
+  // also keyed on `panZoom` so the controlled value is re-applied once the instance mounts (its initial
+  // `defaultViewport` seed would otherwise clobber a transform set before mount)
+  watch(
+    [model, panZoom],
+    ([viewport]) => {
+      if (!viewport) {
+        return
+      }
+
+      const current = { x: transform.value[0], y: transform.value[1], zoom: transform.value[2] }
+      if (sameViewport(viewport, current)) {
+        return
+      }
+
+      panZoom.value?.syncViewport(viewport)
+      transform.value = [viewport.x, viewport.y, viewport.zoom]
+    },
+    { immediate: true },
+  )
+
+  watch(transform, (next) => {
+    const viewport = { x: next[0], y: next[1], zoom: next[2] }
+    if (sameViewport(viewport, model.value)) {
+      return
+    }
+
+    model.value = viewport
+  })
+}

--- a/packages/core/src/composables/useWatchProps.ts
+++ b/packages/core/src/composables/useWatchProps.ts
@@ -220,6 +220,8 @@ export function useWatchProps<NodeType extends Node = Node, EdgeType extends Edg
         'minZoom',
         'applyDefault',
         'autoConnect',
+        // `viewport` is a read-only computed on the store; `useViewportSync` handles its two-way binding
+        'viewport',
       ]
 
       for (const key of Object.keys(props)) {

--- a/packages/core/src/container/VueFlow/VueFlow.vue
+++ b/packages/core/src/container/VueFlow/VueFlow.vue
@@ -1,12 +1,14 @@
 <script lang="ts" setup generic="NodeType extends Node = Node, EdgeType extends Edge = Edge">
 import type { Ref } from 'vue'
 import { inject, onUnmounted, provide } from 'vue'
+import type { Viewport } from '@xyflow/system'
 import ZoomPane from '../ZoomPane/ZoomPane.vue'
 import A11yDescriptions from '../../components/A11y/A11yDescriptions.vue'
 import type { Edge, FlowEmits, FlowProps, FlowSlots, Node, VueFlowStore } from '../../types'
 import { Slots, VueFlow as VueFlowInjectionKey } from '../../context'
 import { useOnInitHandler } from '../../composables/useOnInitHandler'
 import { useColorModeClass } from '../../composables/useColorModeClass'
+import { useViewportSync } from '../../composables/useViewportSync'
 import { useWatchProps } from '../../composables/useWatchProps'
 import { useCreateVueFlow } from '../../composables/useCreateVueFlow'
 import { useHooks } from '../../store/hooks'
@@ -54,6 +56,7 @@ const slots = defineSlots<FlowSlots<NodeType, EdgeType>>()
 
 const modelNodes = defineModel<NodeType[]>('nodes')
 const modelEdges = defineModel<EdgeType[]>('edges')
+const modelViewport = defineModel<Viewport>('viewport')
 
 // Reuse an ancestor `<VueFlowProvider>`'s store if present; otherwise this `<VueFlow>` owns it —
 // create + provide our own (auto-wrap, like react's `<Wrapper>`). The store is only ever created by a
@@ -89,6 +92,8 @@ useOnInitHandler(vfInstance)
 useStylesLoadedWarning(vfInstance)
 
 const colorModeClass = useColorModeClass(vfInstance)
+
+useViewportSync(modelViewport, vfInstance)
 
 // slots will be passed via provide
 // this is to avoid having to pass them down through all the components

--- a/packages/core/src/store/state.ts
+++ b/packages/core/src/store/state.ts
@@ -129,6 +129,7 @@ export const storeOptionsToSkip: (keyof Partial<FlowProps & Omit<State, 'nodes' 
   'translateExtent',
   'nodeExtent',
   'fitView',
+  'viewport',
   'hooks',
   'defaultEdgeOptions',
 ]

--- a/packages/core/src/types/flow.ts
+++ b/packages/core/src/types/flow.ts
@@ -121,7 +121,10 @@ export interface FlowProps<NodeType extends Node = Node, EdgeType extends Edge =
   panOnDrag?: boolean | number[]
   minZoom?: number
   maxZoom?: number
+  /** initial viewport for an uncontrolled flow; ignored once the user pans/zooms */
   defaultViewport?: Partial<Viewport>
+  /** controlled viewport (`v-model:viewport`) — keeps the flow's transform in sync with the bound value */
+  viewport?: Viewport
   translateExtent?: CoordinateExtent
   nodeExtent?: CoordinateExtent | CoordinateExtentRange
   /** origin of all nodes relative to their position — `[0, 0]` top-left, `[0.5, 0.5]` center, `[1, 1]` bottom-right */
@@ -251,6 +254,7 @@ export interface FlowEmits<NodeType extends Node = Node, EdgeType extends Edge =
   /** v-model event definitions */
   (event: 'update:nodes', value: NodeType[]): void
   (event: 'update:edges', value: EdgeType[]): void
+  (event: 'update:viewport', value: Viewport): void
 }
 
 // Slots are optional (a flow needn't define every node-/edge-type slot), so use `Partial<Record<…>>`

--- a/tests/cypress/component/2-vue-flow/controlledViewport.cy.ts
+++ b/tests/cypress/component/2-vue-flow/controlledViewport.cy.ts
@@ -1,0 +1,72 @@
+import type { Ref } from 'vue'
+import { defineComponent, h, ref } from 'vue'
+import type { Viewport, VueFlowStore } from '@vue-flow/core'
+import { VueFlow, useVueFlow } from '@vue-flow/core'
+
+// `v-model:viewport` two-way binds the bound value to the flow's transform (xyflow parity). We drive it
+// through a wrapper holding a reactive `viewport` ref so we can mutate the "prop" and observe emits.
+let store: VueFlowStore
+let controlledViewport: Ref<Viewport>
+
+const Wrapper = defineComponent({
+  setup() {
+    const viewport = ref<Viewport>({ x: 0, y: 0, zoom: 1 })
+    controlledViewport = viewport
+
+    const Capture = defineComponent({
+      setup() {
+        store = useVueFlow()
+        return () => null
+      },
+    })
+
+    return () =>
+      h(
+        VueFlow as any,
+        {
+          'id': 'test',
+          'fitView': false,
+          'viewport': viewport.value,
+          'onUpdate:viewport': (next: Viewport) => (viewport.value = next),
+        },
+        { default: () => h(Capture) },
+      )
+  },
+})
+
+describe('controlled viewport (v-model:viewport)', () => {
+  beforeEach(() => {
+    cy.mount(Wrapper, { attrs: { style: { width: '100vw', height: '100vh' } } })
+  })
+
+  it('applies the initial `viewport` to the transform', () => {
+    cy.then(() => {
+      controlledViewport.value = { x: 120, y: 60, zoom: 1.5 }
+    })
+
+    cy.tryAssertion(() => {
+      expect(store.transform.value).to.deep.eq([120, 60, 1.5])
+      expect(store.viewport.value).to.deep.eq({ x: 120, y: 60, zoom: 1.5 })
+    })
+  })
+
+  it('reactively syncs the transform when the bound viewport changes', () => {
+    cy.then(() => {
+      controlledViewport.value = { x: -40, y: 200, zoom: 0.75 }
+    })
+
+    cy.tryAssertion(() => {
+      expect(store.transform.value).to.deep.eq([-40, 200, 0.75])
+    })
+  })
+
+  it('writes user/programmatic transform changes back to the bound viewport', () => {
+    cy.then(() => {
+      store.setViewport({ x: 33, y: 44, zoom: 1.25 })
+    })
+
+    cy.tryAssertion(() => {
+      expect(controlledViewport.value).to.deep.eq({ x: 33, y: 44, zoom: 1.25 })
+    })
+  })
+})


### PR DESCRIPTION
Adds a controlled `viewport` prop with `v-model:viewport`, matching `xyflow/react`'s controlled viewport and `xyflow/svelte`'s `bind:viewport`.

## API

```vue
<VueFlow v-model:viewport="viewport" />
```

The bound value two-way binds to the flow's canonical `transform`:
- **in** (bound value → flow): applies the viewport via the panzoom's `syncViewport`, which sets the transform **without firing pan/zoom events**, then mirrors it onto `transform`. Re-applied once the panzoom mounts so the controlled value wins over the `defaultViewport` seed.
- **out** (flow → bound value): user/programmatic transform changes write back through `update:viewport`.
- Equality guards on both watchers break the round-trip loop.

`defaultViewport` stays the **uncontrolled** initial-viewport prop; use `viewport` when you want to own the viewport state.

## Implementation

- New `viewport?: Viewport` prop + `update:viewport` emit; `defineModel('viewport')` in `<VueFlow>`.
- New internal `useViewportSync` composable (runs for both owned and reused-provider stores).
- `viewport` is skipped in the generic `setState` loop and in `useWatchProps`'s `watchRest` (it's a read-only computed on the store — `useViewportSync` owns its binding).

## Verification

- `vue-tsc` clean (core + examples) · `pnpm build` OK
- New `controlledViewport.cy.ts` (initial apply, reactive in-sync, write-back out) passes 3/3
- Full Cypress suite: `viewport`/`vmodel`/`drag` unaffected. The only failures are the known rotating flakes (`lookup-sync` O(changed), `setState` nodeExtent re-clamp) — both pass in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)