### PR TITLE
fix(docs): render the REPL preview with the local 2.0 core styles

### DIFF
--- a/docs/components/DocsRepl.vue
+++ b/docs/components/DocsRepl.vue
@@ -7,10 +7,10 @@ import { exampleImports } from '../examples'
 
 const props = defineProps<{ example: keyof typeof exampleImports; mainFile?: string }>()
 
-const vueFlowVersion = __VUE_FLOW_VERSION__
-
-let css = `@import 'https://cdn.jsdelivr.net/npm/@vue-flow/core@${vueFlowVersion}/dist/style.css';
-@import 'https://cdn.jsdelivr.net/npm/@vue-flow/core@${vueFlowVersion}/dist/theme-default.css';
+// load the in-repo 2.0 core styles served from /public (see .vitepress/plugins/copy.ts) rather than
+// the CDN — the CDN only has the last published 1.x release, which mismatches the local 2.0 runtime
+let css = `@import '${location.origin}/vue-flow-core.css';
+@import '${location.origin}/vue-flow-core-theme-default.css';
 
 html,
 body,

--- a/docs/src/.vitepress/plugins/copy.ts
+++ b/docs/src/.vitepress/plugins/copy.ts
@@ -13,24 +13,30 @@ function getPublicPath(fileName: string) {
 }
 
 function copyFiles(emit: Emit) {
-  // 2.0 ships a single `@vue-flow/core` package (node-resizer/node-toolbar/etc. were merged into it)
-  ;['core'].forEach((name) => {
-    const fileName = `vue-flow-${name}.mjs`
+  // 2.0 ships a single `@vue-flow/core` package (node-resizer/node-toolbar/etc. were merged into it).
+  // The REPL sandbox loads the runtime AND styles from these local copies (not a CDN), so the
+  // playground tracks the in-repo 2.0 build instead of the last published 1.x release.
+  const assets = [
+    { from: 'vue-flow-core.mjs', to: 'vue-flow-core.mjs' },
+    { from: 'style.css', to: 'vue-flow-core.css' },
+    { from: 'theme-default.css', to: 'vue-flow-core-theme-default.css' },
+  ]
 
-    const filePath = resolve(__dirname, getPkgPath(name, fileName))
+  assets.forEach(({ from, to }) => {
+    const filePath = getPkgPath('core', from)
 
     if (!existsSync(filePath)) {
-      throw new Error(`${name} not built. ` + `Run "pnpm -w build" first.`)
+      throw new Error(`core not built. Run "pnpm -w build" first.`)
     }
 
     emit({
       type: 'asset',
-      fileName,
+      fileName: to,
       filePath,
       source: readFileSync(filePath, 'utf-8'),
     })
 
-    console.log(`Copied ${fileName} to /public/${fileName}`)
+    console.log(`Copied ${from} to /public/${to}`)
   })
 }
 export function copyVueFlowPlugin(): Plugin {


### PR DESCRIPTION
Follow-up to #2083. The REPL playground loaded `@vue-flow/core` **JS** from the in-repo 2.0 build (served from `/public`) but pulled its **styles** from the CDN, pinned to `__VUE_FLOW_VERSION__` (= 1.48.2, the last published 1.x). The 1.x CSS didn't match the 2.0 markup, so the preview's controls/minimap rendered unstyled — control buttons blew up to ~313px.

### Change
- `.vitepress/plugins/copy.ts`: copy the local `style.css` + `theme-default.css` into `/public` (as `vue-flow-core.css` / `vue-flow-core-theme-default.css`) alongside the runtime `vue-flow-core.mjs`.
- `DocsRepl.vue`: the sandbox's `main.css` now `@import`s those local URLs instead of the CDN (`__VUE_FLOW_VERSION__` is no longer needed here).

### Verification (Chrome)
- Before: `.vue-flow__controls-button` computed width **313px** (unstyled).
- After: **16px**, node padding 10px / radius 3px — styled correctly against the matching 2.0 build; the live flow renders.

> The "[Vue Flow]: …haven't loaded the necessary styles" console warning remains — a pre-existing benign timing false-positive (the check runs at mount before any async `@import`, CDN or local, resolves). The styles do apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)