### PR TITLE
fix(core): queue the initial fitView until nodes are measured and the container settles

### DIFF
--- a/packages/core/src/composables/useFitViewOnInit.ts
+++ b/packages/core/src/composables/useFitViewOnInit.ts
@@ -1,0 +1,55 @@
+import { watch } from 'vue';
+import { storeToRefs } from './storeToRefs';
+import { useNodesInitialized } from './useNodesInitialized';
+import { useStore } from './useStore';
+import { useVueFlow } from './useVueFlow';
+
+/**
+ * Drives the `fitView` prop's initial fit.
+ *
+ * Runs once the panZoom is ready AND every (non-hidden) node has been measured, then **re-runs while the
+ * container is still settling** (its dimensions keep changing) — until the user takes viewport control.
+ * This makes the initial fit deterministic without consumer-side `setTimeout`s, even when the container
+ * resizes on mount, e.g. inside the docs REPL sandbox where the preview pane lays out after the flow
+ * (a one-shot fit on the first measurement would latch against a too-small container → top-aligned view).
+ *
+ * Must be called from a descendant of the provider (it injects the store) — currently `<ZoomPane>`, not
+ * `<VueFlow>` itself (which can't inject its own `provide`).
+ *
+ * @internal
+ */
+export function useFitViewOnInit() {
+  const { fitView, onMoveStart } = useVueFlow();
+  const { panZoom, dimensions, fitViewOnInit, fitViewOnInitDone, fitViewOptions } = storeToRefs(useStore());
+  const nodesInitialized = useNodesInitialized();
+
+  // A user pan/zoom hands viewport control to the user — stop auto-fitting from then on. Our own
+  // programmatic `fitView` also fires `moveStart`, but with a `null` `event` (no DOM source event), so
+  // gating on `event` ignores it.
+  let userControlled = false;
+  onMoveStart(({ event }) => {
+    if (event) {
+      userControlled = true;
+    }
+  });
+
+  watch(
+    [nodesInitialized, panZoom, () => dimensions.value.width, () => dimensions.value.height],
+    () => {
+      if (
+        userControlled
+        || !fitViewOnInit.value
+        || !panZoom.value
+        || !nodesInitialized.value
+        || !dimensions.value.width
+        || !dimensions.value.height
+      ) {
+        return;
+      }
+
+      fitView(fitViewOptions?.value);
+      fitViewOnInitDone.value = true;
+    },
+    { immediate: true, flush: 'post' },
+  );
+}

--- a/packages/core/src/container/ZoomPane/ZoomPane.vue
+++ b/packages/core/src/container/ZoomPane/ZoomPane.vue
@@ -2,6 +2,7 @@
 import { XYPanZoom } from '@xyflow/system';
 import { onMounted, onUnmounted, toRef, watch } from 'vue';
 import { storeToRefs, useKeyPress, useStore, useVueFlow } from '../../composables';
+import { useFitViewOnInit } from '../../composables/useFitViewOnInit';
 import { useResizeHandler } from '../../composables/useResizeHandler';
 import EdgeRenderer from '../EdgeRenderer/EdgeRenderer.vue';
 import NodeRenderer from '../NodeRenderer/NodeRenderer.vue';
@@ -50,6 +51,9 @@ const shouldPanOnScroll = toRef(() => panKeyPressed.value || panOnScroll.value);
 const isSelecting = toRef(() => selectionKeyPressed.value || (selectionKeyCode.value === true && shouldPanOnDrag.value !== true));
 
 useResizeHandler(zoomPane);
+
+// drives the `fitView` prop's initial fit (waits for nodes + re-fits while the container settles)
+useFitViewOnInit();
 
 onUnmounted(() => panZoom.value?.destroy());
 

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -481,11 +481,9 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
       changes.push(...handleExpandParent(parentExpandChildren, systemNodeLookup, systemParentLookup, state.nodeOrigin));
     }
 
-    if (!state.fitViewOnInitDone && state.fitViewOnInit) {
-      viewportHelper.value.fitView(state.fitViewOptions).then(() => {
-        state.fitViewOnInitDone = true;
-      });
-    }
+    // the initial `fitView` (the `fitView` prop) is handled reactively by `useFitViewOnInit`: it waits
+    // for every node to be measured AND re-fits while the container is still settling — neither of which
+    // a one-shot here (fired per measurement batch, against a partial/zero-bounds subset) could do.
 
     if (changes.length) {
       state.hooks.nodesChange.trigger(changes);


### PR DESCRIPTION
The `fitView` prop's initial fit was unreliable — it could zoom to maxZoom or sit **top-aligned with a bottom gap**, very visible in the docs REPL. Pressing the controls' fit button corrected it. Reported by @braks.

### Cause
The init-fit fired once from inside `updateNodeDimensions`, gated only on `!fitViewOnInitDone && fitViewOnInit`, then latched. So it:
1. could run against a **partial / zero-bounds** node set — each `NodeWrapper` measures itself on mount, so the first batch can carry a single node; and
2. **never re-fit** when the container resized afterwards — the REPL preview pane lays out *after* the flow, so the fit ran against a too-short container and then latched (→ top-aligned).

### Fix — `useFitViewOnInit` (driven from `<ZoomPane>`)
A watcher that:
- fits once the panZoom **and every non-hidden node** are measured (xyflow's `nodesInitialized`), and
- **re-fits while the container dimensions keep changing** (it settles on mount), then
- **stops the moment the user takes viewport control** — a user pan/zoom. Our own programmatic `fitView` also fires `moveStart`, but with a `null` `event` (no DOM source event), so it's ignored.

Deterministic init fit, no consumer-side `setTimeout`s — so examples can use the declarative `:fit-view` prop instead of `onInit(() => fitView())` (which fires before nodes are measured).

### Verification
- Full cypress component suite: **167/167**.
- REPL basic example via `:fit-view`, across reloads: consistently centered (gap-top == gap-bottom, gap-left == gap-right; imbalance 0). Before: maxZoom overflow / top-aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)