### PR TITLE
fix(core): re-measure edge label box after fonts/styles settle

### DIFF
--- a/packages/core/src/components/Edges/EdgeText.vue
+++ b/packages/core/src/components/Edges/EdgeText.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import type { Rect as RectType } from '@xyflow/system';
 import type { EdgeTextProps } from '../../types/components';
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, onMounted, shallowRef, watch } from 'vue';
 
 const {
   x,
@@ -14,9 +14,9 @@ const {
   labelBgBorderRadius = 2,
 } = defineProps<EdgeTextProps>();
 
-const box = ref<RectType>({ x: 0, y: 0, width: 0, height: 0 });
+const box = shallowRef<RectType>({ x: 0, y: 0, width: 0, height: 0 });
 
-const el = ref<SVGTextElement | null>(null);
+const el = shallowRef<SVGTextElement | null>(null);
 
 const transform = computed(() => `translate(${x - box.value.width / 2} ${y - box.value.height / 2})`);
 
@@ -56,7 +56,7 @@ export default {
 </script>
 
 <template>
-  <g :transform="transform" class="vue-flow__edge-textwrapper">
+  <g :transform="transform" :visibility="box.width ? 'visible' : 'hidden'" class="vue-flow__edge-textwrapper">
     <rect
       v-if="labelShowBg"
       class="vue-flow__edge-textbg"

--- a/packages/core/src/components/Edges/EdgeText.vue
+++ b/packages/core/src/components/Edges/EdgeText.vue
@@ -20,7 +20,16 @@ const el = ref<SVGTextElement | null>(null);
 
 const transform = computed(() => `translate(${x - box.value.width / 2} ${y - box.value.height / 2})`);
 
-onMounted(getBox);
+onMounted(() => {
+  getBox();
+
+  // The first measurement can run before the theme stylesheet (`font-size`) and web font are applied,
+  // sizing the box for the wrong (default 16px) font. Since we deliberately don't re-measure on x/y
+  // changes (that would force a reflow every drag frame — see the watch below), it would never self-
+  // correct. Re-measure once after a frame and once fonts settle so the box snaps to the real text size.
+  requestAnimationFrame(getBox);
+  document.fonts?.ready?.then(getBox);
+});
 
 // the text's bounding box depends on its content/font, NOT its x/y position — re-measuring (getBBox forces
 // a reflow) on every move would thrash layout each drag frame for no change, so only watch el + label


### PR DESCRIPTION
## Problem

On the Basic example the edge-label background box renders **too large** and the label looks **off-center** (left-shifted).

## Root cause (confirmed empirically)

The label `<rect>` is sized from the `<text>`'s `getBBox()`. The first measurement can run **before `theme-default.css` (`font-size: 10px`) and the web font apply**, so `getBBox()` reports the text at the browser-default **16px**:

| label | stale box (16px) | real text (10px) | ratio |
|---|---|---|---|
| "edge with arrowhead" | 183 × 18.4 | 114.4 × 12 | **1.60×** |
| "smoothstep-edge" | 144.5 × 18.4 | 90.3 × 12 | **1.60×** |
| "Node 2" | 57.8 × 18.4 | 36.1 × 12 | **1.60×** |

A dead-constant **1.60× = 16/10**. Since the text sits at `x=0` (anchor `start`), the oversized rect leaves ~70px of dead space on the right → the label looks left-shifted.

`dd4938b1` is what exposed it: it dropped `() => x, () => y` from the watch (**correctly** — re-measuring `getBBox` every drag frame thrashes layout). But that x/y watch had been *accidentally* re-measuring once layout settled (e.g. on `fitView`), masking the premature measurement. With it gone, the stale 16px box never self-corrected.

## Fix

Re-measure once after a frame and once `document.fonts.ready` resolves, so a premature (pre-CSS / pre-font) measurement self-corrects — **without** reintroducing the per-frame reflow:

\`\`\`js
onMounted(() => {
  getBox();
  requestAnimationFrame(getBox);
  document.fonts?.ready?.then(getBox);
});
\`\`\`

The \`watch([el, () => label], getBox)\` (no \`x\`/\`y\`) is kept, so the drag-frame perf win from \`dd4938b1\` is preserved.

## Verification

Rebuilt core and reloaded the Basic example — all three labels now: \`rectW === text + 2·padX\`, \`rectH === 20\` (= text 12 + 2·padY 4), and left/right gap both exactly \`2px\` (= \`labelBgPadding[0]\`). Properly snug and centered.

No changeset: the regression only ever existed in unreleased 2.0 dev (1.x measured correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)