### PR TITLE
docs(guides): refresh API/config/state guides for 2.0

### DIFF
--- a/docs/src/guide/composables.md
+++ b/docs/src/guide/composables.md
@@ -47,27 +47,18 @@ The getters are read-only; update the graph through the actions (or by binding `
 
 ### State creation and injection
 
-The `useVueFlow` composable creates, on first call, a new `VueFlowInstance` and injects it into the Vue component tree.
-This allows you to access the store from any child component using the `useVueFlow` composable.
+`useVueFlow` does **not** create a store — it's a pure consumer. It takes no arguments and resolves the instance from the nearest `<VueFlow>` / `<VueFlowProvider>` ancestor via Vue's `inject` (it throws if there is none).
 
-This also means that the *first call* of `useVueFlow` is crucial as it determines the state instance that will be used throughout the component tree.
-You can think of it as a sort of `<VueFlowProvider>` wrapper that is automatically injected into the component tree.
+The store is created and owned by whichever provider sits above the call site:
+
+- `<VueFlow>` provides its own store to its children.
+- `<VueFlowProvider>` creates a store and shares it with everything inside it — use it when components *outside* `<VueFlow>` (a sidebar, a toolbar) need the same instance, or when you want to call `useVueFlow` in the same component that renders `<VueFlow>`.
 
 You can read more about this in the [State section of the guide](/guide/vue-flow/state).
 
-#### Enforcing a specific state instance
+#### Multiple flows
 
-If necessary, you can enforce the use of a specific state instance by passing an `id` to the `useVueFlow` composable.
-
-```ts
-import { useVueFlow } from '@vue-flow/core'
-
-const { onInit } = useVueFlow({ id: 'my-flow-instance' })
-
-onInit((instance) => {
-  // `instance` is the same type as the return of `useVueFlow` (VueFlowInstance)
-})
-```
+There is no global registry or lookup-by-id. Each flow lives in its own provider tree, so multiple flows on a page simply get their own `<VueFlow>` / `<VueFlowProvider>`, and `useVueFlow()` always resolves the nearest one.
 
 ## [useNodeConnections](/typedocs/functions/useNodeConnections)
 
@@ -166,18 +157,19 @@ This is how the default handle component is built:
 ```vue
 
 <script lang="ts" setup>
-import { NodeId, useHandle, useVueFlow } from '@vue-flow/core'
+import { storeToRefs, useHandle, useNodeId, useStore } from '@vue-flow/core'
 import type { HandleProps, Position } from '@vue-flow/core'
 
 const props = withDefaults(defineProps<HandleProps>(), {
   type: 'source',
   position: 'top' as Position,
-  connectable: true,
+  isConnectable: true,
 })
 
-const nodeId = inject(NodeId, '')
+const nodeId = useNodeId()
 
-const { id, hooks, connectionStartHandle } = useVueFlow()
+// `connectionStartHandle` is raw store state — pull it off `useStore` (as a ref) via `storeToRefs`
+const { connectionStartHandle } = storeToRefs(useStore())
 
 const { handlePointerDown, handleClick } = useHandle({
   nodeId,
@@ -209,10 +201,10 @@ export default {
       {
         source: type !== 'target',
         target: type === 'target',
-        connectable: connectable,
+        connectable: isConnectable,
         connecting:
           connectionStartHandle?.nodeId === nodeId &&
-          connectionStartHandle?.handleId === id &&
+          connectionStartHandle?.id === id &&
           connectionStartHandle?.type === type,
       },
     ]"

--- a/docs/src/guide/controlled-flow.md
+++ b/docs/src/guide/controlled-flow.md
@@ -4,11 +4,7 @@ title: Controlled Flow
 
 # Taking Control of Vue Flow
 
-::: warning
-This API is subject to change in the next major release where changes will not be applied automatically anymore.
-:::
-
-By default, Vue Flow will apply *changes* automatically, so you don't have to worry about it.
+By default, Vue Flow will apply *changes* automatically (controlled by the `autoApplyChanges` prop), so you don't have to worry about it.
 
 Though, there are cases where you want to take control of changes and apply them manually after some processing and validations for example.
 

--- a/docs/src/guide/utils/instance.md
+++ b/docs/src/guide/utils/instance.md
@@ -2,7 +2,7 @@
 
 Viewport Functions can be accessed via the [`useVueFlow`](/guide/composables#usevueflow)
 utility or with the [`VueFlowInstance`](/typedocs/type-aliases/VueFlowInstance)
-instance provided by [`onPaneReady`](/typedocs/interfaces/FlowEvents#paneready).
+instance provided by [`onInit`](/typedocs/interfaces/FlowEvents#init).
 
 - Using Event Hooks (Composable)
 
@@ -10,10 +10,10 @@ instance provided by [`onPaneReady`](/typedocs/interfaces/FlowEvents#paneready).
 <script setup>
 import { VueFlow, useVueFlow } from '@vue-flow/core'
 
-const { onPaneReady } = useVueFlow()
+const { onInit } = useVueFlow()
 
 // event handler
-onPaneReady((instance) => instance.fitView())
+onInit((instance) => instance.fitView())
 </script>
 ```
 
@@ -31,7 +31,7 @@ export default defineComponent({
     }
   },
   methods: {
-    onPaneReady(vueFlowInstance) {
+    onInit(vueFlowInstance) {
       vueFlowInstance.fitView()
       this.instance = vueFlowInstance
     }
@@ -39,7 +39,7 @@ export default defineComponent({
 })
 </script>
 <template>
-  <VueFlow @pane-ready="onPaneReady" />
+  <VueFlow @init="onInit" />
 </template>
 ```
 
@@ -80,7 +80,7 @@ vueFlowInstance.fitView({ padding: 0.25, includeHiddenNodes: true })
 - Example:
 
 ```ts
-vueFlowInstance.fitBounds(getRectOfNodes(nodes.value))
+vueFlowInstance.fitBounds(getNodesBounds(nodes.value))
 ```
 
 ## [setViewport](/typedocs/type-aliases/SetViewport)
@@ -119,12 +119,6 @@ vueFlowInstance.setViewport({ x: 100, y: 100, zoom: 1.5 })
 
   Zooms to specific level.
 
-## [getElements](/typedocs/interfaces/Getters#getelements)
-
-- Details:
-
-  Returns currently stored elements (nodes + edges).
-
 ## [getNodes](/typedocs/interfaces/Getters#getnodes)
 
 - Details:
@@ -141,14 +135,14 @@ vueFlowInstance.setViewport({ x: 100, y: 100, zoom: 1.5 })
 
 - Details:
 
-  Returns elements, position and zoom of the current flow state.
+  Returns the nodes, edges and viewport of the current flow state.
 
 - Example:
 
 ```ts
 toObject = (): {
-  elements: FlowElements,
-  position: [x, y],
-  zoom: scale,
+  nodes: Node[],
+  edges: Edge[],
+  viewport: { x: number, y: number, zoom: number },
 }
 ```

--- a/docs/src/guide/vue-flow/config.md
+++ b/docs/src/guide/vue-flow/config.md
@@ -374,7 +374,7 @@ const edges = ref([
 
 - Type: `KeyCode`
 
-- Default: `Meta`
+- Default: `Meta` on macOS, `Control` on other platforms
 
 - Details:
 
@@ -554,7 +554,7 @@ const edges = ref([
 
 - Type: `KeyCode`
 
-- Default: `Meta`
+- Default: `Meta` on macOS, `Control` on other platforms
 
 - Details:
 
@@ -721,7 +721,7 @@ const nodes = ref([
 
 - Type: `EdgeReconnectable`
 
-- Default: `true`
+- Default: `false`
 
 - Details:
 

--- a/docs/src/guide/vue-flow/slots.md
+++ b/docs/src/guide/vue-flow/slots.md
@@ -1,10 +1,9 @@
 # Slots
 
-##
-
 Vue Flow provides several slots for customization.
-In addition to the node and edge slots (see the guide on [nodes](/guide/node) and [edges](/guide/edge)),
-there are a number of other slots you can use to customize the visualization.
+In addition to the per-type node and edge slots — `#node-<type>` and `#edge-<type>` (see the guide on [nodes](/guide/node) and [edges](/guide/edge)) — there are a number of other slots you can use to customize the visualization.
+
+All slots are optional: you only need to define the ones you want to customize.
 
 ## Default
 
@@ -27,7 +26,7 @@ is triggered.
 </template>
 ```
 
-The full description of connection line props can be found [here](/typedocs/interfaces/ConnectionLineProps).
+The full description of connection line props can be found [here](/typedocs/interfaces/ConnectionLineProps). The position props follow xyflow/react's naming — `fromX` / `fromY` / `fromPosition` for the connection's origin and `toX` / `toY` / `toPosition` for the pointer, alongside `fromNode` / `fromHandle` and `toNode` / `toHandle` (renamed from the previous `source*` / `target*`).
 
 ## Zoom Pane
 

--- a/docs/src/guide/vue-flow/state.md
+++ b/docs/src/guide/vue-flow/state.md
@@ -1,23 +1,22 @@
 # State
 
-Under the hood Vue Flow uses [Provide/Inject](https://v3.vuejs.org/guide/component-provide-inject)
-to pass around it's state between components.
-You can access the internal state through the [`useVueFlow`](/guide/composables#usevueflow/) composable.
+Under the hood Vue Flow uses [Provide/Inject](https://vuejs.org/guide/components/provide-inject) to pass its state between components.
 
-[`useVueFlow`](/guide/composables#usevueflow/) can be used to either create a new state instance and inject it into
-the current component tree or inject
-an already existing store from the current context.
-Internal state can be manipulated, for example by adding new elements to the state. The
-state is reactive and changes will be reflected on the graph.
+The store is created and owned by `<VueFlow>` (or a standalone `<VueFlowProvider>`). Any descendant component can then reach it through two composables:
+
+- [`useVueFlow`](/guide/composables#usevueflow) — actions, computed getters and event hooks (mirrors `useReactFlow` / `useSvelteFlow`). It is a pure *consumer*: it takes **no arguments** and resolves the store from the nearest `<VueFlow>` / `<VueFlowProvider>` ancestor (it throws if there is none).
+- `useStore` — the raw reactive state (`nodes`, `edges`, `transform`, the lookups, …), read directly like a Pinia store. Use `storeToRefs(useStore())` to destructure individual state fields as refs.
+
+The state is reactive, so manipulating it (typically via the actions returned by `useVueFlow`) is reflected on the graph.
 
 ```vue
 <script setup>
 import { useVueFlow } from '@vue-flow/core'
 
-const { getNodes, onPaneReady } = useVueFlow()
+const { getNodes, onInit } = useVueFlow()
 
 // event handler
-onPaneReady((i) => i.fitView())
+onInit((instance) => instance.fitView())
 
 // watch the stored nodes
 watch(getNodes, (nodes) => console.log('nodes changed', nodes))
@@ -26,59 +25,52 @@ watch(getNodes, (nodes) => console.log('nodes changed', nodes))
 
 ## Accessing Internal State
 
-Using the composition API also allows us to pass the state around outside the current component context, thus we have a
-lot more flexibility when it comes
-to reading, writing and updating the state.
+Because the store lives in the component tree, you can read and update it from any descendant — no prop drilling.
 
-Consider this example, where we want to create a Sidebar that allows us to select all nodes.
+Consider a `Sidebar` that should be able to select all nodes. Wrap the flow and the sidebar in a common `<VueFlowProvider>` so both resolve the *same* store:
 
 ```vue
 <!-- Container.vue -->
+<script setup>
+import { VueFlow, VueFlowProvider } from '@vue-flow/core'
+import Sidebar from './Sidebar.vue'
+</script>
+
 <template>
-  <div>
+  <VueFlowProvider>
     <Sidebar />
+
     <div class="wrapper">
       <VueFlow :nodes="nodes" :edges="edges" />
     </div>
-  </div>
+  </VueFlowProvider>
 </template>
 ```
 
-We could pass all necessary info as props to the Sidebar, which could become either tedious or result in prop drilling,
-which we want to avoid.
-In this example it wouldn't be a big issue but if our destination was 3 components deep, it would become hard to track
-the flow of information.
+`<VueFlowProvider>` creates the store and provides it to everything inside it, so both `<VueFlow>` and `<Sidebar>` share one instance. (A bare `<VueFlow>` provides its own store too, but only to *its* children — a sibling like `<Sidebar>` sits outside it, which is why we hoist the provider.)
 
-Instead, we can initialize a Vue Flow store instance __before__ the Sidebar is initialized, thus the instance becomes
-available as an injection in the component tree.
-
-```vue{5-6}
-<script>
-// Container.vue
-import { useVueFlow  } from '@vue-flow/core'
-
-// initialize a store instance in this context, so it is available when calling inject(VueFlow)
-useVueFlow()
-</script>
-```
-
-Now we can easily access our current state instance from our Sidebar without passing them as props.
+Now the `Sidebar` can reach the state directly:
 
 ```vue
 <script setup>
-import { useVueFlow } from '@vue-flow/core'
+import { storeToRefs, useStore, useVueFlow } from '@vue-flow/core'
 
-const { nodesSelectionActive, addSelectedNodes, getNodes } = useVueFlow()
+// actions + computed getters come from the instance
+const { addSelectedNodes, getNodes } = useVueFlow()
+
+// raw state fields come from the store — destructure them as refs with storeToRefs
+const { nodesSelectionActive } = storeToRefs(useStore())
 
 const selectAll = () => {
   addSelectedNodes(getNodes.value)
   nodesSelectionActive.value = true
 }
 </script>
+
 <template>
   <aside>
     <div class="description">
-      This is an example of how you can access the internal state outside of the Vue VueFlow component.
+      This is an example of how you can access the internal state outside of the Vue Flow component.
     </div>
     <div class="selectall">
       <button @click="selectAll">select all nodes</button>
@@ -88,10 +80,7 @@ const selectAll = () => {
 ```
 
 ::: tip
-If you have multiple store instances in the same context, make sure to give them a unique id in order to guarantee
-access to the correct instance.
-Otherwise `useVueFlow` will try to inject the first instance it can find in the current context, which would usually be
-the last one that has been injected.
+Each flow needs its own `<VueFlow>` or `<VueFlowProvider>`. There is no global registry or lookup-by-id in 2.0 — `useVueFlow()` always resolves the store of the nearest provider ancestor, so multiple flows on a page simply live in separate provider trees.
 :::
 
 ## State Updates
@@ -115,47 +104,60 @@ come with the library to mix it up.
 Read more about this in the [controlled flow](/guide/controlled-flow) guide.
 :::
 
-## Access State in Options API
+## Access State in the Options API
 
-`useVueFlow` was designed to be used in the composition API, __but__ it is still possible to use it in the options API.
-Though it is necessary to pass a unique id for your Vue Flow state instance, otherwise a look-up will fail and Vue Flow
-will create a new state instance
-when mounted.
+`useVueFlow` is built for the composition API, but it works in the options API too — it just has to run inside `setup()`, where `inject` is available. As always, the component calling it must be rendered **inside** a `<VueFlow>` / `<VueFlowProvider>` ancestor, so put the flow logic in a child of the provider:
 
 ```vue
+<!-- App.vue -->
 <script>
-import { VueFlow, useVueFlow } from '@vue-flow/core'
+import { VueFlowProvider } from '@vue-flow/core'
+import Flow from './Flow.vue'
 
-const { addEdges, onConnect } = useVueFlow({ id: 'options-api' })
+export default defineComponent({
+  components: { VueFlowProvider, Flow },
+})
+</script>
+
+<template>
+  <VueFlowProvider>
+    <Flow />
+  </VueFlowProvider>
+</template>
+```
+
+```vue
+<!-- Flow.vue -->
+<script>
+import { useVueFlow, VueFlow } from '@vue-flow/core'
+
 export default defineComponent({
   components: { VueFlow },
+  setup() {
+    // resolves the store from the <VueFlowProvider> ancestor
+    const { addEdges, onConnect } = useVueFlow()
+
+    onConnect((params) => addEdges([params]))
+
+    return { addEdges }
+  },
   data() {
     return {
       nodes: [
-        {
-          id: '1',
-          position: { x: 0, y: 0},
-          data: { label: 'Node 1' }
-        }
+        { id: '1', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
       ],
       edges: [],
     }
   },
   methods: {
-    // regular event handler
-    handleConnect: (params) => {
-      addEdges([params])
-    }
+    handleConnect(params) {
+      this.addEdges([params])
+    },
   },
-  beforeMount() {
-    // Register your event handler, can technically be called in any lifecycle phase
-    // Skip this if you're using regular event handlers
-    onConnect((params) => addEdges([params]))
-  }
 })
 </script>
 
 <template>
-  <VueFlow id="options-api" :nodes="nodes" :edges="edges" @connect="handleConnect" />
+  <VueFlow :nodes="nodes" :edges="edges" @connect="handleConnect" />
 </template>
 ```


### PR DESCRIPTION
Group 3 of the 2.0 guides refresh (after migration #2092 and authoring node/edge/handle #2093). Each guide was audited prop-by-prop / API-by-API against `packages/core/src` and the 2.0 changesets, then fixed.

## Fixed

**`vue-flow/state.md`** — rewritten around the 2.0 store model. The page assumed the 1.x model (`useVueFlow` "creates a store on first call", id-based lookup, `useVueFlow({ id })`). Now:
- `<VueFlowProvider>` (or `<VueFlow>`) owns/creates the store; `useVueFlow()` takes no args and consumes the nearest provider; raw state comes from `useStore()` + `storeToRefs`.
- Sidebar example reads `nodesSelectionActive` via `storeToRefs(useStore())` (it's `State`, not on the instance).
- Options-API example uses a `<VueFlowProvider>` + child `setup()` (so `inject` resolves).
- `onPaneReady` → `onInit`.

**`composables.md`**
- "State creation and injection": `useVueFlow` is a pure consumer (injects, throws outside a provider), not a first-call store creator. Removed the `useVueFlow({ id })` section (no args / no global registry in 2.0).
- `useHandle` example rebuilt: was destructuring `hooks`/`connectionStartHandle` off `useVueFlow()`, importing a non-existent `NodeId`, and using `connectable` / `.handleId`. Now `storeToRefs(useStore())`, `useNodeId()`, `isConnectable`, `.id` — matching the real `Handle.vue`.

**`utils/instance.md`**
- Removed `getElements` (removed API) — use `getNodes` / `getEdges`.
- Fixed `toObject()` return shape: `{ elements, position, zoom }` → `{ nodes, edges, viewport }` (`FlowExportObject`).
- `onPaneReady` → `onInit` / `@init`; `getRectOfNodes` → `getNodesBounds`.

**`controlled-flow.md`** — dropped the stale "next major release will stop applying changes automatically" warning. `autoApplyChanges` is stable and defaults to `true`.

**`vue-flow/config.md`** — corrected defaults against `store/state.ts`:
- `edges-reconnectable`: `true` → **`false`**
- `zoom-activation-key-code` / `multi-selection-key-code`: **`Meta` on macOS, `Control` on other platforms** (`isMacOs() ? 'Meta' : 'Control'`)

**`vue-flow/slots.md`** — connection-line slot props use `from*`/`to*` (renamed from `source*`/`target*`); noted that all slots are optional; documented the `#node-<type>` / `#edge-<type>` pattern.

## Audited clean (no changes)
`vue-flow/events.md`, `utils/graph.md`, `utils/edge.md` — event payloads, graph utils and path-helper signatures already correct for 2.0.

## Follow-up (not in this PR)
`config.md` is missing ~18 props that exist in `FlowProps` (`nodeOrigin`, `selectionMode`, `connectionRadius`, `isValidConnection`, `onBeforeDelete`, `nodeDragThreshold`, `autoPanOnConnect`/`OnNodeDrag`/`Speed`, `paneClickDistance`, `nodeClickDistance`, `panActivationKeyCode`, `edgesFocusable`, `nodesFocusable`, `elevateNodesOnSelect`, `disableKeyboardA11y`, `noDragClassName`, …). Additive, not wrong — better as its own focused pass.

Next group: `components/*`, getting-started / theming / troubleshooting / index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)