### PR TITLE
fix(docs): stop typedoc from type-checking core's vite configs

### DIFF
--- a/docs/tsconfig.docs.json
+++ b/docs/tsconfig.docs.json
@@ -25,8 +25,11 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true
   },
+  // only the package sources feed typedoc's API analysis — `../packages/**/*` also swept in build
+  // configs like `vite.config.ts` (which import `vite`/`node:*` and don't resolve under this config's
+  // `moduleResolution`/`types`), breaking the docs build
   "include": [
-    "../packages/**/*"
+    "../packages/*/src/**/*"
   ],
   "exclude": [
     "node_modules"

--- a/packages/core/tsconfig.node.json
+++ b/packages/core/tsconfig.node.json
@@ -2,9 +2,11 @@
   "compilerOptions": {
     "composite": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "types": ["node"],
+    "skipLibCheck": true
   },
   "files": [
     "package.json"

--- a/packages/core/tsconfig.node.json
+++ b/packages/core/tsconfig.node.json
@@ -4,8 +4,8 @@
     "module": "esnext",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
-    "allowSyntheticDefaultImports": true,
     "types": ["node"],
+    "allowSyntheticDefaultImports": true,
     "skipLibCheck": true
   },
   "files": [


### PR DESCRIPTION
`pnpm dev` (and `build`) in docs failed at the `typedoc:md` step with ~12 TS errors in `packages/core/vite.config.ts` / `vite.config.iife.ts`:

```
vite.config.ts:1:25 - error TS2591: Cannot find name 'node:path'. …
vite.config.ts:3:17 - error TS2307: Cannot find module '@vitejs/plugin-vue' …
vite.config.ts:17:22 - error TS2304: Cannot find name '__dirname'.
```

### Cause
`docs/tsconfig.docs.json` (typedoc's tsconfig) had `include: ["../packages/**/*"]`, which sweeps in core's **build configs**. Those import `vite` / `@vitejs/plugin-vue` / `node:path` / `__dirname`, none of which resolve under that config's `moduleResolution: "node"` + `types: []`. typedoc only documents `core/src/index.ts`, so it should never type-check build configs. (Latent — surfaced once vite 8's exports map stopped resolving under node10.)

### Fix
- **`docs/tsconfig.docs.json`**: scope `include` to package sources (`../packages/*/src/**/*`).
- **`packages/core/tsconfig.node.json`** (the project that actually owns the vite files): `moduleResolution: node → bundler`, add `types: ["node"]` + `skipLibCheck` so they type-check in their proper config and in the IDE.

### Verification
- `typedoc:md` → API markdown emitted, **0 errors**.
- `pnpm dev` boots (vitepress serves).
- `tsc -p packages/core/tsconfig.node.json --noEmit` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)