### PR TITLE
docs(examples): use onBeforeDelete in the confirm-delete example

### DIFF
--- a/docs/examples/confirm-delete/App.vue
+++ b/docs/examples/confirm-delete/App.vue
@@ -4,7 +4,7 @@ import { Background, VueFlow, useVueFlow } from '@vue-flow/core'
 import { useDialog } from './useDialog'
 import Dialog from './Dialog.vue'
 
-const { onConnect, addEdges, onNodesChange, onEdgesChange, applyNodeChanges, applyEdgeChanges } = useVueFlow()
+const { onConnect, addEdges } = useVueFlow()
 
 const dialog = useDialog()
 
@@ -15,7 +15,7 @@ const nodes = ref([
 
 const edges = ref([{ id: 'e1-2', source: '1', target: '2' }])
 
-function dialogMsg(id) {
+function dialogMsg(ids) {
   return h(
     'span',
     {
@@ -26,51 +26,23 @@ function dialogMsg(id) {
         gap: '8px',
       },
     },
-    [`Are you sure?`, h('br'), h('span', `[ELEMENT_ID: ${id}]`)],
+    [`Are you sure?`, h('br'), h('span', `[ELEMENTS: ${ids.join(', ')}]`)],
   )
 }
 
 onConnect(addEdges)
 
-onNodesChange(async (changes) => {
-  const nextChanges = []
+// `onBeforeDelete` is consulted once for the whole deletion (the node plus its connected edges) — return
+// `false` to cancel or `true` to proceed, instead of intercepting individual change events.
+async function onBeforeDelete({ nodes, edges }) {
+  const ids = [...nodes.map((node) => node.id), ...edges.map((edge) => edge.id)]
 
-  for (const change of changes) {
-    if (change.type === 'remove') {
-      const isConfirmed = await dialog.confirm(dialogMsg(change.id))
-
-      if (isConfirmed) {
-        nextChanges.push(change)
-      }
-    } else {
-      nextChanges.push(change)
-    }
-  }
-
-  applyNodeChanges(nextChanges)
-})
-
-onEdgesChange(async (changes) => {
-  const nextChanges = []
-
-  for (const change of changes) {
-    if (change.type === 'remove') {
-      const isConfirmed = await dialog.confirm(dialogMsg(change.id))
-
-      if (isConfirmed) {
-        nextChanges.push(change)
-      }
-    } else {
-      nextChanges.push(change)
-    }
-  }
-
-  applyEdgeChanges(nextChanges)
-})
+  return dialog.confirm(dialogMsg(ids))
+}
 </script>
 
 <template>
-  <VueFlow :nodes="nodes" :edges="edges" :apply-default="false" fit-view class="confirm-flow">
+  <VueFlow :nodes="nodes" :edges="edges" :on-before-delete="onBeforeDelete" fit-view class="confirm-flow">
     <Background />
 
     <Dialog />

--- a/examples/vite/src/ConfirmDelete/ConfirmDeleteExample.vue
+++ b/examples/vite/src/ConfirmDelete/ConfirmDeleteExample.vue
@@ -1,10 +1,10 @@
 <script lang="ts" setup>
-import type { Edge, EdgeChange, Node, NodeChange } from '@vue-flow/core'
+import type { Edge, Node, OnBeforeDelete } from '@vue-flow/core'
 import { Background, VueFlow, useVueFlow } from '@vue-flow/core'
 import { useDialog } from './useDialog'
 import Dialog from './Dialog.vue'
 
-const { onConnect, addEdges, onNodesChange, onEdgesChange, applyNodeChanges, applyEdgeChanges } = useVueFlow()
+const { onConnect, addEdges } = useVueFlow()
 
 const dialog = useDialog({ message: 'Do you really want to delete this item?' })
 
@@ -22,45 +22,13 @@ const edges = ref<Edge[]>([
 
 onConnect(addEdges)
 
-onNodesChange(async (changes) => {
-  const nextChanges: NodeChange[] = []
-
-  for (const change of changes) {
-    if (change.type === 'remove') {
-      const isConfirmed = await dialog.confirm()
-
-      if (isConfirmed) {
-        nextChanges.push(change)
-      }
-    } else {
-      nextChanges.push(change)
-    }
-  }
-
-  applyNodeChanges(nextChanges)
-})
-
-onEdgesChange(async (changes) => {
-  const nextChanges: EdgeChange[] = []
-
-  for (const change of changes) {
-    if (change.type === 'remove') {
-      const isConfirmed = await dialog.confirm()
-
-      if (isConfirmed) {
-        nextChanges.push(change)
-      }
-    } else {
-      nextChanges.push(change)
-    }
-  }
-
-  applyEdgeChanges(nextChanges)
-})
+// `onBeforeDelete` is consulted once per deletion (a node together with its connected edges) — return
+// `false` to cancel or `true` to proceed. Replaces the old `apply-default="false"` + per-change dialog.
+const onBeforeDelete: OnBeforeDelete = () => dialog.confirm()
 </script>
 
 <template>
-  <VueFlow :nodes="nodes" :edges="edges" :apply-default="false" fit-view class="vue-flow-basic-example">
+  <VueFlow :nodes="nodes" :edges="edges" :on-before-delete="onBeforeDelete" fit-view class="vue-flow-basic-example">
     <Background />
 
     <Dialog />


### PR DESCRIPTION
Follow-up to #2071 — migrates the confirm-delete example to the new `onBeforeDelete` hook.

## Before
Both the vite example (`examples/vite/src/ConfirmDelete`) and the docs live example (`docs/examples/confirm-delete`) used the `apply-default="false"` workaround: manually intercepting `onNodesChange`/`onEdgesChange`, awaiting a confirm dialog **per `'remove'` change**, and re-applying only confirmed changes. (This is the exact pattern #1630 found awkward — deleting a node and its edges asked multiple times.)

## After
A single `:on-before-delete` handler:
```ts
const onBeforeDelete: OnBeforeDelete = () => dialog.confirm()
```
`onBeforeDelete` is consulted **once per deletion** with the whole set (`{ nodes, edges }`), so a node and its connected edges are confirmed together. No `apply-default="false"`, no change-array juggling. The docs example shows the gathered ids in the dialog.

## Verification
Examples `vue-tsc` clean (the `:on-before-delete` prop + `OnBeforeDelete` type check under strictTemplates). The delete-key → `onBeforeDelete` behaviour is covered by the tests in #2071.

🤖 Generated with [Claude Code](https://claude.com/claude-code)