### PR TITLE
test(core): extent:parent child re-clamps on parent shrink (#1539)

### DIFF
--- a/tests/cypress/component/2-vue-flow/parentExtentResize.cy.ts
+++ b/tests/cypress/component/2-vue-flow/parentExtentResize.cy.ts
@@ -1,0 +1,35 @@
+import { getStore } from '../../support/component'
+
+// Regression for #1539: a child with `extent: 'parent'` must be re-clamped into the parent when the
+// parent SHRINKS (not only on the child's next drag). 2.0 re-clamps on every commit via
+// `recomputeAbsolutePositions` → the system's `calculateChildXYZ` / `clampPositionToParent`.
+describe('Issue #1539: extent:parent child re-clamps when the parent shrinks', () => {
+  it('clamps the child into the shrunk parent', () => {
+    cy.vueFlow({
+      fitView: false,
+      nodes: [
+        { id: '1', position: { x: 0, y: 0 }, style: { width: '200px', height: '200px' } },
+        { id: '2', parentId: '1', extent: 'parent', position: { x: 150, y: 150 }, style: { width: '40px', height: '40px' } },
+      ],
+    })
+
+    cy.get('[data-id="2"]').should('exist')
+
+    // baseline: child sits at ~150 inside the 200x200 parent
+    cy.tryAssertion(() => {
+      expect(getStore().getInternalNode('2')?.internals.positionAbsolute?.x).to.be.closeTo(150, 5)
+    })
+
+    // shrink the parent to 100x100
+    cy.then(() => {
+      getStore().updateNode('1', { style: { width: '100px', height: '100px' } })
+    })
+
+    // child (40 wide) in a 100-wide parent → max x/y = 60; un-clamped it would stay ~150
+    cy.tryAssertion(() => {
+      const pos = getStore().getInternalNode('2')?.internals.positionAbsolute
+      expect(pos?.x, 'child x re-clamped into shrunk parent').to.be.at.most(61)
+      expect(pos?.y, 'child y re-clamped into shrunk parent').to.be.at.most(61)
+    })
+  })
+})


### PR DESCRIPTION
Regression coverage for #1539 (resolved in 2.0, no code change needed).

## Context
#1539: a child node with `extent: 'parent'` wasn't kept inside its parent when the parent was *resized smaller* — it only re-clamped on the child's next drag (the reporter's "flicker"). In 2.0 this is fixed: `recomputeAbsolutePositions` runs on every commit (including a parent dimension change) and re-clamps `extent:'parent'` children through `@xyflow/system`'s `calculateChildXYZ` → `clampPositionToParent`.

## Test
Shrink a 200×200 parent to 100×100 with a 40×40 `extent:'parent'` child initially at `(150,150)`, and assert the child's `positionAbsolute` is clamped to `<= 60` after the shrink. A **baseline** assertion (`~150` before the shrink) makes it discriminating — if the re-clamp regressed, the child stays at ~150 and the test fails (verified).

Test-only; no changeset. New spec green (Chrome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)