### PR TITLE
docs(guides): refresh the node / edge / handle authoring guides for 2.0

### DIFF
--- a/docs/src/guide/edge.md
+++ b/docs/src/guide/edge.md
@@ -558,18 +558,17 @@ import { VueFlow } from '@vue-flow/core'
 import CustomEdge from './CustomEdge.vue'
 import SpecialEdge from './SpecialEdge.vue'
 
-// You can pass 3 optional generic arguments to the Edge type, allowing you to define:
+// You can pass 2 optional generic arguments to the `Edge` type:
 // 1. The data object type
-// 2. The events object type
-// 3. The possible edge types
+// 2. The possible edge-type string union
 
-interface CustomData {
+export interface CustomData {
     hello: string
 }
 
 type CustomEdgeTypes = 'custom' | 'special'
 
-type CustomEdge = Edge<CustomData, any, CustomEdgeTypes>
+export type CustomEdge = Edge<CustomData, CustomEdgeTypes>
 
 export const edges = ref<CustomEdge[]>([
     {
@@ -639,12 +638,12 @@ const nodes = ref([
 import type { EdgeProps } from '@vue-flow/core';
 import { BezierEdge } from '@vue-flow/core';
 
-import { CustomData } from './edges'
+import type { CustomEdge } from './edges'
 
-// props were passed from the slot using `v-bind="customEdgeProps"`
-const props = defineProps<EdgeProps<CustomData>>();
+// props were passed from the slot using `v-bind="customEdgeProps"` — `EdgeProps` takes the edge type
+const props = defineProps<EdgeProps<CustomEdge>>();
 
-console.log(props.data.hello) // 'world'
+console.log(props.data?.hello)
 </script>
 
 <script lang="ts">
@@ -770,26 +769,34 @@ But you may wish to expand on these features or implement your business logic in
 | Prop Name        | Description                                | Type                                         | Optional                                   |
 |------------------|--------------------------------------------|----------------------------------------------|--------------------------------------------|
 | id               | Unique edge id                             | string                                       | <Close class="text-red-500" />             |
-| sourceNode       | The originating node                       | [GraphNode](/typedocs/type-aliases/GraphNode)  | <Close class="text-red-500" />             |
-| targetNode       | The destination node                       | [GraphNode](/typedocs/type-aliases/GraphNode)  | <Close class="text-red-500" />             |
 | source           | ID of the source node                      | string                                       | <Close class="text-red-500" />             |
 | target           | ID of the target node                      | string                                       | <Close class="text-red-500" />             |
-| type             | Edge Type                                  | string                                       | <Close class="text-red-500" />             |
-| label            | Edge label, can be a string or a VNode     | string \| VNode \| Component \| Object       | <Check class="text-[var(--vp-c-brand)]" /> |
+| sourcePosition   | Source handle position                     | [Position](/typedocs/enumerations/Position)  | <Close class="text-red-500" />             |
+| targetPosition   | Target handle position                     | [Position](/typedocs/enumerations/Position)  | <Close class="text-red-500" />             |
+| sourceX          | Source x coordinate (render output)        | number                                       | <Close class="text-red-500" />             |
+| sourceY          | Source y coordinate (render output)        | number                                       | <Close class="text-red-500" />             |
+| targetX          | Target x coordinate (render output)        | number                                       | <Close class="text-red-500" />             |
+| targetY          | Target y coordinate (render output)        | number                                       | <Close class="text-red-500" />             |
+| type             | Edge type                                  | string                                       | <Check class="text-[var(--vp-c-brand)]" /> |
+| data             | Custom edge data                           | object                                       | <Check class="text-[var(--vp-c-brand)]" /> |
+| label            | Edge label (string or VNode)               | string \| VNode \| Component \| Object       | <Check class="text-[var(--vp-c-brand)]" /> |
 | style            | CSS properties                             | CSSProperties                                | <Check class="text-[var(--vp-c-brand)]" /> |
-| selected         | Is edge selected                           | boolean                                      | <Check class="text-[var(--vp-c-brand)]" /> |
-| sourcePosition   | Source position                            | [Position](/typedocs/enumerations/Position)         | <Close class="text-red-500" />             |
-| targetPosition   | Target position                            | [Position](/typedocs/enumerations/Position)         | <Close class="text-red-500" />             |
+| selected         | Is the edge selected                       | boolean                                      | <Check class="text-[var(--vp-c-brand)]" /> |
+| selectable       | Can the edge be selected                   | boolean                                      | <Check class="text-[var(--vp-c-brand)]" /> |
+| deletable        | Can the edge be deleted                    | boolean                                      | <Check class="text-[var(--vp-c-brand)]" /> |
 | sourceHandleId   | ID of the source handle                    | string                                       | <Check class="text-[var(--vp-c-brand)]" /> |
 | targetHandleId   | ID of the target handle                    | string                                       | <Check class="text-[var(--vp-c-brand)]" /> |
-| animated         | Is edge animated                           | boolean                                      | <Check class="text-[var(--vp-c-brand)]" /> |
-| reconnectable    | Is edge reconnectable                      | boolean                                      | <Check class="text-[var(--vp-c-brand)]" /> |
-| markerStart      | Start marker                               | string                                       | <Close class="text-red-500" />             |
-| markerEnd        | End marker                                 | string                                       | <Close class="text-red-500" />             |
+| animated         | Is the edge animated                       | boolean                                      | <Check class="text-[var(--vp-c-brand)]" /> |
+| reconnectable    | Is the edge reconnectable                  | boolean                                      | <Check class="text-[var(--vp-c-brand)]" /> |
+| markerStart      | Start marker (resolved url string)         | string                                       | <Check class="text-[var(--vp-c-brand)]" /> |
+| markerEnd        | End marker (resolved url string)           | string                                       | <Check class="text-[var(--vp-c-brand)]" /> |
 | curvature        | The curvature of the edge                  | number                                       | <Check class="text-[var(--vp-c-brand)]" /> |
 | interactionWidth | Width of the interaction area for the edge | number                                       | <Check class="text-[var(--vp-c-brand)]" /> |
-| data             | Additional data of edge                    | any object                                   | <Close class="text-red-500" />             |
-| events           | Contextual and custom events of edge       | [EdgeEventsOn](/typedocs/type-aliases/EdgeEventsOn) | <Close class="text-red-500" />             |
+
+::: tip
+There's no `sourceNode` / `targetNode` on `EdgeProps` anymore — resolve the connected nodes with
+`useInternalNode(() => props.source)` / `useInternalNode(() => props.target)`.
+:::
 
 ## Edge Events
 
@@ -900,7 +907,7 @@ function logEvent(eventName, data) {
     @edge-mouse-leave="logEvent('edge mouse leave', $event)"
     @edge-mouse-move="logEvent('edge mouse move', $event)"
     @reconnect-start="logEvent('reconnect start', $event)"
-    @reconnect="logEvent('edge update', $event)"
+    @reconnect="logEvent('reconnect', $event)"
     @reconnect-end="logEvent('reconnect end', $event)"
   />
 </template>
@@ -919,7 +926,7 @@ function logEvent(eventName, data) {
     @edge-mouse-leave="logEvent('edge mouse leave', $event)"
     @edge-mouse-move="logEvent('edge mouse move', $event)"
     @reconnect-start="logEvent('reconnect start', $event)"
-    @reconnect="logEvent('edge update', $event)"
+    @reconnect="logEvent('reconnect', $event)"
     @reconnect-end="logEvent('reconnect end', $event)"
   >
     <Panel position="top-center">

--- a/docs/src/guide/edge.md
+++ b/docs/src/guide/edge.md
@@ -14,12 +14,12 @@ const nodes = ref([
   {
     id: '1',
     type: 'input',
-    label: 'Node 1',
+    data: { label: 'Node 1' },
     position: { x: 50, y: 25 },
   },
   {
     id: '2',
-    label: 'Node 2',
+    data: { label: 'Node 2' },
     position: { x: 100, y: 125 },
   },
 ]);
@@ -54,12 +54,12 @@ const straightNodes = ref([
   {
     id: '1',
     type: 'input',
-    label: 'Node 1',
+    data: { label: 'Node 1' },
     position: { x: 50, y: 25 },
   },
   {
     id: '2',
-    label: 'Node 2',
+    data: { label: 'Node 2' },
     position: { x: 50, y: 125 },
   },
 ]);

--- a/docs/src/guide/handle.md
+++ b/docs/src/guide/handle.md
@@ -127,7 +127,7 @@ You cannot hide a handle by removing it from the DOM (for example using `v-if` o
 
 ## Limiting Connections
 
-You can limit the number of connections a handle can have by setting the `connectable` prop on the `<Handle>` component.
+You can limit the number of connections a handle can have by setting the `isConnectable` prop on the `<Handle>` component.
 
 This prop accepts a boolean value (defaults to `true`), a number (the maximum number of connections), or a function that returns a boolean.
 
@@ -143,16 +143,14 @@ const handleConnectable: HandleConnectableFunc = (node, connectedEdges) => {
 </script>
 
 <template>
-  <Handle type="source" :position="Position.Right" :connectable="handleConnectable" />
+  <Handle type="source" :position="Position.Right" :is-connectable="handleConnectable" />
 </template>
 ```
 
 ## Connection Mode
 
-By default, Vue Flow uses `<VueFlow :connection-mode="ConnectionMode.Strict" />`, where a `source` handle only connects to a `target` handle.
-Set `<VueFlow :connection-mode="ConnectionMode.Loose" />` to allow connecting to any handle (e.g. `source`-to-`source`).
-
-If you want to restrict connections to only be made between `source` and `target` type handles, you can set the `connection-mode` prop to `ConnectionMode.Strict`.
+By default Vue Flow uses **strict** connection mode, where a `source` handle only connects to a `target` handle.
+Set `connection-mode` to `ConnectionMode.Loose` (or the string `'loose'`) to allow connecting to any handle (e.g. `source`-to-`source`).
 
 ```vue
 <script setup>
@@ -160,16 +158,16 @@ import { ConnectionMode, VueFlow } from '@vue-flow/core'
 </script>
 
 <template>
-  <VueFlow :connection-mode="ConnectionMode.Strict" />
+  <VueFlow :connection-mode="ConnectionMode.Loose" />
 </template>
 ```
 
 ## Dynamic Handle Positions & Adding/Removing Handles Dynamically
 
 ::: tip
-In Vue Flow 1.x, there's no need to manually invoke `updateNodeInternals` when dynamically adding handles.
-Upon mounting, handles will automatically attempt to attach to the node.
-However, if for any reason this isn't happening as expected, you can stick to the guideline provided below to enforce Vue Flow to update the node internals.
+Handles register themselves on mount, so statically-defined handles just work. When you add, remove, or move
+handles **dynamically** (after mount), call `updateNodeInternals` so Vue Flow re-measures the node's handle
+bounds — otherwise edges can end up misaligned.
 :::
 
 At times, you may need to modify handle positions dynamically or programmatically add new handles to a node. In this scenario, the [`updateNodeInternals`](/typedocs/type-aliases/UpdateNodeInternals) method found in Vue Flow's API comes in handy.

--- a/docs/src/guide/node.md
+++ b/docs/src/guide/node.md
@@ -21,7 +21,7 @@ const InputFieldNode = () => h('div', { class: 'custom-node-container' }, [
 const defaultNode = ref([
   {
     id: '1',
-    label: 'Default Node',
+    data: { label: 'Default Node' },
     position: { x: 50, y: 75 },
   }
 ]);
@@ -30,7 +30,7 @@ const inputNode = ref([
   {
     id: '1',
     type: 'input',
-    label: 'Input Node',
+    data: { label: 'Input Node' },
     position: { x: 50, y: 75 },
   }
 ]);
@@ -39,7 +39,7 @@ const outputNode = ref([
   {
     id: '1',
     type: 'output',
-    label: 'Output Node',
+    data: { label: 'Output Node' },
     position: { x: 50, y: 75 },
   }
 ]);
@@ -168,7 +168,7 @@ function generateRandomNode() {
   return {
     id: Math.random().toString(),
     position: { x: Math.random() * 500, y: Math.random() * 500 },
-    label: 'Random Node',
+    data: { label: 'Random Node' },
   }
 }
 
@@ -212,10 +212,10 @@ function generateRandomNode() {
   return {
     id: Math.random().toString(),
     position: { x: Math.random() * 500, y: Math.random() * 500 },
-    label: 'Random Node',
-    data: { 
+    data: {
+      label: 'Random Node',
       hello: 'world',
-    }
+    },
   }
 }
 
@@ -329,8 +329,7 @@ function removeMultipleNodes() {
 
 ## Updating Node Data
 
-Since nodes are reactive object, you can update their data at any point by simply mutating it.
-This allows you to disable or enable handles, change the label, or even add new properties to the data object at any point in time.
+In 2.0 nodes are stored **immutably** — mutating a node in place no longer triggers an update (see [Immutability](/guide/migration#_3-nodes-and-edges-are-immutable) in the migration guide). Update node data through the store actions (`updateNodeData` / `updateNode`), or reassign your `v-model:nodes` array immutably.
 
 There are multiple ways of achieving this, here are some examples:
 
@@ -344,40 +343,26 @@ const instance = useVueFlow()
 // use the `updateNodeData` method to update the data of an node
 instance.updateNodeData(nodeId, { hello: 'mona' })
 
-// find the node in the state by its id
-const node = instance.getNode(nodeId)
+// pass a function to derive the update from the current data
+instance.updateNodeData(nodeId, (node) => ({ visits: (node.data?.visits ?? 0) + 1 }))
 
-node.data = {
-  ...node.data,
-  hello: 'world',
-}
-
-// you can also mutate properties like `selectable` or `draggable`
-node.selectable = false
-node.draggable = false
-
-// or use `updateNode` to update the node directly
+// update other node properties (e.g. `selectable` / `draggable`) with `updateNode`
 instance.updateNode(nodeId, { selectable: false, draggable: false })
 ```
 
 ```vue [useNode]
 <!-- CustomNode.vue -->
 <script setup>
-import { useNode } from '@vue-flow/core'
+import { useNode, useVueFlow } from '@vue-flow/core'
 
-// `useNode` returns us the node object straight from the state
-// since the node obj is reactive, we can mutate it to update our nodes' data
-const { node } = useNode()
+// `useNode` resolves the current node (a `ComputedRef`) plus its parent, connected edges and DOM element
+const { id } = useNode()
+
+// `node` is read-only — update through the store action
+const { updateNodeData } = useVueFlow()
 
 function onSomeEvent() {
-  node.data = {
-    ...node.data,  
-    hello: 'world',
-  }
-  
-  // you can also mutate properties like `selectable` or `draggable`
-  node.selectable = false
-  node.draggable = false
+  updateNodeData(id, { hello: 'world' })
 }
 </script>
 ```
@@ -385,6 +370,7 @@ function onSomeEvent() {
 ```vue [v-model]
 <script setup>
 import { ref } from 'vue'
+import { Panel, VueFlow } from '@vue-flow/core'
 
 const nodes = ref([
   {
@@ -398,21 +384,15 @@ const nodes = ref([
 ])
 
 function onSomeEvent(nodeId) {
-  const node = nodes.value.find((node) => node.id === nodeId)
-
-  node.data = {
-    ...nodes.value[0].data,
-    hello: 'world',
-  }
-    
-  // you can also mutate properties like `selectable` or `draggable`
-  node.selectable = false
-  node.draggable = false
+  // reassign immutably — mutating a node in place won't trigger an update
+  nodes.value = nodes.value.map((node) =>
+    node.id === nodeId ? { ...node, data: { ...node.data, hello: 'world' } } : node,
+  )
 }
 </script>
 
 <template>
-  <VueFlow :nodes="nodes">
+  <VueFlow v-model:nodes="nodes">
     <Panel>
       <button type="button" @click="onSomeEvent('1')">Update Node 1</button>
     </Panel>
@@ -555,14 +535,14 @@ export const nodes = ref([
 <script setup>
 import { Position, Handle } from '@vue-flow/core'
 
-// props were passed from the slot using `v-bind="customNodeProps"`
-const props = defineProps(['label'])
+// props were passed from the slot using `v-bind="customNodeProps"` — the node's data is under `data`
+defineProps(['data'])
 </script>
 
 <template>
   <div>
     <Handle type="target" :position="Position.Top" />
-    <div>{{ label }}</div>
+    <div>{{ data.label }}</div>
     <Handle type="source" :position="Position.Bottom" />
   </div>
 </template>
@@ -577,22 +557,17 @@ import { VueFlow } from '@vue-flow/core'
 import CustomNode from './CustomNode.vue'
 import SpecialNode from './SpecialNode.vue'
 
-// You can pass 3 optional generic arguments to the Node interface, allowing you to define:
+// You can pass 2 optional generic arguments to the `Node` type:
 // 1. The data object type
-// 2. The events object type
-// 3. The possible node types
+// 2. The possible node-type string union
 
 export interface CustomData {
-  hello: string
-}
-
-export interface CustomEvents {
-  onCustomEvent: (event: MouseEvent) => void
+  label: string
 }
 
 type CustomNodeTypes = 'custom' | 'special'
 
-type CustomNode = Node<CustomData, CustomEvents, CustomNodeTypes>
+export type CustomNode = Node<CustomData, CustomNodeTypes>
 
 export const nodes = ref<CustomNode[]>([
   {
@@ -613,8 +588,8 @@ export const nodes = ref<CustomNode[]>([
   {
     id: '3', 
     data: { label: 'Node 3' },
-    // this will throw a type error, as the type is not defined in the CustomEdgeTypes
-    // regardless it would be rendered as a default edge type
+    // this will throw a type error, as the type is not defined in CustomNodeTypes
+    // regardless, it would be rendered as the default node type
     type: 'invalid',
     position: { x: 150, y: 50 },
   }
@@ -636,21 +611,21 @@ export const nodes = ref<CustomNode[]>([
 
 ```vue [CustomNode.vue <LogosTypescript />]
 <script setup lang="ts">
-import type { NodeProps } from '@vue-flow/core'  
-import { Position } from '@vue-flow/core'
+import type { NodeProps } from '@vue-flow/core'
+import { Handle, Position } from '@vue-flow/core'
 
-import { CustomData, CustomEvents } from './nodes'
+import type { CustomNode } from './nodes'
 
-// props were passed from the slot using `v-bind="customNodeProps"`
-const props = defineProps<NodeProps<CustomData, CustomEvents>>()
-  
-console.log(props.data.hello) // 'world'
+// `NodeProps` takes the node type (not the data type)
+const props = defineProps<NodeProps<CustomNode>>()
+
+console.log(props.data.label) // 'Node 1'
 </script>
 
 <template>
   <div>
     <Handle type="target" :position="Position.Top" />
-    <div>{{ label }}</div>
+    <div>{{ data.label }}</div>
     <Handle type="source" :position="Position.Bottom" />
   </div>
 </template>
@@ -743,26 +718,32 @@ const nodes = ref([
 Your custom nodes are enclosed so that fundamental functions like dragging or selecting operate. 
 But you may wish to expand on these features or implement your business logic inside nodes, thus your nodes receive the following properties:
 
-| Prop Name                                                   | Description                                                         | Type                                                       | Optional                                   |
-|-------------------------------------------------------------|---------------------------------------------------------------------|------------------------------------------------------------|--------------------------------------------|
-| id                                                          | Unique node id                                                      | string                                                     | <Close class="text-red-500" />             |
-| type                                                        | Node Type                                                           | string                                                     | <Close class="text-red-500" />             |
-| selected                                                    | Is node selected                                                    | boolean                                                    | <Close class="text-red-500" />             |
-| connectable                                                 | Can node handles be connected                                       | [HandleConnectable](/typedocs/type-aliases/HandleConnectable)     | <Close class="text-red-500" />             |
-| position                                                    | Node's x, y (relative) position on the graph                        | [XYPosition](/typedocs/interfaces/XYPosition)              | <Close class="text-red-500" />             |
-| dimensions                                                  | Dom element dimensions (width, height)                              | [Dimensions](/typedocs/interfaces/Dimensions)              | <Close class="text-red-500" />             |
-| label                                                       | Node label, either a string or a VNode. `h('div', props, children)` | string \| VNode \| Component \| Object                     | <Check class="text-[var(--vp-c-brand)]" /> |
-| isValidTargetPos <Badge type="warning" text="deprecated" /> | Called when used as target for new connection                       | [ValidConnectionFunc](/typedocs/type-aliases/ValidConnectionFunc) | <Check class="text-[var(--vp-c-brand)]" /> |
-| isValidSourcePos <Badge type="warning" text="deprecated" /> | Called when used as the source for a new connection                 | [ValidConnectionFunc](/typedocs/type-aliases/ValidConnectionFunc) | <Check class="text-[var(--vp-c-brand)]" /> |
-| parent                                                      | Parent node id                                                      | string                                                     | <Check class="text-[var(--vp-c-brand)]" /> |
-| dragging                                                    | Is node currently dragging                                          | boolean                                                    | <Close class="text-red-500" />             |
-| resizing                                                    | Is node currently resizing                                          | boolean                                                    | <Close class="text-red-500" />             |
-| zIndex                                                      | Node z-index                                                        | number                                                     | <Close class="text-red-500" />             |
-| targetPosition                                              | Handle position                                                     | [Position](/typedocs/enumerations/Position)                       | <Check class="text-[var(--vp-c-brand)]" /> |
-| sourcePosition                                              | Handle position                                                     | [Position](/typedocs/enumerations/Position)                       | <Check class="text-[var(--vp-c-brand)]" /> |
-| dragHandle                                                  | Drag handle query selector                                          | string                                                     | <Check class="text-[var(--vp-c-brand)]" /> |
-| data                                                        | Additional data of node                                             | any object                                                 | <Close class="text-red-500" />             |
-| events                                                      | Contextual and custom events of node                                | [NodeEventsOn](/typedocs/type-aliases/NodeEventsOn)               | <Close class="text-red-500" />             |
+| Prop Name         | Description                                  | Type                                        | Optional                                   |
+|-------------------|----------------------------------------------|---------------------------------------------|--------------------------------------------|
+| id                | Unique node id                               | string                                      | <Close class="text-red-500" />             |
+| type              | Node type                                    | string                                      | <Close class="text-red-500" />             |
+| data              | Custom node data                             | object                                      | <Close class="text-red-500" />             |
+| selected          | Is the node selected                         | boolean                                     | <Close class="text-red-500" />             |
+| selectable        | Can the node be selected                     | boolean                                     | <Close class="text-red-500" />             |
+| deletable         | Can the node be deleted                      | boolean                                     | <Close class="text-red-500" />             |
+| draggable         | Can the node be dragged                      | boolean                                     | <Close class="text-red-500" />             |
+| dragging          | Is the node currently being dragged          | boolean                                     | <Close class="text-red-500" />             |
+| isConnectable     | Can the node's handles be connected          | boolean                                     | <Close class="text-red-500" />             |
+| zIndex            | Node z-index                                 | number                                      | <Close class="text-red-500" />             |
+| positionAbsoluteX | Absolute x position on the graph             | number                                      | <Close class="text-red-500" />             |
+| positionAbsoluteY | Absolute y position on the graph             | number                                      | <Close class="text-red-500" />             |
+| width             | Measured width, once known                   | number                                      | <Check class="text-[var(--vp-c-brand)]" /> |
+| height            | Measured height, once known                  | number                                      | <Check class="text-[var(--vp-c-brand)]" /> |
+| sourcePosition    | Source handle position                       | [Position](/typedocs/enumerations/Position) | <Check class="text-[var(--vp-c-brand)]" /> |
+| targetPosition    | Target handle position                       | [Position](/typedocs/enumerations/Position) | <Check class="text-[var(--vp-c-brand)]" /> |
+| dragHandle        | Drag-handle query selector                   | string                                      | <Check class="text-[var(--vp-c-brand)]" /> |
+| parentId          | Parent node id                               | string                                      | <Check class="text-[var(--vp-c-brand)]" /> |
+
+::: tip
+Need the absolute position as a point, the measured size, or handle bounds? Those live on the `InternalNode` —
+resolve it with `getInternalNode(id)` or `useInternalNode(id)`. And since node defaults are no longer stamped,
+guard optional reads of `data` (`data?.label`).
+:::
 
 ## [Node Events](/typedocs/interfaces/NodeEventsHandler)
 
@@ -921,7 +902,7 @@ const listItems = ref(Array.from({ length: 100 }, (_, i) => i))
 ```
 
 <div class="mt-4 bg-[var(--vp-code-block-bg)] rounded-lg h-50">
-  <VueFlow :nodes="[{ id: '1', type: 'scrollable', label: 'Node 1', position: { x: 50, y: 50 } }]">
+  <VueFlow :nodes="[{ id: '1', type: 'scrollable', data: { label: 'Node 1' }, position: { x: 50, y: 50 } }]">
     <template #node-scrollable>
       <ScrollableNode />
     </template>
@@ -967,7 +948,7 @@ const inputValue = ref('')
 ```
 
 <div class="mt-4 bg-[var(--vp-code-block-bg)] rounded-lg h-50">
-  <VueFlow :nodes="[{ id: '1', type: 'input-field', label: 'Node 1', position: { x: 50, y: 50 } }]">
+  <VueFlow :nodes="[{ id: '1', type: 'input-field', data: { label: 'Node 1' }, position: { x: 50, y: 50 } }]">
     <template #node-input-field>
       <InputFieldNode />
     </template>


### PR DESCRIPTION
Group 2 of 4 of the guides refresh (migration ✓ #2092 → **authoring** → API/config → components).

Refreshes the three custom-element authoring guides against the current source — each was audited API-by-API. Common 2.0 drift, fixed across all three:

**node.md**
- Top-level `label` → `data.label` everywhere (built-in nodes read `data.label`, so the demos were rendering blank).
- `NodeProps`/`Node` generics: a single element-type generic (`NodeProps<CustomNode>`, `Node<Data, Type>`); dropped the removed events generic.
- Props table rewritten to the real `NodeProps` (`isConnectable`, `positionAbsoluteX/Y`, `width`/`height`, `parentId`, +`selectable`/`deletable`/`draggable`; dropped `label`/`position`/`dimensions`/`events`/`isValid*Pos`).
- "Updating Node Data" rewritten for immutability — `updateNode`/`updateNodeData` or immutable v-model reassignment, not in-place mutation.

**edge.md**
- `Edge`/`EdgeProps` generics (2-generic `Edge<Data, Type>`, `EdgeProps<CustomEdge>`).
- Props table rewritten: dropped `sourceNode`/`targetNode`/`events`, added `sourceX/Y`,`targetX/Y`,`selectable`,`deletable`, fixed optionality of `type`/`data`/markers, + a note pointing to `useInternalNode`.
- Demo-node labels → `data.label`; fixed the `@reconnect` handler that logged `'edge update'`.

**handle.md**
- `connectable` prop → `isConnectable`.
- Trimmed the redundant connection-mode prose (strict is the default; show setting `Loose`).
- Replaced the 1.x-flavored `updateNodeInternals` tip with 2.0 guidance.

Verified `NodeProps`/`EdgeProps`/`useNode`/Handle props against `packages/core/src`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)