### PR TITLE
fix(docs): migrate examples off removed useVueFlow state refs

### DIFF
--- a/docs/examples/interaction/App.vue
+++ b/docs/examples/interaction/App.vue
@@ -32,10 +32,46 @@ const edges = ref([
   { id: 'e1-3', source: '1', target: '3' },
   { id: 'e3-4', source: '3', target: '4' },
 ]);
+
+// The interaction settings are reactive props on `<VueFlow>` — drive them from local refs and let the
+// controls panel toggle them (no `useStore` needed; the props are the public API for these).
+const nodesDraggable = ref(true);
+const nodesConnectable = ref(true);
+const elementsSelectable = ref(true);
+const zoomOnScroll = ref(true);
+const zoomOnPinch = ref(true);
+const panOnScroll = ref(false);
+const panOnScrollMode = ref('free');
+const zoomOnDoubleClick = ref(true);
+const panOnDrag = ref(true);
 </script>
 
 <template>
-  <VueFlow :nodes="nodes" :edges="edges" class="interaction-flow" fit-view>
-    <InteractionControls />
+  <VueFlow
+    :nodes="nodes"
+    :edges="edges"
+    :nodes-draggable="nodesDraggable"
+    :nodes-connectable="nodesConnectable"
+    :elements-selectable="elementsSelectable"
+    :zoom-on-scroll="zoomOnScroll"
+    :zoom-on-pinch="zoomOnPinch"
+    :pan-on-scroll="panOnScroll"
+    :pan-on-scroll-mode="panOnScrollMode"
+    :zoom-on-double-click="zoomOnDoubleClick"
+    :pan-on-drag="panOnDrag"
+    class="interaction-flow"
+    fit-view
+  >
+    <InteractionControls
+      v-model:nodes-draggable="nodesDraggable"
+      v-model:nodes-connectable="nodesConnectable"
+      v-model:elements-selectable="elementsSelectable"
+      v-model:zoom-on-scroll="zoomOnScroll"
+      v-model:zoom-on-pinch="zoomOnPinch"
+      v-model:pan-on-scroll="panOnScroll"
+      v-model:pan-on-scroll-mode="panOnScrollMode"
+      v-model:zoom-on-double-click="zoomOnDoubleClick"
+      v-model:pan-on-drag="panOnDrag"
+    />
   </VueFlow>
 </template>

--- a/docs/examples/interaction/InteractionControls.vue
+++ b/docs/examples/interaction/InteractionControls.vue
@@ -2,25 +2,19 @@
 import { Panel, useVueFlow } from '@vue-flow/core';
 import { ref } from 'vue';
 
-const {
-  nodesDraggable,
-  nodesConnectable,
-  elementsSelectable,
-  zoomOnScroll,
-  zoomOnDoubleClick,
-  zoomOnPinch,
-  panOnScroll,
-  panOnScrollMode,
-  panOnDrag,
-  onConnect,
-  onNodeDragStop,
-  onPaneClick,
-  onPaneScroll,
-  onPaneContextMenu,
-  onNodeDragStart,
-  onMoveEnd,
-  addEdges,
-} = useVueFlow();
+// These settings are bound to `<VueFlow>` props by the parent. Expose them as models so the panel can
+// toggle them — the props are reactive, so the flow reacts to every change (no `useStore` needed).
+const nodesDraggable = defineModel('nodesDraggable');
+const nodesConnectable = defineModel('nodesConnectable');
+const elementsSelectable = defineModel('elementsSelectable');
+const zoomOnScroll = defineModel('zoomOnScroll');
+const zoomOnPinch = defineModel('zoomOnPinch');
+const panOnScroll = defineModel('panOnScroll');
+const panOnScrollMode = defineModel('panOnScrollMode');
+const zoomOnDoubleClick = defineModel('zoomOnDoubleClick');
+const panOnDrag = defineModel('panOnDrag');
+
+const { onConnect, onNodeDragStop, onPaneClick, onPaneScroll, onPaneContextMenu, onNodeDragStart, onMoveEnd, addEdges } = useVueFlow();
 
 const captureZoomClick = ref(false);
 

--- a/docs/examples/teleport/useTeleport.js
+++ b/docs/examples/teleport/useTeleport.js
@@ -12,7 +12,7 @@ export function useTeleport(id) {
   const transition = ref(false);
   const teleport = ref(null);
 
-  const { updateNodeInternals, updateNodeData, getNode, edges, setEdges } = useVueFlow();
+  const { updateNodeInternals, updateNodeData, getNode, getEdges, setEdges } = useVueFlow();
 
   /**
    * specify a selector to teleport to
@@ -73,7 +73,7 @@ export function useTeleport(id) {
     updateNodeData(id, { destination });
 
     // hide connected edges when teleporting
-    const connectedEdgeIds = getConnectedEdges([node], edges.value).map(edge => edge.id);
+    const connectedEdgeIds = getConnectedEdges([node], getEdges.value).map(edge => edge.id);
 
     // check if nodes connected to edge are teleported and hide edge if one of them is
     const updateHiddenEdges = () => {

--- a/docs/src/guide/composables.md
+++ b/docs/src/guide/composables.md
@@ -13,14 +13,14 @@ The `useVueFlow` composable provides you with a set of methods to interact with 
 import { ref } from 'vue'
 import { useVueFlow, VueFlow } from '@vue-flow/core'
 
-const { onInit, getNode, fitView, snapToGrid } = useVueFlow()
+const { onInit, getNode, fitView, updateNode } = useVueFlow()
 
 const nodes = ref([/* ... */])
 
 const edges = ref([/* ... */])
 
-// to enable snapping to grid
-snapToGrid.value = true
+// `<VueFlow>` settings such as grid snapping are props — drive them from a ref
+const snapToGrid = ref(true)
 
 // any event that is emitted from the `<VueFlow />` component can be listened to using the `onEventName` method
 onInit((instance) => {
@@ -31,18 +31,19 @@ onInit((instance) => {
   const node = getNode('1')
   
   if (node) {
-    node.position = { x: 100, y: 100 }
+    // nodes are stored immutably — update them through the `updateNode` action, not by mutating in place
+    updateNode('1', { position: { x: 100, y: 100 } })
   }
 })
 </script>
 
 <template>
-  <VueFlow :nodes="nodes" :edges="edges" />
+  <VueFlow :nodes="nodes" :edges="edges" :snap-to-grid="snapToGrid" />
 </template>
 ```
 
-`useVueFlow` exposes the whole internal state, including the nodes and edges.
-The values are reactive, meaning changing the values returned from `useVueFlow` will trigger changes in the graph.
+`useVueFlow` returns the flow's reactive getters (`getNodes`, `getEdges`, `viewport`, …), actions (`updateNode`, `addEdges`, `fitView`, …) and event hooks (`onInit`, `onConnect`, …) — not the raw state.
+The getters are read-only; update the graph through the actions (or by binding `v-model:nodes` / `:edges` etc. on `<VueFlow>`). If you need the writable state directly, reach for `useStore` / `storeToRefs`.
 
 ### State creation and injection
 


### PR DESCRIPTION
## What

In 2.0, `useVueFlow()` returns only the flow's getters/actions/hooks — raw reactive state (the interaction settings, `edges`, `dimensions`, …) moved to `useStore`. A few docs examples still destructured **state** refs from `useVueFlow()`, so they were `undefined` at runtime. This migrates them to the public, declarative API — local refs bound to `<VueFlow>` props — instead of reaching into the store:

- **interaction** (`App.vue` / `InteractionControls.vue`): the 9 settings (`nodesDraggable`, `nodesConnectable`, `elementsSelectable`, `zoomOnScroll`, `zoomOnPinch`, `panOnScroll`, `panOnScrollMode`, `zoomOnDoubleClick`, `panOnDrag`) are local refs in `App.vue` bound to `<VueFlow>` props, toggled from the controls panel via `defineModel` (`v-model:*`). No `useStore`.
- **teleport** (`useTeleport.js`): reads edges through the `getEdges` getter, not the removed `edges` state ref.
- **composables guide** (`composables.md`): grid snapping is a `<VueFlow>` prop driven by a ref (not `useVueFlow().snapToGrid`); nodes updated via `updateNode` instead of mutating `node.position`; fixed the stale "exposes the whole internal state" prose.

## Sweep

Audited all of `docs/examples/**`, `docs/components/**`, `docs/src/**/*.md`. The `storeToRefs(useStore())` examples (save-restore, stress, helper-lines, connection-radius) read genuinely store-only state (e.g. `dimensions`) with no prop equivalent — correct as-is, left unchanged.

## Follow-ups (not in this PR)

- `composables.md` → "State creation and injection" still describes the 1.x model (`useVueFlow` "creates on first call"); in 2.0 the provider creates and `useVueFlow` injects (throws without one). Wants a dedicated guide pass, together with the `useVueFlow({ id })` semantics and the `useHandle` example's `connectionStartHandle` (now store state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)