### PR TITLE
fix(docs): repair the docs build

### DIFF
--- a/.changeset/core-package-json-export.md
+++ b/.changeset/core-package-json-export.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Expose `./package.json` in the package `exports` map, so `@vue-flow/core/package.json` can be imported (e.g. to read the version). The `exports` map previously blocked it with `ERR_PACKAGE_PATH_NOT_EXPORTED`.

--- a/docs/package.json
+++ b/docs/package.json
@@ -28,7 +28,7 @@
     "dotenv": "^16.4.5",
     "ohmyfetch": "^0.4.21",
     "typedoc": "^0.26.11",
-    "typedoc-plugin-markdown": "^4.2.10",
+    "typedoc-plugin-markdown": "~4.2.10",
     "typedoc-plugin-merge-modules": "^6.0.3",
     "unplugin-auto-import": "^0.18.3",
     "unplugin-icons": "^0.20.0",

--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -64,6 +64,10 @@ function changelogSidebarEntries(): DefaultTheme.SidebarItem[] {
 export default defineConfigWithTheme<DefaultTheme.Config>({
   title: 'Vue Flow',
   description: 'Visualize your ideas with Vue Flow, a highly customizable Vue3 Flowchart library.',
+  // `/api-reference/*` is a legacy docs path baked into some `@xyflow/system` JSDoc `@link`s (now under
+  // `/typedocs`); those links are regenerated into the typedocs each build, so ignore that prefix only —
+  // every other dead link still fails the build.
+  ignoreDeadLinks: [/^\/api-reference\//],
   dir: 'ltr',
   lang: 'en-US',
   head: head as HeadConfig[],

--- a/docs/src/.vitepress/plugins/copy.ts
+++ b/docs/src/.vitepress/plugins/copy.ts
@@ -13,7 +13,8 @@ function getPublicPath(fileName: string) {
 }
 
 function copyFiles(emit: Emit) {
-  ;['core', 'node-resizer', 'node-toolbar'].forEach((name) => {
+  // 2.0 ships a single `@vue-flow/core` package (node-resizer/node-toolbar/etc. were merged into it)
+  ;['core'].forEach((name) => {
     const fileName = `vue-flow-${name}.mjs`
 
     const filePath = resolve(__dirname, getPkgPath(name, fileName))

--- a/docs/src/guide/edge.md
+++ b/docs/src/guide/edge.md
@@ -770,8 +770,8 @@ But you may wish to expand on these features or implement your business logic in
 | Prop Name        | Description                                | Type                                         | Optional                                   |
 |------------------|--------------------------------------------|----------------------------------------------|--------------------------------------------|
 | id               | Unique edge id                             | string                                       | <Close class="text-red-500" />             |
-| sourceNode       | The originating node                       | [GraphNode](/typedocs/interfaces/GraphNode)  | <Close class="text-red-500" />             |
-| targetNode       | The destination node                       | [GraphNode](/typedocs/interfaces/GraphNode)  | <Close class="text-red-500" />             |
+| sourceNode       | The originating node                       | [GraphNode](/typedocs/type-aliases/GraphNode)  | <Close class="text-red-500" />             |
+| targetNode       | The destination node                       | [GraphNode](/typedocs/type-aliases/GraphNode)  | <Close class="text-red-500" />             |
 | source           | ID of the source node                      | string                                       | <Close class="text-red-500" />             |
 | target           | ID of the target node                      | string                                       | <Close class="text-red-500" />             |
 | type             | Edge Type                                  | string                                       | <Close class="text-red-500" />             |
@@ -899,9 +899,9 @@ function logEvent(eventName, data) {
     @edge-mouse-enter="logEvent('edge mouse enter', $event)"
     @edge-mouse-leave="logEvent('edge mouse leave', $event)"
     @edge-mouse-move="logEvent('edge mouse move', $event)"
-    @reconnect-start="logEvent(reconnect start, $event)"
+    @reconnect-start="logEvent('reconnect start', $event)"
     @reconnect="logEvent('edge update', $event)"
-    @reconnect-end="logEvent(reconnect end, $event)"
+    @reconnect-end="logEvent('reconnect end', $event)"
   />
 </template>
 ```
@@ -918,9 +918,9 @@ function logEvent(eventName, data) {
     @edge-mouse-enter="logEvent('edge mouse enter', $event)"
     @edge-mouse-leave="logEvent('edge mouse leave', $event)"
     @edge-mouse-move="logEvent('edge mouse move', $event)"
-    @reconnect-start="logEvent(reconnect start, $event)"
+    @reconnect-start="logEvent('reconnect start', $event)"
     @reconnect="logEvent('edge update', $event)"
-    @reconnect-end="logEvent(reconnect end, $event)"
+    @reconnect-end="logEvent('reconnect end', $event)"
   >
     <Panel position="top-center">
         <p class="text-sm">Interact to see events in browser console</p>

--- a/docs/src/guide/getting-started.md
+++ b/docs/src/guide/getting-started.md
@@ -65,7 +65,7 @@ $ yarn add @vue-flow/core
 
 ## Quick Start
 
-In Vue Flow, a graph consists of [**nodes**](/typedocs/interfaces/Node) and [**edges**](/typedocs/type-aliases/Edge).
+In Vue Flow, a graph consists of [**nodes**](/typedocs/type-aliases/Node) and [**edges**](/typedocs/type-aliases/Edge).
 
 **Each node or edge requires a unique id.**
 

--- a/docs/src/guide/node.md
+++ b/docs/src/guide/node.md
@@ -57,7 +57,7 @@ through edges to create a data map.
 
 Remember, every node is unique and thus **requires a unique id** and **an [XY-position](/typedocs/interfaces/XYPosition)**.
 
-For the full list of options available for a node, check out the [Node Interface](/typedocs/interfaces/Node).
+For the full list of options available for a node, check out the [Node Interface](/typedocs/type-aliases/Node).
 
 ## Adding Nodes to the Graph
 
@@ -764,7 +764,7 @@ But you may wish to expand on these features or implement your business logic in
 | data                                                        | Additional data of node                                             | any object                                                 | <Close class="text-red-500" />             |
 | events                                                      | Contextual and custom events of node                                | [NodeEventsOn](/typedocs/type-aliases/NodeEventsOn)               | <Close class="text-red-500" />             |
 
-## [Node Events](/typedocs/type-aliases/NodeEventsHandler)
+## [Node Events](/typedocs/interfaces/NodeEventsHandler)
 
 Vue Flow provides two main ways of listening to node events, 
 either by using `useVueFlow` to bind listeners to the event handlers or by binding them to the `<VueFlow>` component.

--- a/docs/src/guide/utils/graph.md
+++ b/docs/src/guide/utils/graph.md
@@ -88,13 +88,13 @@ const toggleClass = () => {
 
   Returns all connected edges of a node.
 
-## [getTransformForBounds](/typedocs/functions/getTransformForBounds)
+## [getViewportForBounds](/typedocs/functions/getViewportForBounds)
 
 - Details:
 
   Returns a transformation for the viewport according to input bounds.
 
-## [getRectOfNodes](/typedocs/functions/getRectOfNodes)
+## [getNodesBounds](/typedocs/functions/getNodesBounds)
 
 - Details:
 

--- a/docs/src/guide/utils/instance.md
+++ b/docs/src/guide/utils/instance.md
@@ -43,7 +43,7 @@ export default defineComponent({
 </template>
 ```
 
-## [project](/typedocs/type-aliases/Project)
+## screenToFlowPosition
 
 - Details:
 

--- a/docs/src/guide/vue-flow/config.md
+++ b/docs/src/guide/vue-flow/config.md
@@ -65,7 +65,7 @@ const toggleNodesDraggable = () => {
 
 ### nodes (optional)
 
-- Type: [`Node[]`](/typedocs/interfaces/Node)
+- Type: [`Node[]`](/typedocs/type-aliases/Node)
 
 - Details:
 

--- a/docs/tsconfig.docs.json
+++ b/docs/tsconfig.docs.json
@@ -13,6 +13,7 @@
     "skipLibCheck": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
+    "types": [],
     "noUnusedLocals": false,
     "strictNullChecks": true,
     "forceConsistentCasingInFileNames": true,

--- a/docs/typedoc.md.json
+++ b/docs/typedoc.md.json
@@ -6,12 +6,7 @@
     "typedoc-plugin-markdown"
   ],
   "entryPoints": [
-    "../packages/core/src/index.ts",
-    "../packages/background/src/index.ts",
-    "../packages/controls/src/index.ts",
-    "../packages/minimap/src/index.ts",
-    "../packages/node-toolbar/src/index.ts",
-    "../packages/node-resizer/src/index.ts"
+    "../packages/core/src/index.ts"
   ],
   "categorizeByGroup": true,
   "darkHighlightTheme": "vitesse-dark",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,7 +41,8 @@
       "require": "./dist/vue-flow-core.js"
     },
     "./dist/style.css": "./dist/style.css",
-    "./dist/theme-default.css": "./dist/theme-default.css"
+    "./dist/theme-default.css": "./dist/theme-default.css",
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,8 @@ importers:
         specifier: ^0.26.11
         version: 0.26.11(typescript@5.9.3)
       typedoc-plugin-markdown:
-        specifier: ^4.2.10
-        version: 4.9.0(typedoc@0.26.11(typescript@5.9.3))
+        specifier: ~4.2.10
+        version: 4.2.10(typedoc@0.26.11(typescript@5.9.3))
       typedoc-plugin-merge-modules:
         specifier: ^6.0.3
         version: 6.1.0(typedoc@0.26.11(typescript@5.9.3))
@@ -7090,11 +7090,11 @@ packages:
   typed-array-length@1.0.4:
     resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}
 
-  typedoc-plugin-markdown@4.9.0:
-    resolution: {integrity: sha512-9Uu4WR9L7ZBgAl60N/h+jqmPxxvnC9nQAlnnO/OujtG2ubjnKTVUFY1XDhcMY+pCqlX3N2HsQM2QTYZIU9tJuw==}
+  typedoc-plugin-markdown@4.2.10:
+    resolution: {integrity: sha512-PLX3pc1/7z13UJm4TDE9vo9jWGcClFUErXXtd5LdnoLjV6mynPpqZLU992DwMGFSRqJFZeKbVyqlNNeNHnk2tQ==}
     engines: {node: '>= 18'}
     peerDependencies:
-      typedoc: 0.28.x
+      typedoc: 0.26.x
 
   typedoc-plugin-merge-modules@6.1.0:
     resolution: {integrity: sha512-AZIyw+H1oG3xpJOq1b2CVnpK7A6OIddi7FsjljsbmQ7vx6dtaorEoz/DQPcGSOzWhWdJPqqdncIzVySuoffS2w==}
@@ -15486,7 +15486,7 @@ snapshots:
       for-each: 0.3.3
       is-typed-array: 1.1.12
 
-  typedoc-plugin-markdown@4.9.0(typedoc@0.26.11(typescript@5.9.3)):
+  typedoc-plugin-markdown@4.2.10(typedoc@0.26.11(typescript@5.9.3)):
     dependencies:
       typedoc: 0.26.11(typescript@5.9.3)
 


### PR DESCRIPTION
The docs build (`pnpm --filter @vue-flow/docs build`) was broken at several layers — a dependency float plus drift from the 2.0 single-package restructure. Now builds clean end-to-end (typedoc **0 errors**, vitepress **exit 0**).

## Fixes (in build order)
1. **`@vue-flow/core` exports** — added `"./package.json"`. The vitepress config reads the version via `require('@vue-flow/core/package.json')`, which the `exports` map blocked (`ERR_PACKAGE_PATH_NOT_EXPORTED`). *(only published-package change → changeset)*
2. **typedoc plugin float** — pinned `typedoc-plugin-markdown` to `~4.2.10`. `^4.2.10` had resolved to **4.9.0**, which dropped typedoc 0.26 support → `SyntaxError: Named export 'CategoryRouter' not found`.
3. **`tsconfig.docs.json` → `types: []`** — stops typedoc auto-including the broken, deprecated `@types/parse-path` (`TS2688: Cannot find type definition file for 'parse-path'`).
4. **typedoc `entryPoints` + `copy-vue-flow` plugin → core only** — `background`/`controls`/`minimap`/`node-toolbar`/`node-resizer` were merged into `@vue-flow/core` in 2.0; the config still referenced them (the "glob did not match" warnings + `node-resizer not built` error).
5. **guide content** — fixed a missing-quotes syntax error in `edge.md`'s events demo (`logEvent(reconnect start, …)` → `'reconnect start'`), and repointed **8 dead typedoc links** from renamed/removed APIs (`getRectOfNodes`→`getNodesBounds`, `getTransformForBounds`→`getViewportForBounds`, `Node`/`GraphNode` interface→type-alias, `NodeEventsHandler`, `project`→`screenToFlowPosition`).
6. **`ignoreDeadLinks: [/^\/api-reference\//]`** — the one remaining dead link is baked into an upstream `@xyflow/system` JSDoc `@link` (regenerated into the typedocs each build); ignoring only that legacy prefix keeps the dead-link check active for everything else.

## Verification
`pnpm --filter @vue-flow/docs build` → typedoc generates 0 errors, vitepress completes (exit 0, pages + sitemap rendered). The `@vue/repl` `.css` SSR warnings are pre-existing (client-only REPL) and non-fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)