### PR TITLE
fix(core): stop DeepReadonly accessors tripping TS2589

### DIFF
--- a/.changeset/accessor-readonly-depth.md
+++ b/.changeset/accessor-readonly-depth.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Fix `TS2589: Type instantiation is excessively deep and possibly infinite` on the store's read accessors. `getNodes`/`getEdges`/`getSelectedNodes`/`getSelectedEdges` returned `DeepReadonly<…[]>`, which recurses into every nested property — and `Edge.label?: string | VNode | Component` makes it descend into Vue's deeply self-referential `VNode`/`Component` types, past TypeScript's instantiation-depth ceiling. The error surfaced on ordinary reads like `getEdges.value.filter(…)`. These accessors now return a shallow `readonly EdgeType[]` / `readonly NodeType[]`, and `getNode`/`getEdge` return the plain element type. The returned list stays read-only (change nodes/edges via `setNodes`/`updateNode`/`applyNodeChanges`). Fixes #1886.

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -1,4 +1,3 @@
-import type { DeepReadonly } from 'vue'
 import { markRaw, toRaw } from 'vue'
 import {
   clampPosition,
@@ -300,9 +299,9 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
 
     // The public contract: `getNode` returns the user-facing `Node` (the exact object held in
     // `state.nodes`/v-model), which the store keeps on the InternalNode as `internals.userNode`. Enriched
-    // data (internals/measured) is reached via `getInternalNode`. Typed `DeepReadonly` (zero runtime) so
-    // mutating the result is a compile error → use the helpers (updateNode/applyNodeChanges/setNodes).
-    return nodeLookup.get(id)?.internals.userNode as DeepReadonly<NodeType> | undefined
+    // data (internals/measured) is reached via `getInternalNode`. Don't mutate the result in place — it
+    // won't propagate; use the helpers (updateNode/applyNodeChanges/setNodes).
+    return nodeLookup.get(id)?.internals.userNode as NodeType | undefined
   }
 
   // The enriched-node accessor (xyflow/react parity): returns the lookup `InternalNode` (enriched
@@ -321,7 +320,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
       return
     }
 
-    return edgeLookup.get(id) as DeepReadonly<EdgeType> | undefined
+    return edgeLookup.get(id)
   }
 
   const updateNodePositions: Actions<NodeType>['updateNodePositions'] = (dragItems, changed, dragging) => {

--- a/packages/core/src/store/getters.ts
+++ b/packages/core/src/store/getters.ts
@@ -1,5 +1,4 @@
 import { computed } from 'vue'
-import type { DeepReadonly } from 'vue'
 import { getNodesInside, isEdgeVisible } from '@xyflow/system'
 import type { ComputedGetters, Edge, Node, NodeLookup, State } from '../types'
 import { defaultEdgeTypes, defaultNodeTypes } from '../utils/defaultNodesEdges'
@@ -59,10 +58,10 @@ export function useGetters<NodeType extends Node = Node, EdgeType extends Edge =
         },
         state.transform,
         true,
-      ).map((node) => node.internals.userNode) as unknown as DeepReadonly<NodeType[]>
+      ).map((node) => node.internals.userNode) as unknown as readonly NodeType[]
     }
 
-    return state.nodes as unknown as DeepReadonly<NodeType[]>
+    return state.nodes as unknown as readonly NodeType[]
   })
 
   const getEdges: ComputedGetters<NodeType, EdgeType>['getEdges'] = computed(() => {
@@ -91,10 +90,10 @@ export function useGetters<NodeType extends Node = Node, EdgeType extends Edge =
         }
       }
 
-      return visibleEdges as unknown as DeepReadonly<EdgeType[]>
+      return visibleEdges as unknown as readonly EdgeType[]
     }
 
-    return state.edges as unknown as DeepReadonly<EdgeType[]>
+    return state.edges as unknown as readonly EdgeType[]
   })
 
   const getSelectedNodes: ComputedGetters<NodeType>['getSelectedNodes'] = computed(() => {
@@ -105,7 +104,7 @@ export function useGetters<NodeType extends Node = Node, EdgeType extends Edge =
       }
     }
 
-    return selectedNodes as unknown as DeepReadonly<NodeType[]>
+    return selectedNodes as unknown as readonly NodeType[]
   })
 
   const getSelectedEdges: ComputedGetters<NodeType, EdgeType>['getSelectedEdges'] = computed(() => {
@@ -116,7 +115,7 @@ export function useGetters<NodeType extends Node = Node, EdgeType extends Edge =
       }
     }
 
-    return selectedEdges as unknown as DeepReadonly<EdgeType[]>
+    return selectedEdges as unknown as readonly EdgeType[]
   })
 
   // the public `{ x, y, zoom }` shape derived from the canonical `transform` tuple (read-only)

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef, DeepReadonly } from 'vue'
+import type { ComputedRef } from 'vue'
 import type { KeyFilter } from '@vueuse/core'
 import type { ColorMode, PanOnScrollMode, PanZoomInstance, Transform, Viewport } from '@xyflow/system'
 import type { ViewportHelper } from '../composables'
@@ -213,7 +213,7 @@ export type UpdateNodeDimensions = (updates: UpdateNodeDimensionsParams[]) => vo
 
 export type UpdateNodeInternals = (nodeIds?: string[]) => void
 
-export type GetNode<NodeType extends Node = Node> = (id: string | undefined | null) => DeepReadonly<NodeType> | undefined
+export type GetNode<NodeType extends Node = Node> = (id: string | undefined | null) => NodeType | undefined
 
 /**
  * Returns the enriched {@link InternalNode} (`internals.{positionAbsolute, z, handleBounds, userNode}` +
@@ -222,7 +222,7 @@ export type GetNode<NodeType extends Node = Node> = (id: string | undefined | nu
  */
 export type GetInternalNode<NodeType extends Node = Node> = (id: string | undefined | null) => GraphNode<NodeType> | undefined
 
-export type GetEdge<EdgeType extends Edge = Edge> = (id: string | undefined | null) => DeepReadonly<EdgeType> | undefined
+export type GetEdge<EdgeType extends Edge = Edge> = (id: string | undefined | null) => EdgeType | undefined
 
 export type GetIntersectingNodes<NodeType extends Node = Node> = (
   node: (Partial<NodeType> & { id: NodeType['id'] }) | Rect,
@@ -341,15 +341,16 @@ export interface Getters<NodeType extends Node = Node, EdgeType extends Edge = E
   /** returns object containing current node types */
   getNodeTypes: Record<keyof DefaultNodeTypes | string, NodeComponent<NodeType | BuiltInNode>>
   /** all visible nodes (user-facing `Node`s; use `getInternalNode`/`nodeLookup` for enriched data) */
-  getNodes: DeepReadonly<NodeType[]>
-  // NOTE: DeepReadonly is a TYPE-only guard (zero runtime) — mutating a node read here is a compile error
-  // pointing users at the helpers (updateNode/updateNodeData/applyNodeChanges/setNodes); see #40.
+  getNodes: readonly NodeType[]
+  // the returned list is `readonly` — change nodes via setNodes/updateNode/applyNodeChanges (an in-place
+  // mutation to a node read here won't propagate). NOTE: shallow `readonly`, not `DeepReadonly`: the latter
+  // recurses into `Edge.label`'s VNode/Component types and trips TS2589 on a plain `.filter()` (#1886).
   /** all visible edges (user-facing `Edge`s) */
-  getEdges: DeepReadonly<EdgeType[]>
+  getEdges: readonly EdgeType[]
   /** returns all currently selected nodes (user-facing `Node`s) */
-  getSelectedNodes: DeepReadonly<NodeType[]>
+  getSelectedNodes: readonly NodeType[]
   /** returns all currently selected edges */
-  getSelectedEdges: DeepReadonly<EdgeType[]>
+  getSelectedEdges: readonly EdgeType[]
   /** the viewport as `{ x, y, zoom }`, derived from the canonical `transform` — read-only; set via `setViewport`/`zoom*`/`fitView` */
   viewport: Viewport
 }


### PR DESCRIPTION
Fixes #1886.

## Problem
`getNodes`/`getEdges`/`getSelectedNodes`/`getSelectedEdges` were typed `DeepReadonly<…[]>`. `DeepReadonly` recurses into every nested property, and `Edge.label?: string | VNode | Component<EdgeTextProps>` makes it descend into Vue's deeply self-referential `VNode`/`Component` types — exceeding TypeScript's instantiation-depth ceiling. The error then surfaced for consumers on ordinary read operations:

```ts
const { getEdges } = useVueFlow()
getEdges.value.filter(e => e.id !== id)   // TS2589: Type instantiation is excessively deep
```

This hit the docs' own `removeEdge` snippet. `getNodes` only escaped because `Node` has no comparably deep top-level field — a fragile margin, not safety.

## Fix
Return a shallow `readonly EdgeType[]` / `readonly NodeType[]` from the four list accessors, and the plain element type from `getNode`/`getEdge`. The returned list stays read-only (reassign/`push` is still an error; change nodes/edges via `setNodes`/`updateNode`/`applyNodeChanges`), but the runaway `DeepReadonly` recursion into `VNode`/`Component` is gone.

This relaxes the deep per-element immutability typing added in #40 to array-level — a deliberate trade: that guard was bypassable and broke a read-only op (`.filter`). The alternative (a bounded `DeepReadonly` excluding `VNode`/`Component`) preserves the deep guard but is fiddly and easy to get subtly wrong; not worth it here.

## Verification
- The exact #1886 repro (`getEdges.value.filter`/`.map`, `getSelectedEdges.value.filter`, `getNode`/`getEdge`) now type-checks. Confirmed against the built `dist` types.
- `core` + `examples` `vue-tsc` clean; full Cypress component suite green (159/159, Chrome). Type-only change — the casts erase at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)