### PR TITLE
chore(docs): upgrade @vue/repl to 4

### DIFF
--- a/docs/components/DocsRepl.vue
+++ b/docs/components/DocsRepl.vue
@@ -1,7 +1,8 @@
 <script lang="ts" setup>
 import type { SFCOptions } from '@vue/repl'
-import { ReplStore, Repl as VueRepl } from '@vue/repl'
+import { Repl as VueRepl, useStore, useVueImportMap } from '@vue/repl'
 import CodeMirror from '@vue/repl/codemirror-editor'
+import { computed } from 'vue'
 import { exampleImports } from '../examples'
 
 const props = defineProps<{ example: keyof typeof exampleImports; mainFile?: string }>()
@@ -33,14 +34,9 @@ body,
 }
 \n`
 
-const store = new ReplStore({
-  showOutput: true,
-  outputMode: 'preview',
-})
-
-const files: Record<string, (typeof imports)[keyof typeof imports]> = {}
 const imports = exampleImports[props.example]
 const additionalImports = 'additionalImports' in imports ? imports.additionalImports : {}
+const files: Record<string, (typeof imports)[keyof typeof imports]> = {}
 
 for (const example of Object.keys(imports).filter((i) => i !== 'additionalImports')) {
   if (example.includes('css')) {
@@ -50,7 +46,29 @@ for (const example of Object.keys(imports).filter((i) => i !== 'additionalImport
   }
 }
 
-await store.setVueVersion('3.5.0')
+// `useVueImportMap` builds the sandbox's Vue runtime import map (matched to the repl's bundled
+// compiler). Merge the vue-flow runtime modules into the built-in map so they resolve in the
+// sandbox without surfacing as an editable `import-map.json`.
+const { importMap: vueImportMap, vueVersion } = useVueImportMap()
+
+const builtinImportMap = computed(() => ({
+  imports: {
+    ...vueImportMap.value.imports,
+    '@vue-flow/core': `${location.origin}/vue-flow-core.mjs`,
+    ...additionalImports,
+  },
+}))
+
+const sfcOptions: SFCOptions = {
+  script: {
+    propsDestructure: true,
+  },
+}
+
+const store = useStore({ builtinImportMap, vueVersion })
+store.showOutput = true
+store.outputMode = 'preview'
+store.sfcOptions = sfcOptions
 
 await store.setFiles(
   {
@@ -59,20 +77,6 @@ await store.setFiles(
   },
   props.mainFile ?? 'App.vue',
 )
-
-// pre-set import map
-store.setImportMap({
-  imports: {
-    '@vue-flow/core': `${location.origin}/vue-flow-core.mjs`,
-    ...additionalImports,
-  },
-})
-
-const sfcOptions = {
-  script: {
-    propsDestructure: true,
-  },
-} as SFCOptions
 
 function onKeydown(event: KeyboardEvent) {
   // prevent the browser's save dialog on both Ctrl+S and Cmd+S
@@ -94,17 +98,23 @@ function formatCSS(cssString: string) {
 </script>
 
 <template>
-  <VueRepl
-    :editor="CodeMirror"
-    :store="store"
-    :show-compile-output="false"
-    :sfc-options="sfcOptions"
-    :ssr="false"
-    @keydown="onKeydown"
-  />
+  <!-- wrapper owns the keydown guard: v4's <Repl> no longer forwards a `keydown` listener, so we
+       catch the bubbled event here (`display: contents` keeps it layout-neutral) -->
+  <div class="docs-repl" @keydown="onKeydown">
+    <VueRepl
+      :editor="CodeMirror"
+      :store="store"
+      :show-compile-output="false"
+      :ssr="false"
+    />
+  </div>
 </template>
 
 <style>
+.docs-repl {
+  display: contents;
+}
+
 .file-selector {
   @apply scrollbar scrollbar-thin scrollbar-thumb-rounded scrollbar-thumb-green-500 scrollbar-track-black;
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,7 +16,7 @@
     "@vercel/analytics": "^1.3.2",
     "@vercel/speed-insights": "^1.0.14",
     "@vue-flow/core": "workspace:*",
-    "@vue/repl": "3.4.0",
+    "@vue/repl": "4.7.2",
     "blobity": "^0.2.3",
     "vue": "^3.5.12",
     "web-vitals": "^4.2.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/core
       '@vue/repl':
-        specifier: 3.4.0
-        version: 3.4.0
+        specifier: 4.7.2
+        version: 4.7.2
       blobity:
         specifier: ^0.2.3
         version: 0.2.3(react@19.2.7)(vue@3.5.25(typescript@6.0.3))
@@ -3128,8 +3128,8 @@ packages:
   '@vue/reactivity@3.5.38':
     resolution: {integrity: sha512-pG6LV/NDNRbKizcUjFFLAfjaL8mcv4DmR9avNcUw2gDHBzZneuS2TWCmp633ynzxz9YYKNeEPK2I8Wraqy2HUQ==}
 
-  '@vue/repl@3.4.0':
-    resolution: {integrity: sha512-iHhIsmQsp9PJuOwverCRQC2owFb0FSFzk6YWwyirAX6AqH//2FrUV4WB16f9lGX5pDXAHjxlzAE6Lqf9P17HHA==}
+  '@vue/repl@4.7.2':
+    resolution: {integrity: sha512-6x0hisEd5XRYxhLit3fvPCfeUfXEjB3a8Z2Pl3scVa3kZjck4+ERQF4XCahC7PTabWb3He04u+j8q3MK4WZHrQ==}
 
   '@vue/runtime-core@3.5.25':
     resolution: {integrity: sha512-Z751v203YWwYzy460bzsYQISDfPjHTl+6Zzwo/a3CsAf+0ccEjQ8c+0CdX1WsumRTHeywvyUFtW6KvNukT/smA==}
@@ -11716,7 +11716,7 @@ snapshots:
     dependencies:
       '@vue/shared': 3.5.38
 
-  '@vue/repl@3.4.0': {}
+  '@vue/repl@4.7.2': {}
 
   '@vue/runtime-core@3.5.25':
     dependencies:


### PR DESCRIPTION
Upgrades `@vue/repl` 3.4.0 → 4.7.2 (the docs playground). v4 is a class→composable rewrite, so `DocsRepl.vue` was migrated:

- `new ReplStore({ showOutput, outputMode })` → **`useStore()`**, with `showOutput` / `outputMode` / `sfcOptions` set on the store — in v4 these are store state, no longer `<Repl>` props.
- The sandbox's Vue runtime import map now comes from **`useVueImportMap()`**; the vue-flow runtime modules are merged into **`builtinImportMap`** so they resolve without surfacing as an editable `import-map.json` (replaces the old `store.setImportMap()`).
- `store.setVueVersion()` is gone — the version threads through `useVueImportMap` → `useStore({ vueVersion })`.
- v4's `<Repl>` no longer forwards a `keydown` listener, so the Ctrl/Cmd+S save-dialog guard moved onto a `display: contents` wrapper.

### Why this targets `release/2.0.0` (not stacked on #2080)
#2080 was meant to be the base, but its lockfile dropped the `overrides:` section (the `eslint: 8.51.0` pin isn't applied), so `pnpm install --frozen-lockfile` fails there and any install on top re-resolves the whole tree. Landing on `release/2.0.0` (consistent lockfile) keeps this a **clean, repl-only** change. #2080's lockfile is being repaired separately.

### Verification
- `vue-tsc --noEmit`: no `DocsRepl` errors
- `pnpm install --frozen-lockfile`: consistent (lockfile diff is the `@vue/repl` swap only)
- Browser: the basic example REPL renders a live, interactive flow (nodes/edges/minimap/controls) and compiles SFCs

🤖 Generated with [Claude Code](https://claude.com/claude-code)