### PR TITLE
fix(core): honor the fitView prop on init (initial fit was inert)

### DIFF
--- a/.changeset/honor-fit-view-prop.md
+++ b/.changeset/honor-fit-view-prop.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Fix the `fitView` prop being ignored on init — `:fit-view` (and `<VueFlow fit-view>`) had no effect, so flows didn't fit to their nodes after load. `setState` maps the `fitView` prop to the internal `fitViewOnInit` flag, but its generic option loop then re-applied the default `fitViewOnInit: false` (re-spread from the freshly-created state), clobbering the value the mapping had just set. `fitViewOnInit` is now excluded from that loop (it's set solely by the `fitView` mapping), so the initial fit runs as intended. Regression from the `fitViewOnInit`-prop → `fitView`-prop rename.

--- a/packages/core/src/store/state.ts
+++ b/packages/core/src/store/state.ts
@@ -133,6 +133,10 @@ export const storeOptionsToSkip: (keyof Partial<FlowProps & Omit<State, 'nodes' 
   'translateExtent',
   'nodeExtent',
   'fitView',
+  // mapped from the `fitView` prop in `setState`; keep the generic option loop from re-applying the
+  // default — the full state is spread into `setState` on store creation, so a stale `fitViewOnInit: false`
+  // would otherwise clobber the value `fitView` just set, leaving `:fit-view` inert.
+  'fitViewOnInit',
   'viewport',
   'hooks',
   'defaultEdgeOptions',


### PR DESCRIPTION
`:fit-view` (and `<VueFlow fit-view>`) was silently ignored — flows didn't fit to their nodes on load. This read as inconsistent fit-view across the docs examples: some looked fit only because their nodes happened to land inside the default viewport, others were visibly off.

## Root cause
`setState` maps the `fitView` prop to the internal `fitViewOnInit` flag (`actions.ts`), but its generic option loop runs *afterward* and re-assigns `state.fitViewOnInit = opts.fitViewOnInit`. Since `createStore` calls `setState({ ...reactiveState, ...preloadedState })`, `opts` carries the default `fitViewOnInit: false` from the state spread — clobbering the value the mapping just set. `fitView` was in `storeOptionsToSkip`; `fitViewOnInit` wasn't. A regression from the `fitViewOnInit`-prop → `fitView`-prop rename (the prop→state mapping moved to a special case, but the underlying flag wasn't excluded from the generic loop).

## Fix
Add `fitViewOnInit` to `storeOptionsToSkip` so the generic loop leaves it alone — it's set solely by the `fitView` mapping.

## Verified (docs REPL, interaction example)
- **Before:** `fitViewOnInit: false`, transform identity (`scale(1)`), nodes at raw coords.
- **After:** `fitViewOnInit: true`, `fitViewOnInitDone: true`, transform `translate(-86, 229) scale(1.11)`, nodes fitted and centered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)