### PR TITLE
test(core): lock in ConnectionMode.Strict as the default

### DIFF
--- a/tests/cypress/component/2-vue-flow/strictConnectionMode.cy.ts
+++ b/tests/cypress/component/2-vue-flow/strictConnectionMode.cy.ts
@@ -1,0 +1,35 @@
+import { ConnectionMode } from '@vue-flow/core'
+import { getStore } from '../../support/component'
+
+// Regression for #1655: `connectionMode` defaults to `ConnectionMode.Strict` in 2.0 (it was `Loose` in
+// v1). Strict only permits source->target connections; the system rejects same-type (source<->source)
+// connections — which is what the issue asked for. This locks in the default (a Loose default would
+// re-open the bug) and sanity-checks that a normal source->target connection still works.
+describe('Issue #1655: ConnectionMode.Strict is the default', () => {
+  beforeEach(() => {
+    cy.vueFlow({
+      fitView: false,
+      // intentionally no `connectionMode` prop — this asserts the DEFAULT
+      autoConnect: true,
+      nodes: [
+        { id: '1', data: { label: 'Node 1' }, position: { x: 0, y: 0 } },
+        { id: '2', data: { label: 'Node 2' }, position: { x: 300, y: 300 } },
+      ],
+    })
+  })
+
+  it('defaults connectionMode to Strict', () => {
+    cy.then(() => {
+      expect(getStore().connectionMode.value).to.eq(ConnectionMode.Strict)
+    })
+  })
+
+  it('connects a source handle to a target handle', () => {
+    cy.dragConnection('1', '2')
+
+    cy.get('.vue-flow__edge').should('have.length', 1)
+    cy.then(() => {
+      expect(getStore().edges.value).to.have.length(1)
+    })
+  })
+})


### PR DESCRIPTION
Regression coverage for #1655 (resolved in 2.0, no code change needed).

## Context
#1655 reported that, under the v1 `ConnectionMode.Loose` default, same-type connections (source↔source / target↔target) were accepted and connection success was order-dependent. The maintainer deferred the fix to 2.0. It's now resolved: `connectionMode` defaults to `ConnectionMode.Strict` (`state.ts`), and `@xyflow/system` only looks up the target handle in the target bounds under Strict, so same-type connections are rejected.

## What this adds
A regression test that:
- asserts `connectionMode` defaults to `Strict` — **this is the discriminating guard**: I verified it fails if the default is flipped back to `Loose`, so it locks in the fix.
- sanity-checks that a normal source→target connection still works under the Strict default.

## Note on scope
I intended to also assert that a source↔source drag is *rejected*, but found that the synthetic connection drag doesn't reproduce a `Loose` source↔source connection even with fixed handle ids — so that assertion would be **vacuous** (passes regardless of mode). Rather than ship a misleading test, I kept the non-vacuous default-value guard. The rejection behaviour itself is enforced upstream in `@xyflow/system`'s `getFitViewNodes`/`isValidHandle` (verified by inspection).

Test-only; no changeset. New spec green (2/2, Chrome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)