### PR TITLE
refactor(core)!: align ConnectionLineType, PanelPosition, EdgeMarkerType with @xyflow/system

### DIFF
--- a/.changeset/align-connectionlinetype-panelposition.md
+++ b/.changeset/align-connectionlinetype-panelposition.md
@@ -1,0 +1,8 @@
+---
+"@vue-flow/core": major
+---
+
+Collapse `ConnectionLineType` and `PanelPositionType` onto their `@xyflow/system` counterparts. Both are now re-exported from `@xyflow/system` (the local definitions are removed), aligning `@vue-flow/core` with `@xyflow/react`/`@xyflow/svelte`. Two breaking changes:
+
+- **`ConnectionLineType.SimpleBezier`'s value changed from `'simple-bezier'` to `'simplebezier'`**, matching `@xyflow/system` and vue-flow's own `'simplebezier'` edge-type registry key. If you pass the enum (`{ type: ConnectionLineType.SimpleBezier }`) nothing changes; only the raw string literal `'simple-bezier'` is affected — update it to `'simplebezier'`.
+- **`PanelPositionType` is renamed to `PanelPosition`** (`@xyflow/system`'s type). It now also accepts `'center-left'` and `'center-right'` in addition to the six existing corner/edge positions. Update type references from `PanelPositionType` to `PanelPosition`.

--- a/.changeset/align-connectionlinetype-panelposition.md
+++ b/.changeset/align-connectionlinetype-panelposition.md
@@ -6,3 +6,5 @@ Collapse `ConnectionLineType` and `PanelPositionType` onto their `@xyflow/system
 
 - **`ConnectionLineType.SimpleBezier`'s value changed from `'simple-bezier'` to `'simplebezier'`**, matching `@xyflow/system` and vue-flow's own `'simplebezier'` edge-type registry key. If you pass the enum (`{ type: ConnectionLineType.SimpleBezier }`) nothing changes; only the raw string literal `'simple-bezier'` is affected — update it to `'simplebezier'`.
 - **`PanelPositionType` is renamed to `PanelPosition`** (`@xyflow/system`'s type). It now also accepts `'center-left'` and `'center-right'` in addition to the six existing corner/edge positions. Update type references from `PanelPositionType` to `PanelPosition`.
+
+Also trims the redundant `| MarkerType` from `EdgeMarkerType` (now `string | EdgeMarker`, matching the system shape) — non-breaking, since `MarkerType` values are already strings.

--- a/docs/src/guide/migration.md
+++ b/docs/src/guide/migration.md
@@ -290,6 +290,11 @@ far the pointer may move and still count as a node click.
   - `NodePositionChange.from` → `positionAbsolute`
   - `NodeAddChange.item` / `EdgeAddChange.item` are the user `Node` / `Edge` (not `GraphNode`/`GraphEdge`); both gain an optional `index`
   - `EdgeRemoveChange` is `{ id, type: 'remove' }` only — read `source`/`target`/handles from the edge via `getEdge(id)` before the change applies
+- **`ConnectionLineType` is `@xyflow/system`'s enum.** Its `SimpleBezier` member's value changed from
+  `'simple-bezier'` to `'simplebezier'` (matching system and vue-flow's own `'simplebezier'` edge-type key).
+  Use the enum (`ConnectionLineType.SimpleBezier`) rather than the raw string and nothing changes.
+- **`PanelPositionType` → `PanelPosition`** (`@xyflow/system`'s type). It now also accepts `'center-left'`
+  and `'center-right'` in addition to the six corner/edge positions.
 
 ## Cheat sheet
 
@@ -320,6 +325,8 @@ node.label             → node.data.label
 VueFlowStore           → VueFlowInstance
 GraphEdge              → Edge
 NodeProps<Data>        → NodeProps<Node<Data, 'type'>>
+PanelPositionType      → PanelPosition       // + 'center-left' / 'center-right'
+ConnectionLineType.SimpleBezier  → 'simplebezier'  // value was 'simple-bezier'
 
 // padding (fitView / fitBounds / node extent)
 padding: [10, 20]      → padding: { y: 10, x: 20 }   // positional tuple removed; px/% strings now allowed

--- a/packages/core/src/components/ConnectionLine/index.ts
+++ b/packages/core/src/components/ConnectionLine/index.ts
@@ -1,9 +1,8 @@
 import type { HandleElement } from '../../types';
-import { ConnectionMode, getBezierPath, getHandlePosition, getMarkerId, getSmoothStepPath, oppositePosition, Position } from '@xyflow/system';
+import { ConnectionLineType, ConnectionMode, getBezierPath, getHandlePosition, getMarkerId, getSmoothStepPath, oppositePosition, Position } from '@xyflow/system';
 import { computed, defineComponent, h, inject } from 'vue';
 import { storeToRefs, useStore, useVueFlow } from '../../composables';
 import { Slots } from '../../context';
-import { ConnectionLineType } from '../../types';
 import { getSimpleBezierPath } from '../Edges/SimpleBezierEdge';
 
 const ConnectionLine = defineComponent({

--- a/packages/core/src/components/Controls/types.ts
+++ b/packages/core/src/components/Controls/types.ts
@@ -1,4 +1,5 @@
-import type { FitViewParams, PanelPositionType } from '../../types';
+import type { PanelPosition } from '@xyflow/system';
+import type { FitViewParams } from '../../types';
 
 export interface ControlProps {
   /**
@@ -26,11 +27,11 @@ export interface ControlProps {
    */
   fitViewParams?: FitViewParams;
   /**
-   * The {@link PanelPositionType position} of the `<Controls>` panel
+   * The {@link PanelPosition position} of the `<Controls>` panel
    *
    * @default 'bottom-left'
    */
-  position?: PanelPositionType;
+  position?: PanelPosition;
 }
 
 export interface ControlEmits {

--- a/packages/core/src/components/MiniMap/types.ts
+++ b/packages/core/src/components/MiniMap/types.ts
@@ -1,6 +1,6 @@
-import type { Dimensions, XYPosition } from '@xyflow/system';
+import type { Dimensions, PanelPosition, XYPosition } from '@xyflow/system';
 import type { CSSProperties, InjectionKey } from 'vue';
-import type { GraphNode, NodeMouseEvent, PanelPositionType } from '../../types';
+import type { GraphNode, NodeMouseEvent } from '../../types';
 
 /** expects a node and returns a color value */
 export type MiniMapNodeFunc = (node: GraphNode) => string;
@@ -24,8 +24,8 @@ export interface MiniMapProps {
   maskStrokeColor?: string;
   /** Border width of minimap mask */
   maskStrokeWidth?: number;
-  /** Position of the minimap {@link PanelPositionType} */
-  position?: PanelPositionType;
+  /** Position of the minimap {@link PanelPosition} */
+  position?: PanelPosition;
   /** Enable drag minimap to drag viewport */
   pannable?: boolean;
   /** Enable zoom minimap to zoom viewport */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -89,6 +89,7 @@ export {
   type ColorMode,
   type ColorModeClass,
   type Connection,
+  ConnectionLineType,
   ConnectionMode,
   type Dimensions,
   type EdgeRemoveChange,

--- a/packages/core/src/store/state.ts
+++ b/packages/core/src/store/state.ts
@@ -1,6 +1,5 @@
 import type { Edge, FlowProps, Node, State } from '../types';
-import { ConnectionMode, isMacOs, PanOnScrollMode, SelectionMode } from '@xyflow/system';
-import { ConnectionLineType } from '../types';
+import { ConnectionLineType, ConnectionMode, isMacOs, PanOnScrollMode, SelectionMode } from '@xyflow/system';
 
 import { createHooks } from './hooks';
 

--- a/packages/core/src/types/connection.ts
+++ b/packages/core/src/types/connection.ts
@@ -1,18 +1,9 @@
-import type { Connection, HandleType, NodeConnection, Position, XYPosition } from '@xyflow/system';
+import type { Connection, ConnectionLineType, HandleType, NodeConnection, Position, XYPosition } from '@xyflow/system';
 import type { CSSProperties } from 'vue';
 import type { Edge, EdgeMarkerType } from './edge';
 import type { ClassValue } from './flow';
 import type { ConnectingHandle, HandleElement } from './handle';
 import type { GraphNode, Node } from './node';
-
-/** Connection line types (same as default edge types */
-export enum ConnectionLineType {
-  Bezier = 'default',
-  SimpleBezier = 'simple-bezier',
-  Straight = 'straight',
-  Step = 'step',
-  SmoothStep = 'smoothstep',
-}
 
 export interface ConnectionLineOptions {
   type?: ConnectionLineType;

--- a/packages/core/src/types/edge.ts
+++ b/packages/core/src/types/edge.ts
@@ -40,7 +40,7 @@ export interface MarkerProps {
   strokeWidth?: number;
 }
 
-export type EdgeMarkerType = string | MarkerType | EdgeMarker;
+export type EdgeMarkerType = string | EdgeMarker;
 
 export type EdgeReconnectable = boolean | 'target' | 'source';
 

--- a/packages/core/src/types/panel.ts
+++ b/packages/core/src/types/panel.ts
@@ -1,5 +1,5 @@
-export type PanelPositionType = 'top-left' | 'top-center' | 'top-right' | 'bottom-left' | 'bottom-center' | 'bottom-right';
+import type { PanelPosition } from '@xyflow/system';
 
 export interface PanelProps {
-  position: PanelPositionType;
+  position: PanelPosition;
 }


### PR DESCRIPTION
The two `divergent` types from the dedup audit that needed a value/shape change before they could collapse onto `@xyflow/system`. Both now import from system and re-export from the entry (no shims in the type files).

## `ConnectionLineType`
The enum's `SimpleBezier` value was `'simple-bezier'`; system's is `'simplebezier'` (the only difference). Collapsed onto system → the value is now **`'simplebezier'`**, which also matches vue-flow's *own* edge-type registry (`simplebezier`), fixing an internal inconsistency.

## `PanelPositionType` → `PanelPosition`
We had a local 6-value `PanelPositionType`; system's `PanelPosition` is the same six **plus `center-left` / `center-right`**. Renamed to system's `PanelPosition` (consumers: `Panel`/`Controls`/`MiniMap`) and collapsed onto it, so those two extra positions are now accepted.

### ⚠️ Breaking
- Connection-line `type: 'simple-bezier'` → `'simplebezier'`.
- The `PanelPositionType` type name is gone — use `PanelPosition` (still exported from `@vue-flow/core`).

## Notes
- Public API unchanged in surface: `ConnectionLineType` + `PanelPosition` are re-exported from the entry. The typedoc pages are preserved (TypeDoc follows the re-export — `excludeExternals` is off).
- `vue-tsc` resolved every `defineProps` cleanly — neither tripped the SFC bug, so neither had to stay local.
- `lint` / `vue-tsc` / `build` all pass. Migration guide §13 + cheat sheet updated; `major` changeset.
- Likely a trivial merge conflict with the still-open #2099/#2100 on `connection.ts` — resolve at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)