### PR TITLE
test(core): pin provider + v-model:nodes reused-store sync

### DIFF
--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -201,8 +201,8 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
     // its `isCoordinateExtent` treats any non-`'parent'`/non-nullish value as a coordinate-extent array,
     // so it would index `extent[0]` on the range object and crash. Transiently coerce such extents to
     // their `range` (`'parent'` or a plain `CoordinateExtent`, both system-understood) for the system
-    // pass and restore afterwards. NOTE: the range `padding` is not applied by the system clamp — a
-    // known limitation tracked for follow-up (vue-flow's padded-parent-extent is richer than system's).
+    // pass and restore afterwards. The system clamp can't express the range `padding`, so it's re-applied
+    // separately in the padding-clamp pass below (after absolute positions are fresh).
     // `node.extent` is typed `'parent' | CoordinateExtent | null` (deliberately narrow so `GraphNode`
     // stays structurally assignable to system's `NodeBase`), but at runtime vue-flow also supports a
     // `CoordinateExtentRange` ({ range, padding }) — see utils/drag.ts. Hence the localized casts: the

--- a/tests/cypress/component/2-vue-flow/provider-vmodel.cy.ts
+++ b/tests/cypress/component/2-vue-flow/provider-vmodel.cy.ts
@@ -1,0 +1,87 @@
+import type { Ref } from 'vue'
+import { defineComponent, h, ref } from 'vue'
+import type { Node, VueFlowState, VueFlowStore } from '@vue-flow/core'
+import { VueFlow, VueFlowProvider, storeToRefs, useStore, useVueFlow } from '@vue-flow/core'
+
+// A `<VueFlow v-model:nodes>` INSIDE a `<VueFlowProvider>` reuses the provider's store, which was created
+// before the child's model existed — so the model can't back the store as a signal; `useWatchProps`
+// two-way syncs them instead. This pins that path: external reassignment in, store mutation out, and no
+// proxy-loop (the raw-vs-proxy `toRaw` guard — the original repro was a v-model bound to a plain `ref([])`).
+let store: (VueFlowStore & VueFlowState) | undefined
+let modelNodes: Ref<Node[]>
+
+const node = (id: string): Node => ({ id, position: { x: 0, y: 0 }, data: { label: id } })
+
+const Capture = defineComponent({
+  setup() {
+    store = { ...useVueFlow(), ...storeToRefs(useStore()) } as unknown as VueFlowStore & VueFlowState
+    return () => null
+  },
+})
+
+const Wrapper = defineComponent({
+  setup() {
+    // a PLAIN `ref` bound via v-model is exactly the original proxy-loop repro condition
+    const nodes = ref<Node[]>([node('1')])
+    modelNodes = nodes
+
+    return () =>
+      h(VueFlowProvider, null, {
+        default: () =>
+          h(
+            VueFlow as any,
+            {
+              'nodes': nodes.value,
+              'onUpdate:nodes': (next: Node[]) => (nodes.value = next),
+              'fitView': false,
+              'style': 'height: 200px; width: 200px',
+            },
+            { default: () => h(Capture) },
+          ),
+      })
+  },
+})
+
+describe('provider + v-model:nodes (reused-store sync)', () => {
+  beforeEach(() => {
+    store = undefined
+    cy.mount(Wrapper)
+    cy.get('.vue-flow__node').should('have.length', 1)
+  })
+
+  it('adopts an external v-model reassignment into the reused store', () => {
+    cy.then(() => {
+      modelNodes.value = [node('1'), node('2'), node('3')]
+    })
+
+    cy.get('.vue-flow__node').should('have.length', 3)
+    cy.then(() => {
+      expect(store!.getNodes.value.map((n) => n.id)).to.deep.eq(['1', '2', '3'])
+    })
+  })
+
+  it('writes store mutations back to the bound v-model', () => {
+    cy.then(() => {
+      store!.addNodes([node('99')])
+    })
+
+    cy.get('.vue-flow__node').should('have.length', 2)
+    cy.then(() => {
+      expect(modelNodes.value.map((n) => n.id), 'model reflects the store mutation').to.include('99')
+    })
+  })
+
+  it('does not loop store writes back through the model (no recursive-update overflow)', () => {
+    // a reassign that round-tripped store → model → store would throw "Maximum recursive updates" and
+    // cypress would fail on the uncaught error; assert it settles with store and model in agreement.
+    cy.then(() => {
+      modelNodes.value = [node('1'), node('2')]
+    })
+
+    cy.get('.vue-flow__node').should('have.length', 2)
+    cy.then(() => {
+      expect(store!.getNodes.value, 'store settled').to.have.length(2)
+      expect(modelNodes.value, 'model settled').to.have.length(2)
+    })
+  })
+})


### PR DESCRIPTION
Follow-up to the store split (#2064). On investigation, the "provider-rebind / lookup-inversion" blockers turned out to be **already shipped** — the lookup inversion (plain system maps + O(changed) `syncLookups` + `markRaw`, `useNode`/`useEdge` re-resolving via `computed`) landed in the perf pass + node/internal split, and the v-model proxy-loop fix (`toRaw` raw-vs-proxy guard) landed in #2051. The reused-provider dual-watch sync is inherent (the store is created before the child's model exists, and the store may be shared) and is the correct solution.

The one real gap was **coverage**: the proxy-loop fix on the *provider* path had no dedicated spec (the existing `vmodel.cy.ts` covers the owned-store path). This pins it.

## Added — `provider-vmodel.cy.ts`

`<VueFlow v-model:nodes>` inside a `<VueFlowProvider>` (reused store), with v-model bound to a plain `ref([])` — the exact original proxy-loop repro condition:
- **in**: external `modelNodes.value = […]` reassignment adopts into the reused store
- **out**: `store.addNodes(…)` writes back to the bound v-model
- **no loop**: the round-trip settles instead of overflowing

**Red-green verified:** temporarily defeating the `toRaw(next) === lastSnapshot` guard in `syncModelArray` makes the spec fail with `Maximum recursive updates exceeded in <VueFlowProvider>`; restoring it passes. So the spec genuinely guards the fix, not a vacuous assertion.

## Also

Dropped a stale comment in `recomputeAbsolutePositions` that claimed range-extent `padding` was an unapplied "known limitation" — the padding-clamp pass right below it does apply it.

## Verification

Full Cypress suite **162/162**. Test + comment only — no user-facing change, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)