### PR TITLE
docs(examples): migrate examples + home hero to 2.0 APIs

### DIFF
--- a/docs/components/home/Features.vue
+++ b/docs/components/home/Features.vue
@@ -10,7 +10,12 @@ const instances: VueFlowInstance[] = [];
 
 function onLoad(instance: VueFlowInstance) {
   instances.push(instance);
-  instance.fitView();
+
+  // `@pane` fires on init — before the nodes are measured — so fit once they are (then stop listening)
+  const { off } = instance.onNodesInitialized(() => {
+    instance.fitView();
+    off();
+  });
 }
 
 function fitViews() {

--- a/docs/components/home/flows/Basic.vue
+++ b/docs/components/home/flows/Basic.vue
@@ -122,7 +122,7 @@ function onInit(instance: VueFlowInstance) {
       <Controls position="bottom-right" />
       <Background :gap="60">
         <template #pattern>
-          <Cross :style="{ fontSize: `${8 * (flow?.viewport.value.zoom ?? 1) || 1}px` }" class="text-[#10b981] opacity-50" />
+          <Cross :style="{ fontSize: `${8 * (flow?.viewport?.value?.zoom ?? 1) || 1}px` }" class="text-[#10b981] opacity-50" />
         </template>
       </Background>
     </VueFlow>

--- a/docs/components/home/flows/Intro.vue
+++ b/docs/components/home/flows/Intro.vue
@@ -65,24 +65,35 @@ const initialEdges: Edge[] = [
 ];
 
 // `<VueFlow>` exposes its store via `defineExpose`, so a template ref is the pure-provider way to reach
-// the store (getNodes/getNode/setEdges/updateNodeInternals + the viewport `dimensions`) from the
-// component that renders the flow (no `useVueFlow()` outside a provider needed).
+// the store (getNodes/getNode/setEdges/updateNodeInternals) from the component that renders the flow
+// (no `useVueFlow()` outside a provider needed). The container size comes from the wrapper element —
+// the instance no longer exposes `dimensions` / `vueFlowRef`.
 const flow = ref<VueFlowInstance>();
 
+const flowWrapper = ref<HTMLElement>();
+
 const setElements = useDebounceFn(() => {
-  if (!flow.value) {
+  if (!flow.value || !flowWrapper.value) {
     return;
   }
 
-  const { getNode, getInternalNode, setNodes, setEdges, updateNodeInternals, dimensions } = flow.value;
+  const { getInternalNode, setNodes, setEdges, updateNodeInternals } = flow.value;
 
-  const offsetX = dimensions.value.width / 2;
-  const offsetY = dimensions.value.height / 4;
+  const { width, height } = flowWrapper.value.getBoundingClientRect();
+  const offsetX = width / 2;
+  const offsetY = height / 4;
+
+  // anchor the layout on the centered `intro` position, computed up front. Reading
+  // `getNode('intro').position` inside the `setNodes` map would be a frame behind (it still holds the
+  // pre-update value), so the other nodes would be placed relative to intro's *old* spot — which left
+  // them mis-aligned (e.g. `examples` off-screen) until a second resize happened to re-converge.
+  const mainInternal = getInternalNode('intro')!;
+  const mainWidth = mainInternal.measured.width ?? 0;
+  const mainHeight = mainInternal.measured.height ?? 0;
+  const mainX = offsetX - mainWidth / 2;
+  const mainY = offsetY - mainHeight / 2;
 
   if (breakpoints.isSmaller('md') && currentBreakpoint.value !== 'sm') {
-    const mainNode = getNode('intro')!;
-    const mainInternal = getInternalNode('intro')!;
-
     currentBreakpoint.value = 'sm';
 
     setNodes(nodes =>
@@ -93,17 +104,14 @@ const setElements = useDebounceFn(() => {
           case 'intro':
             return {
               ...node,
-              position: {
-                x: offsetX - (internal.measured.width ?? 0) / 2,
-                y: offsetY - (internal.measured.height ?? 0) / 2,
-              },
+              position: { x: mainX, y: mainY },
             };
           case 'examples':
             return {
               ...node,
               position: {
                 x: offsetX - (internal.measured.width ?? 0) / 2,
-                y: mainNode.position.y + (mainInternal.measured.height ?? 0) * 1.5,
+                y: mainY + mainHeight * 1.5,
               },
             };
           case 'documentation':
@@ -111,7 +119,7 @@ const setElements = useDebounceFn(() => {
               ...node,
               position: {
                 x: offsetX - (internal.measured.width ?? 0) / 2,
-                y: mainNode.position.y + (mainInternal.measured.height ?? 0) * 2 + 50,
+                y: mainY + mainHeight * 2 + 50,
               },
             };
           case 'acknowledgement':
@@ -119,7 +127,7 @@ const setElements = useDebounceFn(() => {
               ...node,
               position: {
                 x: offsetX - (internal.measured.width ?? 0) / 2,
-                y: mainNode.position.y + (mainInternal.measured.height ?? 0) * 3,
+                y: mainY + mainHeight * 3,
               },
             };
           default:
@@ -158,9 +166,6 @@ const setElements = useDebounceFn(() => {
   else if (!breakpoints.isSmaller('md')) {
     currentBreakpoint.value = 'md';
 
-    const mainNode = getNode('intro')!;
-    const mainInternal = getInternalNode('intro')!;
-
     setNodes(nodes =>
       nodes.map((node) => {
         const internal = getInternalNode(node.id)!;
@@ -169,22 +174,22 @@ const setElements = useDebounceFn(() => {
           case 'intro':
             return {
               ...node,
-              position: { x: offsetX - (internal.measured.width ?? 0) / 2, y: offsetY - (internal.measured.height ?? 0) / 2 },
+              position: { x: mainX, y: mainY },
             };
           case 'examples':
             return {
               ...node,
               position: {
-                x: mainNode.position.x - (internal.measured.width ?? 0) / 2,
-                y: mainNode.position.y + (mainInternal.measured.height ?? 0) * 1.5,
+                x: mainX - (internal.measured.width ?? 0) / 2,
+                y: mainY + mainHeight * 1.5,
               },
             };
           case 'documentation':
             return {
               ...node,
               position: {
-                x: mainNode.position.x + (mainInternal.measured.width ?? 0) - (internal.measured.width ?? 0) / 2,
-                y: mainNode.position.y + (mainInternal.measured.height ?? 0) * 1.5,
+                x: mainX + mainWidth - (internal.measured.width ?? 0) / 2,
+                y: mainY + mainHeight * 1.5,
               },
             };
           case 'acknowledgement':
@@ -192,7 +197,7 @@ const setElements = useDebounceFn(() => {
               ...node,
               position: {
                 x: offsetX - (internal.measured.width ?? 0) / 2,
-                y: mainNode.position.y + (mainInternal.measured.height ?? 0) * 2,
+                y: mainY + mainHeight * 2,
               },
             };
           default:
@@ -209,7 +214,7 @@ const setElements = useDebounceFn(() => {
   });
 }, 1);
 
-useResizeObserver(() => flow.value?.vueFlowRef.value ?? null, setElements);
+useResizeObserver(flowWrapper, setElements);
 
 function scrollTo() {
   const el = document.getElementById('acknowledgement');
@@ -221,99 +226,101 @@ function scrollTo() {
 </script>
 
 <template>
-  <VueFlow
-    ref="flow"
-    :nodes="initialNodes"
-    :edges="initialEdges"
-    :elements-selectable="true"
-    :pan-on-drag="false"
-    :zoom-on-scroll="false"
-    :zoom-on-double-click="false"
-    :zoom-on-pinch="false"
-    :prevent-scrolling="false"
-    :elevate-edges-on-select="true"
-    :style="{ opacity: !!currentBreakpoint ? 1 : 0 }"
-  >
-    <Background id="dots" color="#aaa" :size="0.75" :gap="25" />
-    <Background id="lines" variant="lines" :color="isDark ? '#fff' : '#000'" :size="1" :gap="100" />
+  <div ref="flowWrapper" class="h-full w-full">
+    <VueFlow
+      ref="flow"
+      :nodes="initialNodes"
+      :edges="initialEdges"
+      :elements-selectable="true"
+      :pan-on-drag="false"
+      :zoom-on-scroll="false"
+      :zoom-on-double-click="false"
+      :zoom-on-pinch="false"
+      :prevent-scrolling="false"
+      :elevate-edges-on-select="true"
+      :style="{ opacity: !!currentBreakpoint ? 1 : 0 }"
+    >
+      <Background id="dots" color="#aaa" :size="0.75" :gap="25" />
+      <Background id="lines" variant="lines" :color="isDark ? '#fff' : '#000'" :size="1" :gap="100" />
 
-    <template #node-box="props">
-      <template v-if="props.id === 'intro'">
-        <div class="box max-w-75 md:max-w-125">
-          <div class="intro px-4 py-2 shadow-lg rounded-md border-2 border-solid border-black">
-            <div class="font-mono flex flex-col gap-4 p-4 items-center text-center">
-              <h1 class="text-2xl lg:text-4xl !my-0 !pt-0 font-bold">
-                Vue Flow
-              </h1>
+      <template #node-box="props">
+        <template v-if="props.id === 'intro'">
+          <div class="box max-w-75 md:max-w-125">
+            <div class="intro px-4 py-2 shadow-lg rounded-md border-2 border-solid border-black">
+              <div class="font-mono flex flex-col gap-4 p-4 items-center text-center">
+                <h1 class="text-2xl lg:text-4xl !my-0 !pt-0 font-bold">
+                  Vue Flow
+                </h1>
 
-              <h2 class="!text-lg !lg:text-xl !tracking-normal !font-normal !p-0 !m-0 !border-0 !mb-4">
-                The customizable Vue 3 component bringing interactivity to flowcharts and graphs.
-              </h2>
+                <h2 class="!text-lg !lg:text-xl !tracking-normal !font-normal !p-0 !m-0 !border-0 !mb-4">
+                  The customizable Vue 3 component bringing interactivity to flowcharts and graphs.
+                </h2>
+              </div>
+
+              <Handle
+                :is-connectable="false"
+                style="height: 12px; width: 6rem; bottom: -6px; background: #aaa; border-radius: 2px"
+                type="source"
+                :position="Position.Bottom"
+              />
             </div>
-
-            <Handle
-              :connectable="false"
-              style="height: 12px; width: 6rem; bottom: -6px; background: #aaa; border-radius: 2px"
-              type="source"
-              :position="Position.Bottom"
-            />
           </div>
-        </div>
+        </template>
+
+        <template v-else-if="props.id === 'documentation'">
+          <div class="flex">
+            <a class="intro-link group bg-[#f15a16]" href="/guide/"> Read The Documentation </a>
+          </div>
+
+          <Handle
+            style="height: 12px; width: 2rem; top: -6px; background: #aaa; border-radius: 2px"
+            type="target"
+            :position="Position.Top"
+          />
+
+          <Handle
+            style="height: 12px; width: 2rem; bottom: -6px; background: #aaa; border-radius: 2px"
+            class="block md:hidden"
+            type="source"
+            :position="Position.Bottom"
+          />
+        </template>
+
+        <template v-else-if="props.id === 'examples'">
+          <div class="flex">
+            <a class="intro-link group bg-pink-500" href="/examples/"> Check The Examples </a>
+          </div>
+
+          <Handle
+            style="height: 12px; width: 2rem; top: -6px; background: #aaa; border-radius: 2px"
+            type="target"
+            :position="Position.Top"
+          />
+
+          <Handle
+            style="height: 12px; width: 2rem; bottom: -6px; background: #aaa; border-radius: 2px"
+            class="block md:hidden"
+            type="source"
+            :position="Position.Bottom"
+          />
+        </template>
+
+        <template v-else-if="props.id === 'acknowledgement'">
+          <div class="flex" @click="scrollTo">
+            <button class="intro-link group bg-sky-500">
+              <Heart class="text-red-500" /> Acknowledgement
+            </button>
+          </div>
+
+          <Handle
+            style="height: 12px; width: 2rem; top: -6px; background: #aaa; border-radius: 2px"
+            type="target"
+            :position="Position.Top"
+          />
+        </template>
       </template>
-
-      <template v-else-if="props.id === 'documentation'">
-        <div class="flex">
-          <a class="intro-link group bg-[#f15a16]" href="/guide/"> Read The Documentation </a>
-        </div>
-
-        <Handle
-          style="height: 12px; width: 2rem; top: -6px; background: #aaa; border-radius: 2px"
-          type="target"
-          :position="Position.Top"
-        />
-
-        <Handle
-          style="height: 12px; width: 2rem; bottom: -6px; background: #aaa; border-radius: 2px"
-          class="block md:hidden"
-          type="source"
-          :position="Position.Bottom"
-        />
-      </template>
-
-      <template v-else-if="props.id === 'examples'">
-        <div class="flex">
-          <a class="intro-link group bg-pink-500" href="/examples/"> Check The Examples </a>
-        </div>
-
-        <Handle
-          style="height: 12px; width: 2rem; top: -6px; background: #aaa; border-radius: 2px"
-          type="target"
-          :position="Position.Top"
-        />
-
-        <Handle
-          style="height: 12px; width: 2rem; bottom: -6px; background: #aaa; border-radius: 2px"
-          class="block md:hidden"
-          type="source"
-          :position="Position.Bottom"
-        />
-      </template>
-
-      <template v-else-if="props.id === 'acknowledgement'">
-        <div class="flex" @click="scrollTo">
-          <button class="intro-link group bg-sky-500">
-            <Heart class="text-red-500" /> Acknowledgement
-          </button>
-        </div>
-
-        <Handle
-          style="height: 12px; width: 2rem; top: -6px; background: #aaa; border-radius: 2px"
-          type="target"
-          :position="Position.Top"
-        />
-      </template>
-    </template>
-  </VueFlow>
+    </VueFlow>
+  </div>
 </template>
 
 <style>

--- a/docs/examples/basic/Flow.vue
+++ b/docs/examples/basic/Flow.vue
@@ -26,8 +26,9 @@ const dark = ref(false);
  * onInit is called when the VueFlow viewport is initialized
  */
 onInit((vueFlowInstance) => {
-  // instance is the same as the return of `useVueFlow`
-  vueFlowInstance.fitView();
+  // the initial fit is handled declaratively by the `:fit-view` prop (queued until the nodes are
+  // measured) — calling `fitView()` here would run before the nodes have dimensions
+  console.log('Flow initialized', vueFlowInstance);
 });
 
 /**
@@ -95,7 +96,7 @@ function toggleDarkMode() {
     :edges="edges"
     :class="{ dark }"
     class="basic-flow"
-    :default-viewport="{ zoom: 1.5 }"
+    fit-view
     :min-zoom="0.2"
     :max-zoom="4"
   >

--- a/docs/examples/dnd/useDnD.js
+++ b/docs/examples/dnd/useDnD.js
@@ -26,7 +26,7 @@ const state = {
 export default function useDragAndDrop() {
   const { draggedType, isDragOver, isDragging } = state;
 
-  const { addNodes, screenToFlowPosition, onNodesInitialized, updateNode } = useVueFlow();
+  const { addNodes, screenToFlowPosition, getInternalNode, onNodesInitialized, updateNode } = useVueFlow();
 
   watch(isDragging, (dragging) => {
     document.body.style.userSelect = dragging ? 'none' : '';
@@ -98,8 +98,15 @@ export default function useDragAndDrop() {
      * We can hook into events even in a callback, and we can remove the event listener after it's been called.
      */
     const { off } = onNodesInitialized(() => {
+      // measured size lives on the internal node in 2.0 (`getInternalNode(...).measured`), not on the
+      // user node as `dimensions`
+      const internalNode = getInternalNode(nodeId);
+
       updateNode(nodeId, node => ({
-        position: { x: node.position.x - node.dimensions.width / 2, y: node.position.y - node.dimensions.height / 2 },
+        position: {
+          x: node.position.x - internalNode.measured.width / 2,
+          y: node.position.y - internalNode.measured.height / 2,
+        },
       }));
 
       off();

--- a/docs/examples/math/OperatorNode.vue
+++ b/docs/examples/math/OperatorNode.vue
@@ -21,7 +21,7 @@ const { updateNodeData } = useVueFlow();
     </button>
   </div>
 
-  <Handle type="source" :position="Position.Right" :connectable="false" />
-  <Handle id="target-a" type="target" :position="Position.Left" :connectable="false" />
-  <Handle id="target-b" type="target" :position="Position.Left" :connectable="false" />
+  <Handle type="source" :position="Position.Right" :is-connectable="false" />
+  <Handle id="target-a" type="target" :position="Position.Left" :is-connectable="false" />
+  <Handle id="target-b" type="target" :position="Position.Left" :is-connectable="false" />
 </template>

--- a/docs/examples/math/ResultNode.vue
+++ b/docs/examples/math/ResultNode.vue
@@ -70,7 +70,7 @@ const result = computed(() => {
   <Handle
     type="target"
     :position="Position.Left"
-    :connectable="false"
+    :is-connectable="false"
     :style="{ background: result > 0 ? '#5EC697' : '#f15a16' }"
   />
 </template>

--- a/docs/examples/math/ValueNode.vue
+++ b/docs/examples/math/ValueNode.vue
@@ -15,5 +15,5 @@ const value = computed({
 <template>
   <input :id="`${id}-input`" v-model="value" type="number" class="nodrag">
 
-  <Handle type="source" :position="Position.Right" :connectable="false" />
+  <Handle type="source" :position="Position.Right" :is-connectable="false" />
 </template>


### PR DESCRIPTION
Migrates docs examples and the homepage hero flows off removed/renamed 2.0 APIs, and fixes the hero layout/warnings @braks flagged.

### Examples
- **basic**: `onInit(() => fitView())` → declarative `:fit-view` (queued by core until nodes are measured).
- **dnd**: dropped-node size via `getInternalNode(id).measured` (node `dimensions` removed).
- **math**: Handle `:connectable` → `:isConnectable`.

### Home hero (was crashing / mis-laid-out)
- **Intro**: instance no longer exposes `dimensions`/`vueFlowRef` → measure a wrapper element. Also anchored the responsive layout on the computed centered `intro` position so it converges in **one pass** (it read intro's *stale* position before, leaving `examples` off-screen). `:connectable` → `:is-connectable`. Verified: all nodes in-bounds, centered.
- **Basic**: `flow?.viewport.value.zoom` threw pre-mount (only `flow` guarded) → `flow?.viewport?.value?.zoom`.
- **Features**: fit each demo flow on `onNodesInitialized` rather than on `@pane` (which fires pre-measure).

### Depends on (core)
- #2086 — the `:fit-view` queue-until-measured fix.
- A follow-up core fix for `EdgeProps.markerStart/markerEnd` (currently typed required `string`, causing `Invalid prop` warnings on the RGB flow's custom edge). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)