### PR TITLE
refactor(core): adopt typeof and ?? over instanceof Function and ||

### DIFF
--- a/packages/core/src/components/Edges/EdgeWrapper.ts
+++ b/packages/core/src/components/Edges/EdgeWrapper.ts
@@ -20,7 +20,7 @@ function getNodeHandles(node: GraphNode, side: 'source' | 'target', strict: bool
   }
 
   const other = side === 'source' ? 'target' : 'source';
-  return [...(bounds?.[side] || []), ...(bounds?.[other] || [])];
+  return [...(bounds?.[side] ?? []), ...(bounds?.[other] ?? [])];
 }
 
 const EdgeWrapper = defineComponent({
@@ -93,9 +93,11 @@ const EdgeWrapper = defineComponent({
     // not the internal `{ ...defaultEdgeOptions, ...edge }` render view — only the resolved fn is read off
     // the merged view so a defaults-provided callback still applies
     const edgeClass = computed(() =>
-      edge.value.class instanceof Function ? edge.value.class(storedEdge.value) : edge.value.class,
+      typeof edge.value.class === 'function' ? edge.value.class(storedEdge.value) : edge.value.class,
     );
     const edgeStyle = computed(() =>
+      // `edge.style` can be a function at runtime (a style callback); the type doesn't model it
+      // eslint-disable-next-line unicorn/no-instanceof-builtins
       edge.value.style instanceof Function ? edge.value.style(storedEdge.value) : edge.value.style,
     );
 

--- a/packages/core/src/components/Nodes/NodeWrapper.ts
+++ b/packages/core/src/components/Nodes/NodeWrapper.ts
@@ -169,13 +169,16 @@ const NodeWrapper = defineComponent({
       if (!node) {
         return undefined;
       }
-      return node.class instanceof Function ? node.class(node) : node.class;
+      return typeof node.class === 'function' ? node.class(node) : node.class;
     });
 
     const getStyle = computed(() => {
       const node = nodeRef.value;
       // clone: never mutate the user's `node.style` (nodes are markRaw, so an in-place write isn't
       // reactive AND would cache stale width/height onto the user object across renders)
+      // `node.style` can be a function at runtime (a style callback); the `Styles` type doesn't model
+      // that, so `typeof` would narrow it to `never` — keep `instanceof Function`.
+      // eslint-disable-next-line unicorn/no-instanceof-builtins
       const styles = { ...(node?.style instanceof Function ? node.style(node) : node?.style) };
 
       const width = node?.width;

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -565,7 +565,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
   };
 
   const setNodes: Actions<NodeType>['setNodes'] = (nodes) => {
-    const nextNodes = nodes instanceof Function ? nodes(state.nodes) : nodes;
+    const nextNodes = typeof nodes === 'function' ? nodes(state.nodes) : nodes;
 
     if (!state.initialized && !nextNodes.length) {
       return;
@@ -576,7 +576,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
   };
 
   const setEdges: Actions<NodeType, EdgeType>['setEdges'] = (edges) => {
-    const nextEdges = edges instanceof Function ? edges(state.edges) : edges;
+    const nextEdges = typeof edges === 'function' ? edges(state.edges) : edges;
 
     if (!state.initialized && !nextEdges.length) {
       return;
@@ -596,7 +596,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
   };
 
   const addNodes: Actions<NodeType>['addNodes'] = (nodes) => {
-    let nextNodes = nodes instanceof Function ? nodes(state.nodes) : nodes;
+    let nextNodes = typeof nodes === 'function' ? nodes(state.nodes) : nodes;
     nextNodes = Array.isArray(nextNodes) ? nextNodes : [nextNodes];
 
     // Emit `add` changes for the valid user nodes (filter invalid up front — `applyChanges` would
@@ -615,7 +615,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
   };
 
   const addEdges: Actions<NodeType, EdgeType>['addEdges'] = (params) => {
-    let nextEdges = params instanceof Function ? params(state.edges) : params;
+    let nextEdges = typeof params === 'function' ? params(state.edges) : params;
     nextEdges = Array.isArray(nextEdges) ? nextEdges : [nextEdges];
 
     // the `add` change items are the validated USER edges (a `Connection` becomes a new edge with
@@ -641,7 +641,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
   };
 
   const removeNodes: Actions<NodeType>['removeNodes'] = (nodes, removeConnectedEdges = true, removeChildren = false) => {
-    const nextNodes = nodes instanceof Function ? nodes(state.nodes) : nodes;
+    const nextNodes = typeof nodes === 'function' ? nodes(state.nodes) : nodes;
     const nodesToRemove = Array.isArray(nextNodes) ? nextNodes : [nextNodes];
 
     const nodeChanges: NodeRemoveChange[] = [];
@@ -714,7 +714,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
   };
 
   const removeEdges: Actions<NodeType, EdgeType>['removeEdges'] = (edges) => {
-    const nextEdges = edges instanceof Function ? edges(state.edges) : edges;
+    const nextEdges = typeof edges === 'function' ? edges(state.edges) : edges;
     const edgesToRemove = Array.isArray(nextEdges) ? nextEdges : [nextEdges];
 
     const changes: EdgeRemoveChange[] = [];
@@ -985,7 +985,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
   };
 
   const setState: Actions<NodeType, EdgeType>['setState'] = (options) => {
-    const opts = options instanceof Function ? options(state) : options;
+    const opts = typeof options === 'function' ? options(state) : options;
 
     // these options cannot be set after initialization
     const exclude: (keyof typeof opts)[] = ['viewportRef', 'vueFlowRef', 'dimensions', 'hooks'];

--- a/packages/core/src/utils/changes.ts
+++ b/packages/core/src/utils/changes.ts
@@ -97,7 +97,7 @@ export function applyChanges<
               const setW = currentChange.setAttributes === true || currentChange.setAttributes === 'width';
               const setH = currentChange.setAttributes === true || currentChange.setAttributes === 'height';
               updated.style = {
-                ...(updated.style || {}),
+                ...(updated.style ?? {}),
                 ...(setW && { width: `${currentChange.dimensions?.width}px` }),
                 ...(setH && { height: `${currentChange.dimensions?.height}px` }),
               };

--- a/tooling/eslint-config/index.mts
+++ b/tooling/eslint-config/index.mts
@@ -24,11 +24,5 @@ export default antfu({
     // misfires on the documented overloaded composables (useNodesData/useEdgesData): the shared JSDoc
     // block sits above the first overload, so `@param guard` reads as "not matching" a parameter
     'jsdoc/check-param-names': 'off',
-    // Keep these OFF: their `--fix` rewrites *existing* code in behaviour-changing ways. `||` → `??`
-    // (antfu's e18e plugin) differs for `0` / `''` / `false` — it silently broke viewport/measurement
-    // math — and `instanceof Function` → `typeof x === 'function'` narrows non-function-typed values to
-    // `never`. Adopt `??` / `typeof` deliberately if wanted, not via a blanket reformat.
-    'e18e/prefer-nullish-coalescing': 'off',
-    'unicorn/no-instanceof-builtins': 'off',
   },
 });


### PR DESCRIPTION
Follow-up to #2081 (stacked on it). #2081 disabled `unicorn/no-instanceof-builtins` and `e18e/prefer-nullish-coalescing` to dodge a behaviour-changing blanket `--fix`; this re-enables them and adopts the idioms **by hand**, deliberately.

## `instanceof Function` → `typeof x === 'function'`
- Store-action functional-updater guards (`setNodes`/`setEdges`/`addNodes`/`addEdges`/`removeNodes`/`removeEdges`/`setState`) and the **class** callbacks in the Node/Edge wrappers.
- `typeof` is also *more correct* here: it matches cross-realm functions (e.g. an updater created in a test realm) that `instanceof Function` misses.

## Deliberately kept as `instanceof Function`
- `node.style` / `edge.style`: style **can** be a function at runtime (a style callback — the cypress fixtures rely on it), but the `Styles` type doesn't model that, so `typeof` would narrow it to `never`. Kept `instanceof Function` with an inline-disable + note. (This was the actual regression behind the blanket-`--fix` test breakage in #2081 — the `||`→`??` theory was wrong.)

## `||` → `??`
Converted only the **collection** fallbacks where the left side is nullish solely via optional chaining (so `||` and `??` are behaviour-identical and `??` reads clearer):
- `EdgeWrapper` handle-bounds spread, `applyNodeChanges` style merge.

Left as `||` (intentional falsy/NaN coalescing): `size.width || 500` (resize floor), `gap*zoom || 1` (background), `z || 1` (zIndex floor), drag-offset `|| 0` and `Math.max(z || 0, …)`.

> Note: `e18e/prefer-nullish-coalescing` is type-aware and a **no-op** under the current type-info-less lint setup (empirically confirmed — it doesn't flag an unsafe `a || 'x'`). The `??` adoption above is therefore manual; repo-wide enforcement would require wiring type-aware linting (a separate pass).

## Verification
- `vue-tsc --noEmit`: 0 errors
- core build: ✓
- cypress component suite: **167/167**

🤖 Generated with [Claude Code](https://claude.com/claude-code)