### PR TITLE
docs: migrate guides + home flows to 2.0 APIs

### DIFF
--- a/docs/components/home/Features.vue
+++ b/docs/components/home/Features.vue
@@ -1,14 +1,14 @@
 <script lang="ts" setup>
-import type { VueFlowStore } from '@vue-flow/core'
+import type { VueFlowInstance } from '@vue-flow/core'
 import Basic from './flows/Basic.vue'
 import RGB from './flows/RGB.vue'
 import Nested from './flows/Nested.vue'
 import Additional from './flows/Additional.vue'
 
 const el = ref<HTMLDivElement>()
-const instances: VueFlowStore[] = []
+const instances: VueFlowInstance[] = []
 
-function onLoad(instance: VueFlowStore) {
+function onLoad(instance: VueFlowInstance) {
   instances.push(instance)
   instance.fitView()
 }

--- a/docs/components/home/flows/Basic.vue
+++ b/docs/components/home/flows/Basic.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import type { Connection, Edge, Node, Styles, VueFlowStore } from '@vue-flow/core'
+import type { Connection, Edge, Node, Styles, VueFlowInstance } from '@vue-flow/core'
 import { Background, ConnectionLineType, Controls, VueFlow } from '@vue-flow/core'
 
 import Cross from '~icons/mdi/window-close'
@@ -20,7 +20,7 @@ const edgeStyle: Styles = {
 
 // `<VueFlow>` exposes its store via `defineExpose`; reach `viewport`/`addEdges` through a template ref
 // (pure-provider: no `useVueFlow()` outside a provider).
-const flow = ref<VueFlowStore>()
+const flow = ref<VueFlowInstance>()
 
 const nodes = ref<Node[]>([
   {
@@ -85,7 +85,7 @@ function onConnect(param: Connection) {
   ])
 }
 
-function onInit(instance: VueFlowStore) {
+function onInit(instance: VueFlowInstance) {
   emit('pane', instance)
 }
 </script>

--- a/docs/components/home/flows/Intro.vue
+++ b/docs/components/home/flows/Intro.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import type { Edge, Node, VueFlowStore } from '@vue-flow/core'
+import type { Edge, Node, VueFlowInstance } from '@vue-flow/core'
 import { Background, Handle, Position, VueFlow } from '@vue-flow/core'
 import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
 import Heart from '~icons/mdi/heart'
@@ -67,7 +67,7 @@ const initialEdges: Edge[] = [
 // `<VueFlow>` exposes its store via `defineExpose`, so a template ref is the pure-provider way to reach
 // the store (getNodes/getNode/setEdges/updateNodeInternals + the viewport `dimensions`) from the
 // component that renders the flow (no `useVueFlow()` outside a provider needed).
-const flow = ref<VueFlowStore>()
+const flow = ref<VueFlowInstance>()
 
 const setElements = useDebounceFn(() => {
   if (!flow.value) {

--- a/docs/components/home/flows/RGB.vue
+++ b/docs/components/home/flows/RGB.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import type { Edge, MiniMapNodeFunc, Node, VueFlowStore } from '@vue-flow/core'
+import type { Edge, MiniMapNodeFunc, Node, VueFlowInstance } from '@vue-flow/core'
 import { Background, Controls, MiniMap, VueFlow } from '@vue-flow/core'
 import { breakpointsTailwind } from '@vueuse/core'
 
@@ -12,7 +12,7 @@ const emit = defineEmits(['pane'])
 
 const breakpoints = useBreakpoints(breakpointsTailwind)
 
-const flow = ref<VueFlowStore>()
+const flow = ref<VueFlowInstance>()
 
 const panOnDrag = ref(true)
 

--- a/docs/src/guide/components/minimap-node.md
+++ b/docs/src/guide/components/minimap-node.md
@@ -24,7 +24,6 @@ To use the component pass the `MiniMapNode` as a child to the [`MiniMap`](/guide
 | Name           | Definition                      | Type                                                | Optional | Default |
 |----------------|---------------------------------|-----------------------------------------------------|----------|---------|
 | id             | Node id                         | string                                              | false    | -       |
-| parentNode     | Parent node id                  | string                                              | true     | -       |
 | selected       | Is node selected                | boolean                                             | true     | false   |
 | dragging       | Is node dragging                | boolean                                             | true     | false   |
 | position       | XY position of node             | [XYPosition](/typedocs/interfaces/XYPosition) | false    | -       |

--- a/docs/src/guide/composables.md
+++ b/docs/src/guide/composables.md
@@ -24,7 +24,7 @@ snapToGrid.value = true
 
 // any event that is emitted from the `<VueFlow />` component can be listened to using the `onEventName` method
 onInit((instance) => {
-  // `instance` is the same type as the return of `useVueFlow` (VueFlowStore)
+  // `instance` is the same type as the return of `useVueFlow` (VueFlowInstance)
   
   fitView()
   
@@ -46,7 +46,7 @@ The values are reactive, meaning changing the values returned from `useVueFlow` 
 
 ### State creation and injection
 
-The `useVueFlow` composable creates, on first call, a new instance of the `VueFlowStore` and injects it into the Vue component tree.
+The `useVueFlow` composable creates, on first call, a new `VueFlowInstance` and injects it into the Vue component tree.
 This allows you to access the store from any child component using the `useVueFlow` composable.
 
 This also means that the *first call* of `useVueFlow` is crucial as it determines the state instance that will be used throughout the component tree.
@@ -64,7 +64,7 @@ import { useVueFlow } from '@vue-flow/core'
 const { onInit } = useVueFlow({ id: 'my-flow-instance' })
 
 onInit((instance) => {
-  // `instance` is the same type as the return of `useVueFlow` (VueFlowStore)
+  // `instance` is the same type as the return of `useVueFlow` (VueFlowInstance)
 })
 ```
 

--- a/docs/src/guide/edge.md
+++ b/docs/src/guide/edge.md
@@ -10,7 +10,7 @@ import Check from '~icons/mdi/check';
 import Close from '~icons/mdi/close';
 import { ref } from 'vue';
 
-const nodes = [
+const nodes = ref([
   {
     id: '1',
     type: 'input',
@@ -22,10 +22,9 @@ const nodes = [
     label: 'Node 2',
     position: { x: 100, y: 125 },
   },
-];
+]);
 
-const bezierEdge = ref([
-  ...nodes,
+const bezierEdges = ref([
   {
     id: 'e1-2',
     source: '1',
@@ -33,8 +32,7 @@ const bezierEdge = ref([
   }
 ]);
 
-const stepEdge = ref([
-  ...nodes,
+const stepEdges = ref([
   {
     id: 'e1-2',
     type: 'step',
@@ -43,8 +41,7 @@ const stepEdge = ref([
   },
 ]);
 
-const smoothStepEdge = ref([
-  ...nodes,
+const smoothStepEdges = ref([
   {
     id: 'e1-2',
     type: 'smoothstep',
@@ -53,7 +50,7 @@ const smoothStepEdge = ref([
   },
 ]);
 
-const straightEdge = ref([
+const straightNodes = ref([
   {
     id: '1',
     type: 'input',
@@ -65,6 +62,9 @@ const straightEdge = ref([
     label: 'Node 2',
     position: { x: 50, y: 125 },
   },
+]);
+
+const straightEdges = ref([
   {
     id: 'e1-2',
     type: 'straight',
@@ -89,7 +89,7 @@ For the full list of options available for an edge, check out the [Edge Type](/t
 
 ## Adding Edges to the Graph
 
-Edges are rendered by passing them to the `edges` prop (or the deprecated `v-model` prop) of the Vue Flow component.
+Edges are rendered by passing them to the `edges` prop (or `v-model:edges` for two-way binding) of the Vue Flow component.
 
 :::warning
 This method will *not* create a change. Check out the [Controlled Flow](/guide/controlled-flow.html) section for more information.
@@ -213,7 +213,7 @@ addEdges([
 
 ## Removing Edges from the Graph
 
-Similar to adding edges, edges can be removed from the graph by removing them from the `mode-value` (using `v-model`) or from the `edges` prop of the Vue Flow component.
+Similar to adding edges, edges can be removed from the graph by removing them from your bound array (using `v-model:edges`) or from the `edges` prop of the Vue Flow component.
 
 ```vue
 <script setup>
@@ -419,7 +419,7 @@ The included node types are `default` (bezier), `step`, `smoothstep` and `straig
 The default edge is a bezier curve that connects two nodes.
 
 <div class="mt-4 bg-[var(--vp-code-block-bg)] rounded-lg h-50">
-  <VueFlow v-model="bezierEdge">
+  <VueFlow v-model:nodes="nodes" v-model:edges="bezierEdges">
     <Background class="rounded-lg" />
   </VueFlow>
 </div>
@@ -429,7 +429,7 @@ The default edge is a bezier curve that connects two nodes.
 A step edge has a straight path with a step towards the target.
 
 <div class="mt-4 bg-[var(--vp-code-block-bg)] rounded-lg h-50">
-  <VueFlow v-model="stepEdge">
+  <VueFlow v-model:nodes="nodes" v-model:edges="stepEdges">
     <Background class="rounded-lg" />
   </VueFlow>
 </div>
@@ -439,7 +439,7 @@ A step edge has a straight path with a step towards the target.
 The same as the step edge though with a border radius on the step (rounded step).
 
 <div class="mt-4 bg-[var(--vp-code-block-bg)] rounded-lg h-50">
-  <VueFlow v-model="smoothStepEdge">
+  <VueFlow v-model:nodes="nodes" v-model:edges="smoothStepEdges">
     <Background class="rounded-lg" />
   </VueFlow>
 </div>
@@ -449,7 +449,7 @@ The same as the step edge though with a border radius on the step (rounded step)
 A simple straight path.
 
 <div class="mt-4 bg-[var(--vp-code-block-bg)] rounded-lg h-50">
-  <VueFlow v-model="straightEdge">
+  <VueFlow v-model:nodes="straightNodes" v-model:edges="straightEdges">
     <Background class="rounded-lg" />
   </VueFlow>
 </div>
@@ -910,7 +910,8 @@ function logEvent(eventName, data) {
 
 <div class="mt-4 bg-[var(--vp-code-block-bg)] rounded-lg h-50">
   <VueFlow 
-    v-model="bezierEdge" 
+    v-model:nodes="nodes" 
+    v-model:edges="bezierEdges" 
     @edge-click="logEvent('edge clicked', $event)"
     @edge-double-click="logEvent('edge double clicked', $event)"
     @edge-context-menu="logEvent('edge context menu', $event)"

--- a/docs/src/guide/node.md
+++ b/docs/src/guide/node.md
@@ -61,7 +61,7 @@ For the full list of options available for a node, check out the [Node Interface
 
 ## Adding Nodes to the Graph
 
-Nodes are rendered by passing them to the `nodes` prop (or the deprecated `v-model` prop) of the Vue Flow component.
+Nodes are rendered by passing them to the `nodes` prop (or `v-model:nodes` for two-way binding) of the Vue Flow component.
 
 :::warning
 This method will *not* create a change. Check out the [Controlled Flow](/guide/controlled-flow.html) section for more information.
@@ -249,7 +249,7 @@ This will allow you to mutate *your* nodes and have the changes reflected in the
 
 ## Removing Nodes from the Graph
 
-Similar to adding nodes, nodes can be removed from the graph by removing them from the `mode-value` (using `v-model`) or from the `nodes` prop of the Vue Flow component.
+Similar to adding nodes, nodes can be removed from the graph by removing them from your bound array (using `v-model:nodes`) or from the `nodes` prop of the Vue Flow component.
 
 ```vue
 <script setup>
@@ -449,7 +449,7 @@ const nodes = ref([
 ```
 
 <div class="mt-4 bg-[var(--vp-code-block-bg)] rounded-lg h-50">
-  <VueFlow v-model="defaultNode">
+  <VueFlow v-model:nodes="defaultNode">
     <Background class="rounded-lg" />
   </VueFlow>
 </div>
@@ -474,7 +474,7 @@ const nodes = ref([
 ```
 
 <div class="mt-4 bg-[var(--vp-code-block-bg)] rounded-lg h-50">
-  <VueFlow v-model="inputNode">
+  <VueFlow v-model:nodes="inputNode">
     <Background class="rounded-lg" />
   </VueFlow>
 </div>
@@ -499,7 +499,7 @@ const nodes = ref([
 ```
 
 <div class="mt-4 bg-[var(--vp-code-block-bg)] rounded-lg h-50">
-  <VueFlow v-model="outputNode">
+  <VueFlow v-model:nodes="outputNode">
      <Background class="rounded-lg" />
   </VueFlow>
 </div>
@@ -857,7 +857,7 @@ function logEvent(name, data) {
 
 <div class="mt-4 bg-[var(--vp-code-block-bg)] rounded-lg h-50">
   <VueFlow 
-    v-model="defaultNode" 
+    v-model:nodes="defaultNode" 
     @node-drag-start="logEvent('drag start', $event)"
     @node-drag="logEvent('drag', $event)"
     @node-drag-stop="logEvent('drag stop', $event)"
@@ -921,7 +921,7 @@ const listItems = ref(Array.from({ length: 100 }, (_, i) => i))
 ```
 
 <div class="mt-4 bg-[var(--vp-code-block-bg)] rounded-lg h-50">
-  <VueFlow :model-value="[{ id: '1', type: 'scrollable', label: 'Node 1', position: { x: 50, y: 50 } }]">
+  <VueFlow :nodes="[{ id: '1', type: 'scrollable', label: 'Node 1', position: { x: 50, y: 50 } }]">
     <template #node-scrollable>
       <ScrollableNode />
     </template>
@@ -967,7 +967,7 @@ const inputValue = ref('')
 ```
 
 <div class="mt-4 bg-[var(--vp-code-block-bg)] rounded-lg h-50">
-  <VueFlow :model-value="[{ id: '1', type: 'input-field', label: 'Node 1', position: { x: 50, y: 50 } }]">
+  <VueFlow :nodes="[{ id: '1', type: 'input-field', label: 'Node 1', position: { x: 50, y: 50 } }]">
     <template #node-input-field>
       <InputFieldNode />
     </template>

--- a/docs/src/guide/theming.md
+++ b/docs/src/guide/theming.md
@@ -13,9 +13,12 @@ const CustomNode = (props) => h('div', [
   h(Handle, { connectable: false, type: 'source', position: Position.Bottom }),
 ]);
 
-const elements = ref([
+const nodes = ref([
   { id: '1', label: 'Node 1', position: { x: 0, y: 0 }, draggable: false, deletable: false, selectable: false, type: 'custom' },
   { id: '2', label: 'Node 2', position: { x: 75, y: 75 }, draggable: false, deletable: false, selectable: false, type: 'custom' },
+])
+
+const edges = ref([
   { id: 'e1-2', source: '1', target: '2', animated: true, selectable: false, deletable: false },
 ])
 </script>
@@ -63,7 +66,7 @@ Here's how you can use CSS classes to add a pop of color or alter the font style
 ```
 
 <div class="mt-4 bg-[var(--vp-code-block-bg)] rounded-lg h-50">
-  <VueFlow v-model="elements" fit-view>
+  <VueFlow v-model:nodes="nodes" v-model:edges="edges" fit-view>
     <template #node-custom="props">
       <CustomNode v-bind="props" />
     </template>

--- a/docs/src/guide/troubleshooting.md
+++ b/docs/src/guide/troubleshooting.md
@@ -49,8 +49,8 @@ const nodes = ref([
 // Here's an example of a valid nested node configuration
 const nodes = ref([
   { id: '1', type: 'input', label: 'Node 1', position: { x: 250, y: 5 } },
-  { id: '2', label: 'Node 2', position: { x: 100, y: 100 }, parentNode: '1' },
-  { id: '3', type: 'output', label: 'Node 3', position: { x: 400, y: 200 }, parentNode: '1' },
+  { id: '2', label: 'Node 2', position: { x: 100, y: 100 }, parentId: '1' },
+  { id: '3', type: 'output', label: 'Node 3', position: { x: 400, y: 200 }, parentId: '1' },
 ])
 ```
 

--- a/docs/src/guide/utils/graph.md
+++ b/docs/src/guide/utils/graph.md
@@ -8,28 +8,28 @@
 
 - Example:
 
-```vue{13}
+```vue{17}
 <script setup>
 import { VueFlow, isEdge } from '@vue-flow/core'
 
-const elements = ref([
+const nodes = ref([
   { id: '1', position: { x: 250, y: 5 }, },
   { id: '2', position: { x: 100, y: 100 }, },
+])
 
+const edges = ref([
   { id: 'e1-2', source: '1', target: '2', class: 'light' },
 ])
 
 const toggleClass = () => {
-  elements.value.forEach((el) => {
-    if (isEdge(el)) {
-      el.class = el.class === 'light' ? 'dark' : 'light'
-    }
-  })
+  edges.value = edges.value.map((el) =>
+    isEdge(el) ? { ...el, class: el.class === 'light' ? 'dark' : 'light' } : el,
+  )
 }
 </script>
 
 <template>
-  <VueFlow v-model="elements">
+  <VueFlow v-model:nodes="nodes" v-model:edges="edges">
     <button @click="toggleClass">Toggle classes</button>
   </VueFlow>
 </template>
@@ -43,28 +43,28 @@ const toggleClass = () => {
 
 - Example:
 
-```vue{13}
+```vue{17}
 <script setup>
 import { VueFlow, isNode } from '@vue-flow/core'
 
-const elements = ref([
+const nodes = ref([
   { id: '1', label: 'Node 1', position: { x: 250, y: 5 }, class: 'light' },
   { id: '2', label: 'Node 2', position: { x: 100, y: 100 }, class: 'light' },
+])
 
+const edges = ref([
   { id: 'e1-2', source: '1', target: '2' },
 ])
 
 const toggleClass = () => {
-  elements.value.forEach((el) => {
-    if (isNode(el)) {
-      el.class = el.class === 'light' ? 'dark' : 'light'
-    }
-  })
+  nodes.value = nodes.value.map((el) =>
+    isNode(el) ? { ...el, class: el.class === 'light' ? 'dark' : 'light' } : el,
+  )
 }
 </script>
 
 <template>
-  <VueFlow v-model="elements">
+  <VueFlow v-model:nodes="nodes" v-model:edges="edges">
     <button @click="toggleClass">Toggle classes</button>
   </VueFlow>
 </template>

--- a/docs/src/guide/utils/instance.md
+++ b/docs/src/guide/utils/instance.md
@@ -1,7 +1,7 @@
 # Viewport Functions
 
 Viewport Functions can be accessed via the [`useVueFlow`](/guide/composables#usevueflow)
-utility or with the [`VueFlowStore`](/typedocs/type-aliases/VueFlowStore)
+utility or with the [`VueFlowInstance`](/typedocs/type-aliases/VueFlowInstance)
 instance provided by [`onPaneReady`](/typedocs/interfaces/FlowEvents#paneready).
 
 - Using Event Hooks (Composable)

--- a/docs/src/guide/vue-flow/config.md
+++ b/docs/src/guide/vue-flow/config.md
@@ -71,7 +71,7 @@ const toggleNodesDraggable = () => {
 
   An array of nodes.
 
-  Use either the modelValue prop or nodes separately. __Do not mix them!__
+  Pass via the `nodes` prop, or use `v-model:nodes` for two-way binding.
 
 - Example:
 
@@ -118,7 +118,7 @@ const nodes = ref([
 
   An array of edges.
 
-  Use either the modelValue prop or edges separately. __Do not mix them!__
+  Pass via the `edges` prop, or use `v-model:edges` for two-way binding.
 
 - Example:
 
@@ -169,15 +169,12 @@ const edges = ref([
 </template>
 ```
 
-### modelValue (optional) (deprecated)
-
-- Type: [`Elements`](/typedocs/type-aliases/Elements)
+### Two-way binding (`v-model`)
 
 - Details:
 
-  An array of elements (nodes + edges).
-
-  Use either the modelValue prop or nodes/edges separately. __Do not mix them!__
+  For two-way binding, use `v-model:nodes` and `v-model:edges`. The combined `v-model` (the old
+  `modelValue` of mixed nodes + edges) was removed in 2.0 — bind nodes and edges separately.
 
 - Example:
 
@@ -186,18 +183,21 @@ const edges = ref([
 import { ref } from 'vue'  
 import { VueFlow } from '@vue-flow/core'
 
-const elements = ref([
+const nodes = ref([
   { id: '1', type: 'input', label: 'Node 1', position: { x: 250, y: 5 } },
   { id: '2', label: 'Node 2', position: { x: 100, y: 100 }, },
   { id: '3', label: 'Node 3', position: { x: 400, y: 100 } },
   { id: '4', type: 'output', label: 'Node 4', position: { x: 400, y: 200 } },
+])
+
+const edges = ref([
   { id: 'e1-3', source: '1', target: '3' },
   { id: 'e1-2', source: '1', target: '2', animated: true },
 ])
 </script>
 
 <template>
-  <VueFlow v-model="elements" />
+  <VueFlow v-model:nodes="nodes" v-model:edges="edges" />
 </template>
 ```
 


### PR DESCRIPTION
Cleans up the docs to use 2.0 APIs (examples/vite was already migrated by the strictTemplates pass).

## Changes
- **`VueFlowStore` → `VueFlowInstance`** (the type was renamed in 2.0): home-flow components (`Features`, `Intro`, `RGB`, `Basic`) + the instance/composables guides, including the typedoc link.
- **`parentNode` → `parentId`** in node examples. For the `MiniMapNodeProps` table, the prop was *removed* in 2.0 (not renamed — `MiniMapNodeProps` has neither `parentNode` nor `parentId`), so the stale row was dropped.
- **Combined `v-model` → `v-model:nodes` / `v-model:edges`** (combined `v-model`/`modelValue` was removed in 2.0): the node/edge/theming/graph/config guides. Mixed `elements` arrays were split into separate `nodes`/`edges` refs and the toggle handlers rewritten immutably (matching the 2.0 model). Prose describing the removed combined binding was updated.

## Verification
`grep -rnE "VueFlowStore\b|parentNode:|<VueFlow[^>]*v-model=\"" docs/components docs/src/guide` → **clean**. Spot-checked the `v-model` splits for correctness.

> Note: the docs build (`typedoc:md && vitepress build`) does not complete in this environment due to a **pre-existing** toolchain skew — `typedoc-plugin-markdown@4.9.0` vs `typedoc@0.26.11` (named-export mismatch), and `.vitepress/config` `require`-ing `@vue-flow/core/package.json` which the package's `exports` map doesn't expose. Both are independent of these content edits (no config/deps touched). Worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)