### PR TITLE
fix(core): make EdgeProps markerStart/markerEnd optional

### DIFF
--- a/packages/core/src/types/edge.ts
+++ b/packages/core/src/types/edge.ts
@@ -160,8 +160,12 @@ export interface EdgeProps<EdgeType extends Edge = Edge> extends EdgeLabelOption
   targetHandleId?: string | null;
   animated?: boolean;
   reconnectable?: EdgeReconnectable;
-  markerStart: string;
-  markerEnd: string;
+  // optional: an edge without markers has none at runtime, and `EdgeWrapper` passes them through
+  // verbatim. Typed as required, a custom edge's `defineProps<EdgeProps>()` generates required runtime
+  // props and Vue warns "Invalid prop 'markerStart' … Expected String, got Undefined". (Matches `Edge`,
+  // `BaseEdgeProps` and xyflow/react, which all have these optional.)
+  markerStart?: string;
+  markerEnd?: string;
   curvature?: number;
   interactionWidth?: number;
   data?: EdgeType['data'];


### PR DESCRIPTION
On the docs homepage (and for any marker-less edge), a custom edge component logged a dozen Vue warnings on load:

```
[Vue warn]: Invalid prop: type check failed for prop "markerStart". Expected String with value "undefined", got Undefined
[Vue warn]: Invalid prop: type check failed for prop "markerEnd"  …
  at <Custom id="e1-4" …>  (RGB flow)
```

### Cause
`EdgeProps.markerStart`/`markerEnd` were typed as **required `string`**, but a marker-less edge has neither at runtime and `EdgeWrapper` passes them through verbatim. A custom edge using `defineProps<EdgeProps>()` then has the SFC compiler generate **required** runtime props (`{ type: String, required: true }`), so Vue's validator warns on the `undefined` value.

### Fix
Make them optional (`markerStart?`/`markerEnd?`) — matching `Edge`, `BaseEdgeProps`, and xyflow/react, which all have them optional. `defineProps` then generates `required: false`, and Vue skips validation for `undefined`.

### Verification
- `vue-tsc` on core: clean (no built-in edge relied on the required typing).
- Home page (RGB flow's custom edge): the **markerStart/markerEnd warnings are gone**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)