### PR TITLE
feat(core): add `onBeforeDelete` + `deleteElements`

### DIFF
--- a/.changeset/on-before-delete.md
+++ b/.changeset/on-before-delete.md
@@ -1,0 +1,10 @@
+---
+"@vue-flow/core": minor
+---
+
+Add `onBeforeDelete` and `deleteElements` (xyflow/react parity).
+
+- **`onBeforeDelete`** prop — `(params: { nodes, edges }) => Promise<boolean | { nodes, edges }>`, consulted before delete-key removals and `deleteElements`. Return `false` to cancel, `true` to delete the gathered set, or `{ nodes, edges }` to delete only a subset.
+- **`deleteElements({ nodes, edges })`** action — gathers the targeted nodes plus their child nodes and connected edges (skipping `deletable: false`), runs `onBeforeDelete`, removes the resolved set, and resolves to `{ deletedNodes, deletedEdges }`.
+
+The Delete key now routes through `deleteElements`, so a single keypress can confirm/cancel a node together with its edges. Low-level `removeNodes`/`removeEdges` stay hook-free. Resolves the tracked enhancement in #1630.

--- a/packages/core/src/container/Pane/Pane.vue
+++ b/packages/core/src/container/Pane/Pane.vue
@@ -11,7 +11,7 @@ import { getMousePosition } from './utils'
 
 const { isSelecting, selectionKeyPressed } = defineProps<{ isSelecting: boolean; selectionKeyPressed: boolean }>()
 
-const { emits, removeSelectedNodes, removeSelectedEdges, getSelectedEdges, getSelectedNodes, removeNodes, removeEdges } =
+const { emits, removeSelectedNodes, removeSelectedEdges, getSelectedEdges, getSelectedNodes, deleteElements } =
   useVueFlow()
 
 const { edgeLookup, nodeLookup } = useStore()
@@ -58,9 +58,11 @@ watch(deleteKeyPressed, (isKeyPressed) => {
     return
   }
 
-  removeNodes(getSelectedNodes.value as unknown as Node[])
-
-  removeEdges(getSelectedEdges.value as unknown as Edge[])
+  // routed through `deleteElements` so the `onBeforeDelete` guard (cancel/confirm/filter) is consulted
+  deleteElements({
+    nodes: getSelectedNodes.value as unknown as Node[],
+    edges: getSelectedEdges.value as unknown as Edge[],
+  })
 
   nodesSelectionActive.value = false
 })

--- a/packages/core/src/container/Pane/Pane.vue
+++ b/packages/core/src/container/Pane/Pane.vue
@@ -11,8 +11,7 @@ import { getMousePosition } from './utils'
 
 const { isSelecting, selectionKeyPressed } = defineProps<{ isSelecting: boolean; selectionKeyPressed: boolean }>()
 
-const { emits, removeSelectedNodes, removeSelectedEdges, getSelectedEdges, getSelectedNodes, deleteElements } =
-  useVueFlow()
+const { emits, removeSelectedNodes, removeSelectedEdges, getSelectedEdges, getSelectedNodes, deleteElements } = useVueFlow()
 
 const { edgeLookup, nodeLookup } = useStore()
 

--- a/packages/core/src/container/VueFlow/VueFlow.vue
+++ b/packages/core/src/container/VueFlow/VueFlow.vue
@@ -44,6 +44,7 @@ const props = withDefaults(defineProps<FlowProps<NodeType, EdgeType>>(), {
   autoPanOnConnect: undefined,
   autoPanOnNodeDrag: undefined,
   isValidConnection: undefined,
+  onBeforeDelete: undefined,
   deleteKeyCode: undefined,
   selectionKeyCode: undefined,
   multiSelectionKeyCode: undefined,

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -5,6 +5,7 @@ import {
   clampPositionToParent,
   getConnectedEdges as getConnectedEdgesBase,
   getDimensions,
+  getElementsToRemove,
   getHandleBounds,
   getOverlappingArea,
   handleExpandParent,
@@ -734,6 +735,32 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
     state.hooks.edgesChange.trigger(changes)
   }
 
+  const deleteElements: Actions<NodeType, EdgeType>['deleteElements'] = async ({ nodes = [], edges = [] }) => {
+    // `getElementsToRemove` (xyflow/system) gathers the full set — the targeted nodes + their child nodes,
+    // plus connected + explicitly-listed edges, skipping `deletable: false` — then consults `onBeforeDelete`
+    // and returns the elements that should actually be removed (`false` → none, an object → that subset).
+    const { nodes: matchingNodes, edges: matchingEdges } = await getElementsToRemove<NodeType, EdgeType>({
+      nodesToRemove: nodes,
+      edgesToRemove: edges,
+      nodes: state.nodes,
+      edges: state.edges,
+      onBeforeDelete: state.onBeforeDelete ?? undefined,
+    })
+
+    // remove exactly that set: `matchingNodes` already includes children and `matchingEdges` the connected
+    // edges (both reflecting any `onBeforeDelete` filtering), so tell `removeNodes` NOT to also pull in
+    // connected edges/children — that would bypass an `onBeforeDelete` that chose to keep some.
+    if (matchingNodes.length) {
+      removeNodes(matchingNodes, false, false)
+    }
+
+    if (matchingEdges.length) {
+      removeEdges(matchingEdges)
+    }
+
+    return { deletedNodes: matchingNodes, deletedEdges: matchingEdges }
+  }
+
   const reconnectEdge: Actions<NodeType, EdgeType>['reconnectEdge'] = (oldEdge, newConnection, shouldReplaceId = true) => {
     const prevEdge = getEdge(oldEdge.id)
 
@@ -1068,6 +1095,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
     addEdges,
     removeNodes,
     removeEdges,
+    deleteElements,
     getNode,
     getInternalNode,
     getEdge,

--- a/packages/core/src/store/state.ts
+++ b/packages/core/src/store/state.ts
@@ -76,6 +76,7 @@ export function useState<NodeType extends Node = Node, EdgeType extends Edge = E
     connectOnClick: true,
     connectionStatus: null,
     isValidConnection: null,
+    onBeforeDelete: null,
 
     snapGrid: [15, 15],
     snapToGrid: false,

--- a/packages/core/src/types/flow.ts
+++ b/packages/core/src/types/flow.ts
@@ -22,6 +22,16 @@ import type { FitViewParams } from './zoom'
 // todo: should be object type
 export type ElementData = any
 
+/**
+ * Consulted before nodes/edges are deleted (via the delete key or `deleteElements`). Receives the full set
+ * about to be removed (the targeted nodes/edges plus connected edges and child nodes). Return `false` to
+ * cancel, `true` to delete that set, or `{ nodes, edges }` to delete only a subset. Mirrors xyflow/react.
+ */
+export type OnBeforeDelete<NodeType extends Node = Node, EdgeType extends Edge = Edge> = (params: {
+  nodes: NodeType[]
+  edges: EdgeType[]
+}) => Promise<boolean | { nodes: NodeType[]; edges: EdgeType[] }>
+
 export interface CustomThemeVars {
   [key: string]: string | number | undefined
 }
@@ -103,6 +113,8 @@ export interface FlowProps<NodeType extends Node = Node, EdgeType extends Edge =
   connectionLineOptions?: ConnectionLineOptions
   connectionRadius?: number
   isValidConnection?: ValidConnectionFunc | null
+  /** consulted before delete-key/`deleteElements` removals — cancel, confirm, or filter the set */
+  onBeforeDelete?: OnBeforeDelete<NodeType, EdgeType> | null
   deleteKeyCode?: KeyFilter | null
   selectionKeyCode?: KeyFilter | null
   multiSelectionKeyCode?: KeyFilter | null

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -2,7 +2,17 @@ import type { ComputedRef, DeepReadonly } from 'vue'
 import type { KeyFilter } from '@vueuse/core'
 import type { ColorMode, PanOnScrollMode, PanZoomInstance, Transform, Viewport } from '@xyflow/system'
 import type { ViewportHelper } from '../composables'
-import type { Dimensions, FlowExportObject, FlowProps, Rect, SelectionMode, SelectionRect, SnapGrid, XYPosition } from './flow'
+import type {
+  Dimensions,
+  FlowExportObject,
+  FlowProps,
+  OnBeforeDelete,
+  Rect,
+  SelectionMode,
+  SelectionRect,
+  SnapGrid,
+  XYPosition,
+} from './flow'
 import type { DefaultEdgeTypes, DefaultNodeTypes, EdgeComponent, NodeComponent } from './components'
 import type {
   Connection,
@@ -93,6 +103,7 @@ export interface State<NodeType extends Node = Node, EdgeType extends Edge = Edg
   connectionRadius: number
   connectionStatus: ConnectionStatus | null
   isValidConnection: ValidConnectionFunc | null
+  onBeforeDelete: OnBeforeDelete<NodeType, EdgeType> | null
 
   connectOnClick: boolean
   reconnectRadius: number
@@ -172,6 +183,15 @@ export type RemoveNodes = (
 export type RemoveEdges = (
   edges: (string | Edge) | (Edge | string)[] | ((edges: Edge[]) => (string | Edge) | (Edge | string)[]),
 ) => void
+
+/**
+ * Delete the given nodes/edges along with their connected edges and child nodes, gated by `onBeforeDelete`.
+ * Resolves to the elements actually removed. Mirrors xyflow/react's `deleteElements`.
+ */
+export type DeleteElements<NodeType extends Node = Node, EdgeType extends Edge = Edge> = (elements: {
+  nodes?: (Partial<NodeType> & { id: string })[]
+  edges?: (Partial<EdgeType> & { id: string })[]
+}) => Promise<{ deletedNodes: NodeType[]; deletedEdges: EdgeType[] }>
 
 export type AddEdges<EdgeType extends Edge = Edge> = (
   edgesOrConnections:
@@ -258,6 +278,8 @@ export interface Actions<NodeType extends Node = Node, EdgeType extends Edge = E
   removeNodes: RemoveNodes
   /** remove edges from state */
   removeEdges: RemoveEdges
+  /** delete nodes/edges (with connected edges + children), gated by `onBeforeDelete`; mirrors xyflow/react */
+  deleteElements: DeleteElements<NodeType, EdgeType>
   /** find a node by id */
   getNode: GetNode<NodeType>
   /** get the enriched internal node (store-computed `internals` + `measured`) by id */

--- a/tests/cypress/component/2-vue-flow/onBeforeDelete.cy.ts
+++ b/tests/cypress/component/2-vue-flow/onBeforeDelete.cy.ts
@@ -1,0 +1,65 @@
+import { getStore } from '../../support/component'
+
+const nodes = [
+  { id: '1', position: { x: 0, y: 0 }, data: { label: '1' } },
+  { id: '2', position: { x: 200, y: 0 }, data: { label: '2' } },
+]
+const edges = [{ id: 'e1-2', source: '1', target: '2' }]
+
+describe('onBeforeDelete + deleteElements (#1630)', () => {
+  it('deleteElements removes a node + its connected edges and returns the deleted set', () => {
+    cy.vueFlow({ fitView: false, nodes, edges })
+    cy.then(() => {
+      const store = getStore()
+      return (store.deleteElements({ nodes: [{ id: '1' }] }) as Promise<any>).then((result: any) => {
+        expect(result.deletedNodes.map((n: any) => n.id)).to.deep.eq(['1'])
+        expect(result.deletedEdges.map((e: any) => e.id)).to.deep.eq(['e1-2'])
+        expect(store.nodes.value.map((n: any) => n.id)).to.deep.eq(['2'])
+        expect(store.edges.value).to.have.length(0)
+      })
+    })
+  })
+
+  it('onBeforeDelete returning false cancels the deletion', () => {
+    const guard = cy.stub().resolves(false).as('guard')
+    cy.vueFlow({ fitView: false, nodes, edges, onBeforeDelete: guard } as any)
+    cy.then(() => {
+      const store = getStore()
+      return (store.deleteElements({ nodes: [{ id: '1' }] }) as Promise<any>).then((result: any) => {
+        expect(result.deletedNodes).to.have.length(0)
+        expect(store.nodes.value).to.have.length(2)
+        expect(store.edges.value).to.have.length(1)
+      })
+    })
+    cy.get('@guard').should('have.been.calledOnce')
+  })
+
+  it('onBeforeDelete can return a subset (delete the node, keep its edge)', () => {
+    const guard = ({ nodes: n }: any) => Promise.resolve({ nodes: n, edges: [] })
+    cy.vueFlow({ fitView: false, nodes, edges, onBeforeDelete: guard } as any)
+    cy.then(() => {
+      const store = getStore()
+      return (store.deleteElements({ nodes: [{ id: '1' }] }) as Promise<any>).then(() => {
+        expect(store.nodes.value.map((n: any) => n.id)).to.deep.eq(['2'])
+        expect(store.edges.value, 'edge kept by the subset').to.have.length(1)
+      })
+    })
+  })
+
+  it('the delete key routes through onBeforeDelete', () => {
+    const guard = cy.stub().resolves(false).as('guard')
+    cy.vueFlow({
+      fitView: false,
+      nodes: [{ ...nodes[0], selected: true }, nodes[1]],
+      edges,
+      onBeforeDelete: guard,
+    } as any)
+    cy.window().then((win) => {
+      win.document.dispatchEvent(new win.KeyboardEvent('keydown', { key: 'Backspace', code: 'Backspace', bubbles: true }))
+    })
+    cy.get('@guard').should('have.been.calledOnce')
+    cy.then(() => {
+      expect(getStore().nodes.value, 'nothing deleted while the guard says no').to.have.length(2)
+    })
+  })
+})


### PR DESCRIPTION
Resolves the tracked enhancement in #1630, and completes the react-flow deletion parity surface.

## What
- **`onBeforeDelete`** prop — `(params: { nodes: Node[]; edges: Edge[] }) => Promise<boolean | { nodes; edges }>`. Consulted before any delete-key removal or `deleteElements` call:
  - `false` → cancel the deletion
  - `true` → delete the gathered set
  - `{ nodes, edges }` → delete only that subset
- **`deleteElements({ nodes, edges })`** action — gathers the targeted nodes + their child nodes + connected/explicit edges (skipping `deletable: false`), runs `onBeforeDelete`, removes the resolved set, and resolves to `{ deletedNodes, deletedEdges }`.
- The **Delete key** (Pane) now routes through `deleteElements`, so a single keypress can confirm/cancel a node *together with* its edges — the exact #1630 pain point (previously `removeNodes` + `removeEdges` fired separately with no confirm hook).

## How
The gather + `onBeforeDelete` step reuses `@xyflow/system`'s `getElementsToRemove`, so the semantics match react-flow exactly. `deleteElements` removes precisely the resolved set (`removeNodes(set, /* removeConnectedEdges */ false)` + `removeEdges(set)`), so an `onBeforeDelete` that *keeps* some edges is honored. Low-level `removeNodes`/`removeEdges` stay hook-free (parity — react-flow's low-level ops bypass `onBeforeDelete` too).

## Tests
New `onBeforeDelete.cy.ts`: `deleteElements` removes a node + its connected edges and returns the deleted set; `onBeforeDelete` → `false` cancels; → a subset deletes only that subset (node removed, edge kept); and the Delete key routes through the guard. Full Cypress component suite green (**163/163**, Chrome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)