### PR TITLE
fix(core): reactive MiniMap nodeColor

### DIFF
--- a/.changeset/minimap-nodecolor-reactive.md
+++ b/.changeset/minimap-nodecolor-reactive.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Fix `<MiniMap>`'s `nodeColor` not reacting to external reactive state. A `nodeColor` / `nodeStrokeColor` / `nodeClassName` function that reads a reactive value declared outside the node (e.g. recoloring a node from a `ref`) didn't update the minimap, because the per-node `v-memo` keyed on the function *reference*. It now keys on the function *result*, so such recolors re-render the affected minimap node while untouched nodes still skip during drag/pan frames.

--- a/packages/core/src/components/MiniMap/MiniMap.vue
+++ b/packages/core/src/components/MiniMap/MiniMap.vue
@@ -233,12 +233,15 @@ export default {
 
       <!-- v-memo on the lookup entry: unchanged nodes keep their InternalNode reference across commits
       (checkEquality reuse), so drag/pan-frame MiniMap re-renders skip every untouched child instead of
-      re-rendering all of them (the inline per-node prop objects/calls would otherwise always patch) -->
+      re-rendering all of them (the inline per-node prop objects/calls would otherwise always patch). The
+      node*Func RESULTS are in the deps (not the fn refs) so a recolor driven by an external reactive dep
+      read inside a `nodeColor`/`nodeStrokeColor`/`nodeClassName` callback still re-renders the affected
+      node — memoizing the fn refs froze the color until the node itself changed -->
       <MiniMapNode
         v-for="node of minimapNodes"
         :id="node.id"
         :key="node.id"
-        v-memo="[node, nodeClassNameFunc, nodeColorFunc, nodeStrokeColorFunc, nodeBorderRadius, nodeStrokeWidth, shapeRendering]"
+        v-memo="[node, nodeClassNameFunc(node), nodeColorFunc(node), nodeStrokeColorFunc(node), nodeBorderRadius, nodeStrokeWidth, shapeRendering]"
         :position="node.internals.positionAbsolute"
         :dimensions="getNodeDimensions(node)"
         :selected="node.selected"


### PR DESCRIPTION
`<MiniMap>`'s per-node `v-memo` keyed on the `nodeColor` / `nodeStrokeColor` / `nodeClassName` **function reference** (which is stable), so recoloring a node from a `ref` declared outside it — e.g. the RGB flow's color-output node — never re-rendered the minimap node. It now keys on the function **result**, so such recolors re-render the affected minimap node while untouched nodes still skip during drag/pan frames.

> **Scope trimmed:** the original `dragstart` preventer was removed. That "native drag image" wasn't a drag-engine regression — it was custom nodes not declaring `NodeProps`, so the `draggable` prop leaked onto the DOM via Vue `$attrs` and made the node a native drag source. Fixed at the source in `ff4a89c5` (the RGB nodes now `defineProps<NodeProps<…>>()`). Verified: a correctly-declared node's subtree has zero native-drag sources, and d3-drag's `dragDisable` already suppresses native drag during a drag exactly as 1.x did — so no preventer is needed (RF/SF don't have one either).

🤖 Generated with [Claude Code](https://claude.com/claude-code)