### PR TITLE
refactor(core): collapse more duplicate types onto @xyflow/system

### DIFF
--- a/.changeset/collapse-more-system-types.md
+++ b/.changeset/collapse-more-system-types.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Reuse more `@xyflow/system` types instead of re-defining them locally: `XYPosition`, `Dimensions`, `Rect`, `SnapGrid`, `SelectionRect`, `SelectionMode`, `Position`, `ConnectionMode`, `Connection`, `NodeConnection`, `HandleType`, `NodeDimensionChange`, `NodePositionChange`, `NodeSelectionChange`, `NodeRemoveChange`, `EdgeSelectionChange`, `EdgeRemoveChange` and `Align`. Public API is unchanged (they're re-exported from the entry).

--- a/packages/core/src/components/ConnectionLine/index.ts
+++ b/packages/core/src/components/ConnectionLine/index.ts
@@ -1,9 +1,9 @@
 import type { HandleElement } from '../../types';
-import { getBezierPath, getHandlePosition, getMarkerId, getSmoothStepPath, oppositePosition } from '@xyflow/system';
+import { ConnectionMode, getBezierPath, getHandlePosition, getMarkerId, getSmoothStepPath, oppositePosition, Position } from '@xyflow/system';
 import { computed, defineComponent, h, inject } from 'vue';
 import { storeToRefs, useStore, useVueFlow } from '../../composables';
 import { Slots } from '../../context';
-import { ConnectionLineType, ConnectionMode, Position } from '../../types';
+import { ConnectionLineType } from '../../types';
 import { getSimpleBezierPath } from '../Edges/SimpleBezierEdge';
 
 const ConnectionLine = defineComponent({

--- a/packages/core/src/components/Edges/BezierEdge.ts
+++ b/packages/core/src/components/Edges/BezierEdge.ts
@@ -1,7 +1,6 @@
 import type { BezierEdgeProps } from '../../types';
-import { getBezierPath } from '@xyflow/system';
+import { getBezierPath, Position } from '@xyflow/system';
 import { defineComponent, h } from 'vue';
-import { Position } from '../../types';
 import BaseEdge from './BaseEdge.vue';
 import { baseEdgeProps } from './utils';
 

--- a/packages/core/src/components/Edges/EdgeAnchor.ts
+++ b/packages/core/src/components/Edges/EdgeAnchor.ts
@@ -1,6 +1,6 @@
 import type { FunctionalComponent, HTMLAttributes } from 'vue';
+import { Position } from '@xyflow/system';
 import { h } from 'vue';
-import { Position } from '../../types';
 
 interface Props extends HTMLAttributes {
   position: Position;

--- a/packages/core/src/components/Edges/EdgeText.vue
+++ b/packages/core/src/components/Edges/EdgeText.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import type { Rect as RectType } from '../../types';
+import type { Rect as RectType } from '@xyflow/system';
 import type { EdgeTextProps } from '../../types/components';
 import { computed, onMounted, ref, watch } from 'vue';
 

--- a/packages/core/src/components/Edges/EdgeWrapper.ts
+++ b/packages/core/src/components/Edges/EdgeWrapper.ts
@@ -1,9 +1,9 @@
-import type { Connection, Edge, EdgeComponent, GraphNode, HandleType, MouseTouchEvent } from '../../types';
-import { getHandlePosition, getMarkerId } from '@xyflow/system';
+import type { Connection, HandleType } from '@xyflow/system';
+import type { Edge, EdgeComponent, GraphNode, MouseTouchEvent } from '../../types';
+import { ConnectionMode, getHandlePosition, getMarkerId, Position } from '@xyflow/system';
 import { computed, defineComponent, getCurrentInstance, h, inject, provide, resolveComponent, shallowRef, toRef } from 'vue';
 import { storeToRefs, useEdgeHooks, useHandle, useStore, useVueFlow } from '../../composables';
 import { EdgeId, EdgeRef, Slots } from '../../context';
-import { ConnectionMode, Position } from '../../types';
 import { ARIA_EDGE_DESC_KEY, elementSelectionKeys, ErrorCode, getEdgeHandle, getEdgeZIndex, VueFlowError } from '../../utils';
 import EdgeAnchor from './EdgeAnchor';
 

--- a/packages/core/src/components/Edges/SimpleBezierEdge.ts
+++ b/packages/core/src/components/Edges/SimpleBezierEdge.ts
@@ -1,7 +1,6 @@
 import type { SimpleBezierEdgeProps } from '../../types';
-import { getBezierEdgeCenter } from '@xyflow/system';
+import { getBezierEdgeCenter, Position } from '@xyflow/system';
 import { defineComponent, h } from 'vue';
-import { Position } from '../../types';
 import BaseEdge from './BaseEdge.vue';
 import { baseEdgeProps } from './utils';
 

--- a/packages/core/src/components/Edges/SmoothStepEdge.ts
+++ b/packages/core/src/components/Edges/SmoothStepEdge.ts
@@ -1,7 +1,6 @@
 import type { SmoothStepEdgeProps } from '../../types';
-import { getSmoothStepPath } from '@xyflow/system';
+import { getSmoothStepPath, Position } from '@xyflow/system';
 import { defineComponent, h } from 'vue';
-import { Position } from '../../types';
 import BaseEdge from './BaseEdge.vue';
 import { baseEdgeProps } from './utils';
 

--- a/packages/core/src/components/Handle/Handle.vue
+++ b/packages/core/src/components/Handle/Handle.vue
@@ -1,9 +1,8 @@
 <script lang="ts" setup>
 import type { HandleProps } from '../../types';
-import { getDimensions, isMouseEvent } from '@xyflow/system';
+import { getDimensions, isMouseEvent, Position } from '@xyflow/system';
 import { computed, onMounted, ref, toRef } from 'vue';
 import { storeToRefs, useHandle, useNode, useStore, useVueFlow } from '../../composables';
-import { Position } from '../../types';
 import { isDef } from '../../utils';
 
 const {

--- a/packages/core/src/components/MiniMap/types.ts
+++ b/packages/core/src/components/MiniMap/types.ts
@@ -1,5 +1,6 @@
+import type { Dimensions, XYPosition } from '@xyflow/system';
 import type { CSSProperties, InjectionKey } from 'vue';
-import type { Dimensions, GraphNode, NodeMouseEvent, PanelPositionType, XYPosition } from '../../types';
+import type { GraphNode, NodeMouseEvent, PanelPositionType } from '../../types';
 
 /** expects a node and returns a color value */
 export type MiniMapNodeFunc = (node: GraphNode) => string;

--- a/packages/core/src/components/NodeResizer/NodeResizer.vue
+++ b/packages/core/src/components/NodeResizer/NodeResizer.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import type { NodeDimensionChange } from '../../types';
+import type { NodeDimensionChange } from '@xyflow/system';
 import type { ControlLinePosition, ControlPosition, NodeResizerEmits, NodeResizerProps } from './types';
 import { getNodeDimensions } from '@xyflow/system';
 import { computed, inject, toRef, watch } from 'vue';

--- a/packages/core/src/components/NodeResizer/ResizeControl.vue
+++ b/packages/core/src/components/NodeResizer/ResizeControl.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import type { XYResizerChange, XYResizerChildChange } from '@xyflow/system';
-import type { NodeChange, NodeDimensionChange, NodePositionChange } from '../../types';
+import type { NodeDimensionChange, NodePositionChange, XYResizerChange, XYResizerChildChange } from '@xyflow/system';
+import type { NodeChange } from '../../types';
 import type { NodeResizerEmits, ResizeControlProps } from './types';
 import { evaluateAbsolutePosition, handleExpandParent, XYResizer } from '@xyflow/system';
 import { computed, ref, toRef, watchEffect } from 'vue';

--- a/packages/core/src/components/NodeToolbar/NodeToolbar.vue
+++ b/packages/core/src/components/NodeToolbar/NodeToolbar.vue
@@ -2,12 +2,10 @@
 import type { CSSProperties } from 'vue';
 import type { GraphNode } from '../../types';
 import type { NodeToolbarProps } from './types';
-import { getNodesBounds, getNodeToolbarTransform } from '@xyflow/system';
+import { getNodesBounds, getNodeToolbarTransform, Position } from '@xyflow/system';
 import { computed, inject } from 'vue';
 import { storeToRefs, useStore, useVueFlow } from '../../composables';
 import { NodeId } from '../../context';
-
-import { Position } from '../../types';
 
 const props = withDefaults(defineProps<NodeToolbarProps>(), {
   position: Position.Top,

--- a/packages/core/src/components/NodeToolbar/types.ts
+++ b/packages/core/src/components/NodeToolbar/types.ts
@@ -1,4 +1,4 @@
-import type { Position } from '../../types';
+import type { Position } from '@xyflow/system';
 
 export interface NodeToolbarProps {
   nodeId?: string | string[];
@@ -7,5 +7,3 @@ export interface NodeToolbarProps {
   offset?: number;
   align?: 'center' | 'start' | 'end';
 }
-
-export type Align = 'center' | 'start' | 'end';

--- a/packages/core/src/components/Nodes/DefaultNode.ts
+++ b/packages/core/src/components/Nodes/DefaultNode.ts
@@ -1,7 +1,7 @@
 import type { Component, FunctionalComponent } from 'vue';
 import type { BuiltInNode, NodeProps } from '../../types';
+import { Position } from '@xyflow/system';
 import { Fragment, h } from 'vue';
-import { Position } from '../../types';
 import Handle from '../Handle/Handle.vue';
 
 const DefaultNode: FunctionalComponent<NodeProps<BuiltInNode>> = function ({

--- a/packages/core/src/components/Nodes/InputNode.ts
+++ b/packages/core/src/components/Nodes/InputNode.ts
@@ -1,7 +1,7 @@
 import type { Component, FunctionalComponent } from 'vue';
 import type { BuiltInNode, NodeProps } from '../../types';
+import { Position } from '@xyflow/system';
 import { Fragment, h } from 'vue';
-import { Position } from '../../types';
 import Handle from '../Handle/Handle.vue';
 
 const InputNode: FunctionalComponent<NodeProps<BuiltInNode>> = function ({

--- a/packages/core/src/components/Nodes/OutputNode.ts
+++ b/packages/core/src/components/Nodes/OutputNode.ts
@@ -1,7 +1,7 @@
 import type { Component, FunctionalComponent } from 'vue';
 import type { BuiltInNode, NodeProps } from '../../types';
+import { Position } from '@xyflow/system';
 import { Fragment, h } from 'vue';
-import { Position } from '../../types';
 import Handle from '../Handle/Handle.vue';
 
 const OutputNode: FunctionalComponent<NodeProps<BuiltInNode>> = function ({

--- a/packages/core/src/components/UserSelection/UserSelection.vue
+++ b/packages/core/src/components/UserSelection/UserSelection.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import type { SelectionRect } from '../../types';
+import type { SelectionRect } from '@xyflow/system';
 
 defineProps<{ userSelectionRect: SelectionRect }>();
 </script>

--- a/packages/core/src/composables/useHandle.ts
+++ b/packages/core/src/composables/useHandle.ts
@@ -1,9 +1,8 @@
-import type { ConnectionState, IsValidConnection as SystemIsValidConnection } from '@xyflow/system';
+import type { Connection, ConnectionState, HandleType, IsValidConnection as SystemIsValidConnection } from '@xyflow/system';
 import type { MaybeRefOrGetter } from 'vue';
-import type { ConnectingHandle, Connection, HandleType, MouseTouchEvent, ValidConnectionFunc } from '../types';
-import { getEventPosition, getHostForElement, XYHandle } from '@xyflow/system';
+import type { ConnectingHandle, MouseTouchEvent, ValidConnectionFunc } from '../types';
+import { getEventPosition, getHostForElement, Position, XYHandle } from '@xyflow/system';
 import { toValue } from 'vue';
-import { Position } from '../types';
 import { isValidHandle } from '../utils';
 import { storeToRefs } from './storeToRefs';
 import { useStore } from './useStore';

--- a/packages/core/src/composables/useNodeConnections.ts
+++ b/packages/core/src/composables/useNodeConnections.ts
@@ -1,5 +1,5 @@
+import type { HandleType, NodeConnection } from '@xyflow/system';
 import type { MaybeRefOrGetter } from 'vue';
-import type { HandleType, NodeConnection } from '../types';
 import { areConnectionMapsEqual, handleConnectionChange } from '@xyflow/system';
 import { computed, ref, toValue, watch } from 'vue';
 import { storeToRefs } from './storeToRefs';

--- a/packages/core/src/composables/useUpdateNodePositions.ts
+++ b/packages/core/src/composables/useUpdateNodePositions.ts
@@ -1,4 +1,5 @@
-import type { NodeDragItem, XYPosition } from '../types';
+import type { XYPosition } from '@xyflow/system';
+import type { NodeDragItem } from '../types';
 import { getNodeDimensions } from '@xyflow/system';
 import { calcNextPosition } from '../utils';
 import { storeToRefs } from './storeToRefs';

--- a/packages/core/src/composables/useWatchProps.ts
+++ b/packages/core/src/composables/useWatchProps.ts
@@ -1,5 +1,6 @@
+import type { Connection } from '@xyflow/system';
 import type { Ref, ToRefs } from 'vue';
-import type { Connection, Edge, FlowProps, Node, VueFlowStoreHandle } from '../types';
+import type { Edge, FlowProps, Node, VueFlowStoreHandle } from '../types';
 import { effectScope, isRef, toRaw, toRef, watch } from 'vue';
 import { isDef } from '../utils';
 import { storeToRefs } from './storeToRefs';

--- a/packages/core/src/container/Pane/Pane.vue
+++ b/packages/core/src/container/Pane/Pane.vue
@@ -1,11 +1,10 @@
 <script lang="ts" setup>
 import type { EdgeChange, NodeChange } from '../../types';
-import { areSetsEqual, getEventPosition, getNodesInside } from '@xyflow/system';
+import { areSetsEqual, getEventPosition, getNodesInside, SelectionMode } from '@xyflow/system';
 import { shallowRef, toRef, watch } from 'vue';
 import NodesSelection from '../../components/NodesSelection/NodesSelection.vue';
 import UserSelection from '../../components/UserSelection/UserSelection.vue';
 import { storeToRefs, useKeyPress, useStore, useVueFlow } from '../../composables';
-import { SelectionMode } from '../../types';
 import { getSelectionChanges } from '../../utils';
 import { getMousePosition } from './utils';
 

--- a/packages/core/src/container/Pane/utils.ts
+++ b/packages/core/src/container/Pane/utils.ts
@@ -1,4 +1,4 @@
-import type { XYPosition } from '../../types';
+import type { XYPosition } from '@xyflow/system';
 
 export function getMousePosition(event: MouseEvent, containerBounds: DOMRect): XYPosition {
   return {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -84,4 +84,30 @@ export {
   rendererPointToPoint,
 } from '@xyflow/system';
 
-export { type ColorMode, type ColorModeClass, type Padding, type PaddingUnit, type PaddingWithUnit, PanOnScrollMode, type Viewport } from '@xyflow/system';
+export {
+  type Align,
+  type ColorMode,
+  type ColorModeClass,
+  type Connection,
+  ConnectionMode,
+  type Dimensions,
+  type EdgeRemoveChange,
+  type EdgeSelectionChange,
+  type HandleType,
+  type NodeConnection,
+  type NodeDimensionChange,
+  type NodePositionChange,
+  type NodeRemoveChange,
+  type NodeSelectionChange,
+  type Padding,
+  type PaddingUnit,
+  type PaddingWithUnit,
+  PanOnScrollMode,
+  Position,
+  type Rect,
+  SelectionMode,
+  type SelectionRect,
+  type SnapGrid,
+  type Viewport,
+  type XYPosition,
+} from '@xyflow/system';

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -1,21 +1,23 @@
 import type {
+  EdgeRemoveChange,
+  EdgeSelectionChange,
+  NodeDimensionChange,
+  NodePositionChange,
+  NodeRemoveChange,
+  Rect,
+} from '@xyflow/system';
+import type {
   Actions,
   CoordinateExtent,
   CoordinateExtentRange,
   Edge,
   EdgeAddChange,
   EdgeLookup,
-  EdgeRemoveChange,
-  EdgeSelectionChange,
   FlowExportObject,
   GraphNode,
   Node,
   NodeAddChange,
-  NodeDimensionChange,
   NodeLookup,
-  NodePositionChange,
-  NodeRemoveChange,
-  Rect,
   State,
 } from '../types';
 import {

--- a/packages/core/src/store/state.ts
+++ b/packages/core/src/store/state.ts
@@ -1,6 +1,6 @@
 import type { Edge, FlowProps, Node, State } from '../types';
-import { isMacOs, PanOnScrollMode } from '@xyflow/system';
-import { ConnectionLineType, ConnectionMode, SelectionMode } from '../types';
+import { ConnectionMode, isMacOs, PanOnScrollMode, SelectionMode } from '@xyflow/system';
+import { ConnectionLineType } from '../types';
 
 import { createHooks } from './hooks';
 

--- a/packages/core/src/types/changes.ts
+++ b/packages/core/src/types/changes.ts
@@ -1,5 +1,13 @@
+import type {
+  EdgeRemoveChange,
+  EdgeSelectionChange,
+  NodeDimensionChange,
+  NodePositionChange,
+  NodeRemoveChange,
+  NodeSelectionChange,
+  XYPosition,
+} from '@xyflow/system';
 import type { Edge } from './edge';
-import type { XYPosition } from './flow';
 import type { Node, NodeOrigin } from './node';
 
 /**
@@ -36,33 +44,6 @@ export interface NodeDragItem {
  *
  * Item shapes on add changes are the user-provided `Node` / `Edge` types (not the internal `GraphNode`).
  */
-export interface NodeDimensionChange {
-  id: string;
-  type: 'dimensions';
-  dimensions?: { width: number; height: number };
-  resizing?: boolean;
-  setAttributes?: boolean | 'width' | 'height';
-}
-
-export interface NodePositionChange {
-  id: string;
-  type: 'position';
-  position?: XYPosition;
-  positionAbsolute?: XYPosition;
-  dragging?: boolean;
-}
-
-export interface NodeSelectionChange {
-  id: string;
-  type: 'select';
-  selected: boolean;
-}
-
-export interface NodeRemoveChange {
-  id: string;
-  type: 'remove';
-}
-
 export interface NodeAddChange<NodeType extends Node = Node> {
   item: NodeType;
   type: 'add';
@@ -75,10 +56,6 @@ export type NodeChange<NodeType extends Node = Node>
     | NodeSelectionChange
     | NodeRemoveChange
     | NodeAddChange<NodeType>;
-
-export type EdgeSelectionChange = NodeSelectionChange;
-
-export type EdgeRemoveChange = NodeRemoveChange;
 
 export interface EdgeAddChange<EdgeType extends Edge = Edge> {
   item: EdgeType;

--- a/packages/core/src/types/connection.ts
+++ b/packages/core/src/types/connection.ts
@@ -1,7 +1,8 @@
+import type { Connection, HandleType, NodeConnection, Position, XYPosition } from '@xyflow/system';
 import type { CSSProperties } from 'vue';
 import type { Edge, EdgeMarkerType } from './edge';
-import type { ClassValue, Position, XYPosition } from './flow';
-import type { ConnectingHandle, HandleElement, HandleType } from './handle';
+import type { ClassValue } from './flow';
+import type { ConnectingHandle, HandleElement } from './handle';
 import type { GraphNode, Node } from './node';
 
 /** Connection line types (same as default edge types */
@@ -20,22 +21,6 @@ export interface ConnectionLineOptions {
   markerEnd?: EdgeMarkerType;
   markerStart?: EdgeMarkerType;
 }
-
-/** Connection params that are passed when onConnect is called */
-export interface Connection {
-  /** Source node id */
-  source: string;
-  /** Target node id */
-  target: string;
-  /** Source handle id (null when the connection isn't tied to a specific handle) */
-  sourceHandle: string | null;
-  /** Target handle id (null when the connection isn't tied to a specific handle) */
-  targetHandle: string | null;
-}
-
-export type NodeConnection = Connection & {
-  edgeId: string;
-};
 
 export type Connector = (
   params: Connection,
@@ -99,12 +84,6 @@ export interface OnConnectStartParams {
   handleId: string | null;
   /** Source handle type */
   handleType?: HandleType;
-}
-
-/** Connection modes, when set to loose all handles are treated as source */
-export enum ConnectionMode {
-  Strict = 'strict',
-  Loose = 'loose',
 }
 
 export interface ConnectionLineProps {

--- a/packages/core/src/types/edge.ts
+++ b/packages/core/src/types/edge.ts
@@ -1,7 +1,7 @@
-import type { EdgeBase } from '@xyflow/system';
+import type { EdgeBase, Position } from '@xyflow/system';
 import type { Component, CSSProperties, SVGAttributes, VNode } from 'vue';
 import type { EdgeComponent, EdgeTextProps } from './components';
-import type { ClassValue, Position, Styles } from './flow';
+import type { ClassValue, Styles } from './flow';
 
 /** Edge markers */
 export enum MarkerType {

--- a/packages/core/src/types/flow.ts
+++ b/packages/core/src/types/flow.ts
@@ -1,17 +1,10 @@
 import type { KeyFilter } from '@vueuse/core';
-import type { ColorMode, PanOnScrollMode, Viewport } from '@xyflow/system';
+import type { ColorMode, Connection, ConnectionMode, PanOnScrollMode, SelectionMode, SnapGrid, Viewport } from '@xyflow/system';
 import type { CSSProperties } from 'vue';
 import type { VueFlowError } from '../utils';
 import type { EdgeChange, NodeChange } from './changes';
 import type { EdgeTypesObject, NodeTypesObject } from './components';
-import type {
-  Connection,
-  ConnectionLineOptions,
-  ConnectionLineProps,
-  ConnectionMode,
-  Connector,
-  OnConnectStartParams,
-} from './connection';
+import type { ConnectionLineOptions, ConnectionLineProps, Connector, OnConnectStartParams } from './connection';
 import type { DefaultEdgeOptions, Edge, EdgeProps, EdgeReconnectable } from './edge';
 import type { ValidConnectionFunc } from './handle';
 import type { EdgeMouseEvent, EdgeReconnectEvent, MouseTouchEvent, NodeDragEvent, NodeMouseEvent } from './hooks';
@@ -57,38 +50,6 @@ export type Styles = CSSProperties & ThemeVars & CustomThemeVars;
 
 // Vue does not publicly export ClassValue, so we define it here to match its class binding type
 export type ClassValue = string | Record<string, boolean> | ClassValue[];
-
-/** Handle Positions */
-export enum Position {
-  Left = 'left',
-  Top = 'top',
-  Right = 'right',
-  Bottom = 'bottom',
-}
-
-export interface XYPosition {
-  x: number;
-  y: number;
-}
-
-export interface Dimensions {
-  width: number;
-  height: number;
-}
-
-export interface Rect extends Dimensions, XYPosition {}
-
-export type SnapGrid = [x: number, y: number];
-
-export interface SelectionRect extends Rect {
-  startX: number;
-  startY: number;
-}
-
-export enum SelectionMode {
-  Partial = 'partial',
-  Full = 'full',
-}
 
 export interface FlowExportObject {
   /** exported nodes */

--- a/packages/core/src/types/handle.ts
+++ b/packages/core/src/types/handle.ts
@@ -1,9 +1,6 @@
-import type { Connection, ConnectionMode } from './connection';
+import type { Connection, ConnectionMode, Dimensions, HandleType, Position, XYPosition } from '@xyflow/system';
 import type { Edge } from './edge';
-import type { Dimensions, Position, XYPosition } from './flow';
 import type { GraphNode, Node } from './node';
-
-export type HandleType = 'source' | 'target';
 
 export interface HandleElement extends XYPosition, Dimensions {
   id?: string | null;

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -1,7 +1,7 @@
-import type { Viewport } from '@xyflow/system';
+import type { Connection, Viewport } from '@xyflow/system';
 import type { EventHookExtended, EventHookOn, EventHookTrigger, VueFlowError } from '../utils';
 import type { EdgeChange, NodeChange } from './changes';
-import type { Connection, OnConnectStartParams } from './connection';
+import type { OnConnectStartParams } from './connection';
 import type { Edge } from './edge';
 import type { Node } from './node';
 import type { VueFlowInstance } from './store';

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -1,31 +1,29 @@
 import type { KeyFilter } from '@vueuse/core';
-import type { ColorMode, PanOnScrollMode, PanZoomInstance, Transform, Viewport } from '@xyflow/system';
-import type { ComputedRef } from 'vue';
-import type { ViewportHelper } from '../composables';
-import type { EdgeChange, NodeChange, NodeDragItem } from './changes';
-import type { DefaultEdgeTypes, DefaultNodeTypes, EdgeComponent, NodeComponent } from './components';
 import type {
+  ColorMode,
   Connection,
-  ConnectionLineOptions,
-  ConnectionLookup,
   ConnectionMode,
-  ConnectionStatus,
-  Connector,
-  NodeConnection,
-} from './connection';
-import type { DefaultEdgeOptions, Edge, EdgeReconnectable } from './edge';
-import type {
   Dimensions,
-  FlowExportObject,
-  FlowProps,
-  OnBeforeDelete,
+  HandleType,
+  NodeConnection,
+  PanOnScrollMode,
+  PanZoomInstance,
   Rect,
   SelectionMode,
   SelectionRect,
   SnapGrid,
+  Transform,
+  Viewport,
   XYPosition,
-} from './flow';
-import type { ConnectingHandle, HandleType, ValidConnectionFunc } from './handle';
+} from '@xyflow/system';
+import type { ComputedRef } from 'vue';
+import type { ViewportHelper } from '../composables';
+import type { EdgeChange, NodeChange, NodeDragItem } from './changes';
+import type { DefaultEdgeTypes, DefaultNodeTypes, EdgeComponent, NodeComponent } from './components';
+import type { ConnectionLineOptions, ConnectionLookup, ConnectionStatus, Connector } from './connection';
+import type { DefaultEdgeOptions, Edge, EdgeReconnectable } from './edge';
+import type { FlowExportObject, FlowProps, OnBeforeDelete } from './flow';
+import type { ConnectingHandle, ValidConnectionFunc } from './handle';
 import type { FlowHooks, FlowHooksEmit, FlowHooksOn } from './hooks';
 import type { BuiltInNode, CoordinateExtent, CoordinateExtentRange, GraphNode, Node, NodeOrigin } from './node';
 

--- a/packages/core/src/types/zoom.ts
+++ b/packages/core/src/types/zoom.ts
@@ -1,5 +1,4 @@
-import type { Padding, Viewport } from '@xyflow/system';
-import type { Rect, XYPosition } from './flow';
+import type { Padding, Rect, Viewport, XYPosition } from '@xyflow/system';
 
 export interface TransitionOptions {
   duration?: number;

--- a/packages/core/src/utils/a11y.ts
+++ b/packages/core/src/utils/a11y.ts
@@ -1,4 +1,4 @@
-import type { XYPosition } from '../types';
+import type { XYPosition } from '@xyflow/system';
 
 export const ARIA_NODE_DESC_KEY = 'vue-flow__node-desc';
 export const ARIA_EDGE_DESC_KEY = 'vue-flow__edge-desc';

--- a/packages/core/src/utils/changes.ts
+++ b/packages/core/src/utils/changes.ts
@@ -1,16 +1,18 @@
 import type {
+  EdgeRemoveChange,
+  EdgeSelectionChange,
+  NodeRemoveChange,
+  NodeSelectionChange,
+} from '@xyflow/system';
+import type {
   Edge,
   EdgeAddChange,
   EdgeChange,
-  EdgeRemoveChange,
-  EdgeSelectionChange,
   ElementChange,
   GraphNode,
   Node,
   NodeAddChange,
   NodeChange,
-  NodeRemoveChange,
-  NodeSelectionChange,
 } from '../types';
 import { isNode } from '.';
 

--- a/packages/core/src/utils/drag.ts
+++ b/packages/core/src/utils/drag.ts
@@ -1,5 +1,5 @@
-import type { PaddingWithUnit } from '@xyflow/system';
-import type { CoordinateExtent, CoordinateExtentRange, GraphNode, NodeDragItem, State, XYPosition } from '../types';
+import type { PaddingWithUnit, XYPosition } from '@xyflow/system';
+import type { CoordinateExtent, CoordinateExtentRange, GraphNode, NodeDragItem, State } from '../types';
 import { clampPosition, getNodeDimensions } from '@xyflow/system';
 import { ErrorCode, VueFlowError } from '.';
 

--- a/packages/core/src/utils/graph.ts
+++ b/packages/core/src/utils/graph.ts
@@ -1,4 +1,5 @@
-import type { Connection, Edge, GraphNode, Node } from '../types';
+import type { Connection } from '@xyflow/system';
+import type { Edge, GraphNode, Node } from '../types';
 import { isEdgeBase, isInternalNodeBase, isNodeBase } from '@xyflow/system';
 
 export function isEdge<EdgeType extends Edge = Edge>(element: unknown): element is EdgeType {

--- a/packages/core/src/utils/handle.ts
+++ b/packages/core/src/utils/handle.ts
@@ -1,6 +1,6 @@
-import type { Actions, Connection, Edge, HandleElement, HandleType, IsValidParams, Node, NodeLookup, Result } from '../types';
-import { getEventPosition, getHandlePosition } from '@xyflow/system';
-import { ConnectionMode } from '../types';
+import type { Connection, HandleType } from '@xyflow/system';
+import type { Actions, Edge, HandleElement, IsValidParams, Node, NodeLookup, Result } from '../types';
+import { ConnectionMode, getEventPosition, getHandlePosition } from '@xyflow/system';
 
 const alwaysValid = () => true;
 

--- a/packages/core/src/utils/store.ts
+++ b/packages/core/src/utils/store.ts
@@ -1,7 +1,11 @@
-import type { NodeLookup as SystemNodeLookup, ParentLookup as SystemParentLookup } from '@xyflow/system';
+import type {
+  Connection,
+  NodeConnection,
+  NodeLookup as SystemNodeLookup,
+  ParentLookup as SystemParentLookup,
+} from '@xyflow/system';
 import type {
   Actions,
-  Connection,
   ConnectionLookup,
   CoordinateExtent,
   CoordinateExtentRange,
@@ -9,7 +13,6 @@ import type {
   Edge,
   GraphNode,
   Node,
-  NodeConnection,
   NodeOrigin,
   State,
   ValidConnectionFunc,


### PR DESCRIPTION
Continues the `@xyflow/system` dedup: removes locally-redefined types that the system already exports identically, importing them from system and re-exporting from the package entry. **Public API is unchanged** (the names still come out of `@vue-flow/core` via the `index.ts` re-export). Per convention, there are **no re-export shims in the type files** — consumers import straight from `@xyflow/system`.

## Collapsed (18, all structurally identical to system)
`XYPosition`, `Dimensions`, `Rect`, `SnapGrid`, `SelectionRect`, `SelectionMode`, `Position`, `ConnectionMode`, `NodeConnection`, `Connection` (was a local `interface` → system `type`), `HandleType`, `NodeDimensionChange`, `NodePositionChange`, `NodeSelectionChange`, `NodeRemoveChange`, `EdgeSelectionChange`, `EdgeRemoveChange`, `Align`.

The SFC-compiler hazard (`vuejs/core#14236`, the reason `NodeOrigin` stays local) was checked empirically — `vue-tsc` resolved every `defineProps<…>` against the system types, so none had to stay local.

## Deliberately left local (look like dups, but differ)
`ConnectionLineType` (our `simple-bezier` vs system `simplebezier`), `EdgeMarker`/`MarkerProps`/`EdgeMarkerType` (extra fields), `NodeChange`/`EdgeChange`/`*AddChange` (omit `replace`, narrower item type), `OnConnectStartParams` (null/optionality), the `ConnectionState` family (Vue node/handle shapes), `PanelPositionType` (narrower than system's `PanelPosition`), `NodeOrigin` (SFC bug), plus borderline `CoordinateExtent`/`NodeDragItem`/`ConnectionLookup`. These are a separate follow-up (some are real behavior decisions, e.g. the `simple-bezier` value).

## Verification
`pnpm --filter @vue-flow/core lint`, `types` (vue-tsc), and `build` all pass; `dist/index.d.ts` confirms the public surface is unchanged. 40 files, +125/−187.

> Note: touches `connection.ts`/`flow.ts`, so it'll likely have a trivial merge conflict with the still-open #2099 — resolve at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)