### PR TITLE
refactor(core)!: reuse @xyflow/system guards + Padding type

### DIFF
--- a/.changeset/align-system-guards-padding.md
+++ b/.changeset/align-system-guards-padding.md
@@ -1,0 +1,10 @@
+---
+"@vue-flow/core": major
+---
+
+Reuse `@xyflow/system` primitives instead of re-implementing them.
+
+- **Type guards** — `isNode` / `isEdge` / `isGraphNode` now delegate to the system's `isNodeBase` / `isEdgeBase` / `isInternalNodeBase` (single source of truth, matching xyflow/react & xyflow/svelte). Public signatures are unchanged; `isInternalNodeBase` is now re-exported as well.
+- **Padding** — `fitView` / `fitBounds` and a node `extent`'s `CoordinateExtentRange` now use the system's `Padding` type, and `Padding` / `PaddingWithUnit` / `PaddingUnit` are re-exported.
+  - **Breaking:** the extent padding's positional-tuple form (`[y, x]`, `[top, x, bottom]`, `[top, right, bottom, left]`) is removed. Use the object form instead, e.g. `{ top: 10, left: 20 }` or the `x` / `y` shorthands.
+  - `fitView` / `fitBounds` `padding` now accepts per-side values and `px` / `%` units (previously `number` only). A `%` extent padding resolves against the parent's width/height.

--- a/docs/src/guide/migration.md
+++ b/docs/src/guide/migration.md
@@ -273,6 +273,11 @@ far the pointer may move and still count as a node click.
   `NodeProps<MyData>` → `NodeProps<Node<MyData, 'myType'>>` (same for `EdgeProps<Edge<MyData, 'myType'>>`).
 - **`useVueFlow<NodeType, EdgeType>()`** is fully typed on both generics (xyflow order). `GraphNode<NodeType>`
   / `GraphEdge` is now `GraphEdge<EdgeType>`.
+- **Padding uses `@xyflow/system`'s `Padding` type** for both `fitView`/`fitBounds` options and a node
+  `extent`'s `{ range, padding }`. A plain number still works; you can also pass a `'10px'`/`'5%'` string or a
+  per-side object `{ top, right, bottom, left }` (with `x`/`y` shorthands). The old positional-tuple extent
+  padding is **removed**: `padding: [10, 20]` → `padding: { y: 10, x: 20 }`, and
+  `padding: [t, r, b, l]` → `padding: { top: t, right: r, bottom: b, left: l }`.
 - **Change types mirror `@xyflow/system`:**
   - `NodeDimensionChange.updateStyle` → `setAttributes` (`true | 'width' | 'height'`)
   - `NodePositionChange.from` → `positionAbsolute`
@@ -308,6 +313,9 @@ node.label             → node.data.label
 VueFlowStore           → VueFlowInstance
 GraphEdge              → Edge
 NodeProps<Data>        → NodeProps<Node<Data, 'type'>>
+
+// padding (fitView / fitBounds / node extent)
+padding: [10, 20]      → padding: { y: 10, x: 20 }   // positional tuple removed; px/% strings now allowed
 
 // behavior
 node.x = …             → updateNode(id, { x: … }) / immutable reassignment

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -77,10 +77,11 @@ export {
   getOutgoers,
   getViewportForBounds,
   isEdgeBase,
+  isInternalNodeBase,
   isMacOs,
   isNodeBase,
   pointToRendererPoint,
   rendererPointToPoint,
 } from '@xyflow/system';
 
-export { type ColorMode, type ColorModeClass, PanOnScrollMode, type Viewport } from '@xyflow/system';
+export { type ColorMode, type ColorModeClass, type Padding, type PaddingUnit, type PaddingWithUnit, PanOnScrollMode, type Viewport } from '@xyflow/system';

--- a/packages/core/src/types/node.ts
+++ b/packages/core/src/types/node.ts
@@ -1,4 +1,4 @@
-import type { InternalNodeBase, NodeBase } from '@xyflow/system';
+import type { InternalNodeBase, NodeBase, Padding } from '@xyflow/system';
 import type { HTMLAttributes } from 'vue';
 import type { Styles } from './flow';
 import type { HandleElement } from './handle';
@@ -8,13 +8,12 @@ export type CoordinateExtent = [extentFrom: [fromX: number, fromY: number], exte
 
 export interface CoordinateExtentRange {
   range: 'parent' | CoordinateExtent;
-  /** Values are top, right, bottom, left, you can use these the same as CSS padding */
-  padding:
-    | number
-    | [padding: number]
-    | [paddingY: number, paddingX: number]
-    | [paddingTop: number, paddingX: number, paddingBottom: number]
-    | [paddingTop: number, paddingRight: number, paddingBottom: number, paddingLeft: number];
+  /**
+   * Padding inside the parent's bounds (`@xyflow/system`'s `Padding`). A single value applies to all
+   * sides; the object form sets sides individually (`x`/`y` are horizontal/vertical shorthands). A `%`
+   * value resolves against the parent's width/height.
+   */
+  padding: Padding;
 }
 
 /**

--- a/packages/core/src/types/zoom.ts
+++ b/packages/core/src/types/zoom.ts
@@ -1,4 +1,4 @@
-import type { Viewport } from '@xyflow/system';
+import type { Padding, Viewport } from '@xyflow/system';
 import type { Rect, XYPosition } from './flow';
 
 export interface TransitionOptions {
@@ -6,7 +6,7 @@ export interface TransitionOptions {
 }
 
 export type FitViewParams = {
-  padding?: number;
+  padding?: Padding;
   includeHiddenNodes?: boolean;
   minZoom?: number;
   maxZoom?: number;
@@ -22,7 +22,7 @@ export type SetCenterOptions = TransitionOptions & {
 };
 
 export type FitBoundsOptions = TransitionOptions & {
-  padding?: number;
+  padding?: Padding;
 };
 
 /** Fit the viewport around visible nodes */

--- a/packages/core/src/utils/drag.ts
+++ b/packages/core/src/utils/drag.ts
@@ -1,24 +1,43 @@
+import type { PaddingWithUnit } from '@xyflow/system';
 import type { CoordinateExtent, CoordinateExtentRange, GraphNode, NodeDragItem, State, XYPosition } from '../types';
 import { clampPosition, getNodeDimensions } from '@xyflow/system';
 import { ErrorCode, VueFlowError } from '.';
 
-function getExtentPadding(padding: CoordinateExtentRange['padding']): [number, number, number, number] {
-  if (Array.isArray(padding)) {
-    switch (padding.length) {
-      case 1:
-        return [padding[0], padding[0], padding[0], padding[0]];
-      case 2:
-        return [padding[0], padding[1], padding[0], padding[1]];
-      case 3:
-        return [padding[0], padding[1], padding[2], padding[1]];
-      case 4:
-        return padding;
-      default:
-        return [0, 0, 0, 0];
-    }
+// Resolve one `PaddingWithUnit` against a reference length — `%` is relative, `px`/number is absolute.
+function resolvePadding(value: PaddingWithUnit | undefined, reference: number): number {
+  if (typeof value === 'number') {
+    return value;
   }
 
-  return [padding, padding, padding, padding];
+  if (!value) {
+    return 0;
+  }
+
+  const numeric = Number.parseFloat(value);
+
+  if (Number.isNaN(numeric)) {
+    return 0;
+  }
+
+  return value.endsWith('%') ? (numeric / 100) * reference : numeric;
+}
+
+// Resolve system `Padding` into absolute [top, right, bottom, left] within a parent of width × height.
+function getExtentPadding(
+  padding: CoordinateExtentRange['padding'],
+  width: number,
+  height: number,
+): [number, number, number, number] {
+  if (typeof padding === 'number' || typeof padding === 'string') {
+    return [resolvePadding(padding, height), resolvePadding(padding, width), resolvePadding(padding, height), resolvePadding(padding, width)];
+  }
+
+  return [
+    resolvePadding(padding.top ?? padding.y, height),
+    resolvePadding(padding.right ?? padding.x, width),
+    resolvePadding(padding.bottom ?? padding.y, height),
+    resolvePadding(padding.left ?? padding.x, width),
+  ];
 }
 
 function getParentExtent(
@@ -26,7 +45,9 @@ function getParentExtent(
   node: GraphNode | NodeDragItem,
   parent: GraphNode,
 ): CoordinateExtent | false {
-  const [top, right, bottom, left] = typeof currentExtent !== 'string' ? getExtentPadding(currentExtent.padding) : [0, 0, 0, 0];
+  const [top, right, bottom, left] = typeof currentExtent !== 'string'
+    ? getExtentPadding(currentExtent.padding, parent.measured.width ?? 0, parent.measured.height ?? 0)
+    : [0, 0, 0, 0];
 
   if (
     parent
@@ -82,7 +103,9 @@ export function getExtent<T extends NodeDragItem | GraphNode>(
     ];
   }
   else if (currentExtent !== 'parent' && currentExtent?.range && Array.isArray(currentExtent.range)) {
-    const [top, right, bottom, left] = getExtentPadding(currentExtent.padding);
+    const width = currentExtent.range[1][0] - currentExtent.range[0][0];
+    const height = currentExtent.range[1][1] - currentExtent.range[0][1];
+    const [top, right, bottom, left] = getExtentPadding(currentExtent.padding, width, height);
 
     const parentX = parent?.internals.positionAbsolute.x || 0;
     const parentY = parent?.internals.positionAbsolute.y || 0;

--- a/packages/core/src/utils/graph.ts
+++ b/packages/core/src/utils/graph.ts
@@ -2,15 +2,15 @@ import type { Connection, Edge, GraphNode, Node } from '../types';
 import { isEdgeBase, isInternalNodeBase, isNodeBase } from '@xyflow/system';
 
 export function isEdge<EdgeType extends Edge = Edge>(element: unknown): element is EdgeType {
-  return isEdgeBase(element);
+  return !!element && typeof element === 'object' && isEdgeBase(element);
 }
 
 export function isNode<NodeType extends Node = Node>(element: unknown): element is NodeType {
-  return isNodeBase(element);
+  return !!element && typeof element === 'object' && isNodeBase(element);
 }
 
 export function isGraphNode<NodeType extends Node = Node>(element: unknown): element is GraphNode<NodeType> {
-  return isInternalNodeBase(element);
+  return !!element && typeof element === 'object' && isInternalNodeBase(element);
 }
 
 export function connectionExists(edge: Edge | Connection, edges: Edge[]) {

--- a/packages/core/src/utils/graph.ts
+++ b/packages/core/src/utils/graph.ts
@@ -1,15 +1,16 @@
 import type { Connection, Edge, GraphNode, Node } from '../types';
+import { isEdgeBase, isInternalNodeBase, isNodeBase } from '@xyflow/system';
 
 export function isEdge<EdgeType extends Edge = Edge>(element: unknown): element is EdgeType {
-  return !!element && typeof element === 'object' && 'id' in element && 'source' in element && 'target' in element;
+  return isEdgeBase(element);
 }
 
 export function isNode<NodeType extends Node = Node>(element: unknown): element is NodeType {
-  return !!element && typeof element === 'object' && 'id' in element && 'position' in element && !isEdge(element);
+  return isNodeBase(element);
 }
 
 export function isGraphNode<NodeType extends Node = Node>(element: unknown): element is GraphNode<NodeType> {
-  return isNode(element) && 'internals' in element;
+  return isInternalNodeBase(element);
 }
 
 export function connectionExists(edge: Edge | Connection, edges: Edge[]) {


### PR DESCRIPTION
Stops re-implementing two things `@xyflow/system` already owns (matching xyflow/react & xyflow/svelte).

## Type guards
`isNode` / `isEdge` / `isGraphNode` now delegate to the system's `isNodeBase` / `isEdgeBase` / `isInternalNodeBase` instead of hand-rolled key checks. Public signatures (and the `Node`/`Edge`/`GraphNode` generic typing) are unchanged; the predicates are now a single source of truth. `isInternalNodeBase` is re-exported alongside the already-exported `isNodeBase`/`isEdgeBase`.

> The old `isGraphNode` wasn't broken — an internal node extends the user node (keeps `id`/`position`, adds `internals`) so `isNode(x) && 'internals' in x` did match. It was just a duplicate of `isInternalNodeBase`.

## Padding
`fitView` / `fitBounds` options and a node `extent`'s `CoordinateExtentRange` now use the system `Padding` type:

```ts
type Padding = `${number}px` | `${number}%` | number | { top?; right?; bottom?; left?; x?; y? }
```

- `fitView`/`fitBounds` `padding` previously accepted `number` only — now per-side values and `px`/`%` units work.
- A `%` extent padding resolves against the parent (or the explicit range box) width/height.
- `Padding` / `PaddingWithUnit` / `PaddingUnit` are re-exported.

### ⚠️ Breaking
The extent padding's **positional-tuple** form is removed:

```ts
// before                        // after
padding: [10]                 →  padding: 10
padding: [10, 20]             →  padding: { y: 10, x: 20 }
padding: [t, r, b, l]         →  padding: { top: t, right: r, bottom: b, left: l }
```

## Notes
- Migration guide updated (§13 + cheat sheet).
- No example used the tuple form (`stress`'s `fitView({ padding: 0.5 })` is still valid), so no example changes.
- `vite build`, `vue-tsc`, `tsc`, and dist lint all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)