### PR TITLE
docs(guides): refresh component + misc guides for 2.0

### DIFF
--- a/docs/src/guide/components/background.md
+++ b/docs/src/guide/components/background.md
@@ -20,14 +20,18 @@ import { Background, VueFlow } from '@vue-flow/core'
 
 ## [Props](/typedocs/interfaces/BackgroundProps)
 
-| Name         | Definition                            | Type                                                          | Optional | Default |
-|--------------|---------------------------------------|---------------------------------------------------------------|----------|---------|
-| variant      | Pattern variant                       | [BackgroundVariant](/typedocs/type-aliases/BackgroundVariant) | true     | dots    |
-| gap          | Pattern gap                           | number                                                        | true     | 10      |
-| size         | Pattern size                          | number                                                        | true     | 0.4     |
-| patternColor | Pattern color                         | string                                                        | true     | #81818a |
-| bgColor      | Background color (overwrites pattern) | string                                                        | true     | #fff    |
-| height       | Background height                     | number                                                        | true     | 100     |
-| width        | Background width                      | number                                                        | true     | 100     |
-| x            | X-offset                              | number                                                        | true     | 0       |
-| y            | Y-offset                              | number                                                        | true     | 0       |
+| Name      | Definition                                                  | Type                                                          | Optional | Default                           |
+|-----------|-------------------------------------------------------------|---------------------------------------------------------------|----------|-----------------------------------|
+| id        | Background id — needed when several flows show a background  | string                                                        | true     | auto-generated                    |
+| variant   | Pattern variant                                             | [BackgroundVariant](/typedocs/type-aliases/BackgroundVariant) | true     | dots                              |
+| gap       | Pattern gap — a single number or `[x, y]`                   | number \| number[]                                            | true     | 20                                |
+| size      | Pattern size                                                | number                                                        | true     | 1                                 |
+| lineWidth | Line width (for the `lines` variant)                        | number                                                        | true     | 1                                 |
+| color     | Pattern color (only the pattern, not the background)        | string                                                        | true     | `#91919a` (dots) / `#eee` (lines) |
+| offset    | Pattern offset — a single number or `[x, y]`                | number \| [number, number]                                    | true     | 0                                 |
+| x         | Background x-coordinate                                     | number                                                        | true     | 0                                 |
+| y         | Background y-coordinate                                     | number                                                        | true     | 0                                 |
+
+::: tip
+There is no `bgColor` prop — to change the background *color* (rather than the pattern), set a `background-color` on the `<VueFlow>` element via CSS.
+:::

--- a/docs/src/guide/components/control-button.md
+++ b/docs/src/guide/components/control-button.md
@@ -4,9 +4,13 @@ You can use the existing `ControlButton` component to create new control buttons
 
 ## Usage
 
-To use the component pass the `ControlButton` component as a child to the [`Controls`](/guide/components/control-button) component.
+To use the component pass the `ControlButton` component as a child to the [`Controls`](/guide/components/controls) component.
 
 ```vue
+<script setup>
+import { ControlButton, Controls, VueFlow } from '@vue-flow/core'
+</script>
+
 <template>
   <VueFlow>
     <Controls>
@@ -17,6 +21,18 @@ To use the component pass the `ControlButton` component as a child to the [`Cont
   </VueFlow>
 </template>
 ```
+
+## Props
+
+| Name     | Definition         | Type    | Optional | Default |
+|----------|--------------------|---------|----------|---------|
+| disabled | Disable the button | boolean | true     | false   |
+
+## Emits
+
+| Name  | Definition     | Payload    |
+|-------|----------------|------------|
+| click | Button clicked | MouseEvent |
 
 ## Slots
 

--- a/docs/src/guide/components/controls.md
+++ b/docs/src/guide/components/controls.md
@@ -6,8 +6,8 @@ The control panel contains a zoom-in, zoom-out, fit-view and a lock/unlock butto
 
 To use the controls simply pass the `Controls` component as a child to the `VueFlow` component.
 
-::: warning
-Make sure you also import the styles as these are *not* part of the default theme anymore.
+::: tip
+The control styles ship in `@vue-flow/core/dist/style.css` — make sure that base stylesheet is imported (see [Getting Started](/guide/getting-started)).
 :::
 
 ```vue
@@ -31,6 +31,7 @@ import { Controls, VueFlow } from '@vue-flow/core'
 | showInteractive | Show lock interactive btn              | boolean                                        | true     | true    |
 | showZoom        | Show zoom button                       | boolean                                        | true     | true    |
 | fitViewParams   | Params to use on fit-view button click | [FitViewParams](/typedocs/type-aliases/FitViewParams) | true     | -       |
+| position        | Position of the controls panel         | [PanelPosition](/typedocs/type-aliases/PanelPosition) | true     | bottom-left |
 
 ## Emits
 

--- a/docs/src/guide/components/minimap-node.md
+++ b/docs/src/guide/components/minimap-node.md
@@ -24,6 +24,7 @@ To use the component pass the `MiniMapNode` as a child to the [`MiniMap`](/guide
 | Name           | Definition                      | Type                                                | Optional | Default |
 |----------------|---------------------------------|-----------------------------------------------------|----------|---------|
 | id             | Node id                         | string                                              | false    | -       |
+| type           | Node type                       | string                                              | true     | -       |
 | selected       | Is node selected                | boolean                                             | true     | false   |
 | dragging       | Is node dragging                | boolean                                             | true     | false   |
 | position       | XY position of node             | [XYPosition](/typedocs/interfaces/XYPosition) | false    | -       |
@@ -32,7 +33,8 @@ To use the component pass the `MiniMapNode` as a child to the [`MiniMap`](/guide
 | color          | MiniMap node css color          | string                                              | true     | -       |
 | shapeRendering | MiniMap node css shapeRendering | ShapeRendering                                      | true     | -       |
 | strokeColor    | MiniMap node css stroke-color   | string                                              | true     | -       |
-| strokeWidth    | MiniMap node css stroke-width   | string                                              | true     | -       |
+| strokeWidth    | MiniMap node css stroke-width   | number                                              | true     | -       |
+| hidden         | Is the node hidden              | boolean                                             | true     | false   |
 
 ## Slots
 

--- a/docs/src/guide/components/minimap.md
+++ b/docs/src/guide/components/minimap.md
@@ -4,8 +4,8 @@
 
 To use the minimap simply pass the `MiniMap` component as a child to the `VueFlow` component.
 
-::: warning
-Make sure you also import the styles as these are *not* part of the default theme anymore.
+::: tip
+The minimap styles ship in `@vue-flow/core/dist/style.css` — make sure that base stylesheet is imported (see [Getting Started](/guide/getting-started)).
 :::
 
 ```vue
@@ -36,16 +36,26 @@ When enabled, these props allow you to pan on drag and zoom on scroll using the 
 
 ## [Props](/typedocs/interfaces/MiniMapProps)
 
-| Name             | Definition                   | Type                                                       | Optional | Default                 |
-|------------------|------------------------------|------------------------------------------------------------|----------|-------------------------|
-| nodeColor        | Node(s) Background color     | string, [MiniMapNodeFunc](/typedocs/type-aliases/MiniMapNodeFunc) | true     | #fff                    |
-| nodeStrokeColor  | Border color                 | string, [MiniMapNodeFunc](/typedocs/type-aliases/MiniMapNodeFunc) | true     | #555                    |
-| nodeClassName    | Extra classes                | string, [MiniMapNodeFunc](/typedocs/type-aliases/MiniMapNodeFunc) | true     | -                       |
-| nodeBorderRadius | Border radius                | number                                                     | true     | 5                       |
-| nodeStrokeWidth  | Stroke width                 | number                                                     | true     | 2                       |
-| maskColor        | Minimap Background color     | string                                                     | true     | rgb(240, 242, 243, 0.7) |
-| pannable         | Use Minimap to pan on drag   | boolean                                                    | true     | false                   |
-| zoomable         | Use Minimap to zoom on wheel | boolean                                                    | true     | false                   |
+| Name             | Definition                   | Type                                                              | Optional | Default                                           |
+|------------------|------------------------------|-------------------------------------------------------------------|----------|---------------------------------------------------|
+| nodeColor        | Node background color        | string, [MiniMapNodeFunc](/typedocs/type-aliases/MiniMapNodeFunc) | true     | `var(--vf-minimap-node-bg, #e2e2e2)`              |
+| nodeStrokeColor  | Node border color            | string, [MiniMapNodeFunc](/typedocs/type-aliases/MiniMapNodeFunc) | true     | transparent                                       |
+| nodeClassName    | Extra node classes           | string, [MiniMapNodeFunc](/typedocs/type-aliases/MiniMapNodeFunc) | true     | -                                                 |
+| nodeBorderRadius | Node border radius           | number                                                            | true     | 5                                                 |
+| nodeStrokeWidth  | Node stroke width            | number                                                            | true     | 2                                                 |
+| maskColor        | Mask (background) color      | string                                                            | true     | `var(--vf-minimap-mask, rgb(240, 240, 240, 0.6))` |
+| maskStrokeColor  | Mask border color            | string                                                            | true     | none                                              |
+| maskStrokeWidth  | Mask border width            | number                                                            | true     | 1                                                 |
+| maskBorderRadius | Mask border radius           | number                                                            | true     | 0                                                 |
+| position         | Position of the minimap      | [PanelPosition](/typedocs/type-aliases/PanelPosition)             | true     | bottom-right                                      |
+| pannable         | Use Minimap to pan on drag   | boolean                                                           | true     | false                                             |
+| zoomable         | Use Minimap to zoom on wheel | boolean                                                           | true     | false                                             |
+| inversePan       | Invert the pan direction     | boolean                                                           | true     | false                                             |
+| zoomStep         | Zoom step when zooming       | number                                                            | true     | 1                                                 |
+| offsetScale      | Minimap viewbox offset scale | number                                                            | true     | 5                                                 |
+| width            | Minimap width                | number                                                            | true     | -                                                 |
+| height           | Minimap height               | number                                                            | true     | -                                                 |
+| ariaLabel        | Accessibility label          | string \| null                                                    | true     | Vue Flow mini map                                 |
 
 ## Slots
 

--- a/docs/src/guide/components/node-resizer.md
+++ b/docs/src/guide/components/node-resizer.md
@@ -42,8 +42,6 @@ defineProps(['data'])
 ```
 
 
-When enabled, these props allow you to pan on drag and zoom on scroll using the MiniMap.
-
 ## [Props](/typedocs/interfaces/NodeResizerProps)
 
 | Name            | Definition                                                | Type          | Optional | Default              |
@@ -52,11 +50,16 @@ When enabled, these props allow you to pan on drag and zoom on scroll using the 
 | color           | Color of the resizer lines                                | string        | true     | -                    |
 | handleClassName | Extra class for the resize handle                         | string        | true     | -                    |
 | handleStyle     | Additional styles for the resize handle                   | CSSProperties | true     | -                    |
-| lineClassName   | Extra class for the resize lines                          | number        | true     | -                    |
-| lineStyle       | Additional styles for the resize lines                    | string        | true     | -                    |
-| isVisible       | Force visibility of resizer                               | boolean       | true     | true                 |
-| minWidth        | Min width of the resizer (can't resize below this value)  | number        | true     | -                    |
-| minHeight       | Min height of the resizer (can't resize below this value) | number        | true     | -                    |
+| lineClassName   | Extra class for the resize lines                          | string                                              | true     | -                    |
+| lineStyle       | Additional styles for the resize lines                    | CSSProperties                                       | true     | -                    |
+| isVisible       | Force visibility of resizer                               | boolean                                             | true     | true                 |
+| minWidth        | Min width of the resizer (can't resize below this value)  | number                                              | true     | -                    |
+| minHeight       | Min height of the resizer (can't resize below this value) | number                                              | true     | -                    |
+| maxWidth        | Max width of the resizer (can't resize above this value)  | number                                              | true     | -                    |
+| maxHeight       | Max height of the resizer (can't resize above this value) | number                                              | true     | -                    |
+| keepAspectRatio | Lock the aspect ratio while resizing                      | boolean \| number                                   | true     | -                    |
+| shouldResize    | Callback to allow or deny a resize                        | [ShouldResize](/typedocs/type-aliases/ShouldResize) | true     | -                    |
+| autoScale       | Scale the resize controls with the zoom level             | boolean                                             | true     | true                 |
 
 ## [Emits](/typedocs/interfaces/NodeResizerEmits)
 
@@ -65,3 +68,7 @@ When enabled, these props allow you to pan on drag and zoom on scroll using the 
 | resizeStart   |
 | resize        |
 | resizeEnd     |
+
+::: tip
+For a single resize handle (rather than the full resizer), `@vue-flow/core` also exports `NodeResizeControl` — see [`ResizeControlProps`](/typedocs/interfaces/ResizeControlProps).
+:::

--- a/docs/src/guide/components/node-toolbar.md
+++ b/docs/src/guide/components/node-toolbar.md
@@ -60,10 +60,11 @@ defineProps<Props>()
 
 | Name            | Definition                                        | Type                                 | Optional | Default                 |
 |-----------------|---------------------------------------------------|--------------------------------------|----------|-------------------------|
-| nodeId          | Node(s) the toolbar is supposed to be attached to | string array                         | true     | NodeId from context     |
+| nodeId          | Node(s) the toolbar is supposed to be attached to | string \| string[]                   | true     | NodeId from context     |
 | isVisible       | Force visibility of toolbar                       | boolean                              | true     | Selected node           |
 | position        | Toolbar position (top, left, right, bottom)       | [Position](/typedocs/enumerations/Position) | true     | Top                     |
 | offset          | Offset of toolbar position                        | number                               | true     | 10                      |
+| align           | Alignment along the position edge                 | 'start' \| 'center' \| 'end'         | true     | center                  |
 
 ## Slots
 

--- a/docs/src/guide/getting-started.md
+++ b/docs/src/guide/getting-started.md
@@ -22,7 +22,7 @@ If you're looking for a guide on how to setup a Vue project, check out the [offi
 Before you strap in, make sure you're equipped with:
 
 - [Node.js v20 or above](https://nodejs.org/)
-- [Vue 3.3 or above](https://vuejs.org/)
+- [Vue 3.5 or above](https://vuejs.org/)
 
 ## <span class="flex gap-2 items-center"> <VueJs class="text-primary" /> Play Online</span>
 
@@ -204,10 +204,14 @@ import { computed } from 'vue'
 import { Position, Handle } from '@vue-flow/core'
 
 const props = defineProps({
+  data: {
+    type: Object,
+    required: true,
+  },
   position: {
     type: Object,
     required: true,
-  }
+  },
 })
 
 const x = computed(() => `${Math.round(props.position.x)}px`)

--- a/docs/src/guide/theming.md
+++ b/docs/src/guide/theming.md
@@ -226,7 +226,7 @@ Here you'll find a handy reference guide of class names and their respective ele
 | ------------------------- | ------------------------------------------------- |
 | .vue-flow__edges          | Wrapper rendering edges                           |
 | .vue-flow__edge           | Wrapper around each edge element                  |
-| .vue-flow__selectionpane  | Pane for handling user selection                  |
+| .vue-flow__pane           | Pane handling panning & user selection            |
 | .vue-flow__selection      | Defines current user selection box                |
 | .vue-flow__edge-\{type\}  | Edge type (either custom or default)              |
 | .vue-flow__edge.selected  | Defines the currently selected edge(s)            |
@@ -255,5 +255,6 @@ Here you'll find a handy reference guide of class names and their respective ele
 | .vue-flow__handle-top     | Defines a handle at top                   |
 | .vue-flow__handle-left    | Defines a handle at left                  |
 | .vue-flow__handle-right   | Defines a handle at right                 |
-| .vue-flow__handle-connecting | Connection line is over the handle      |
-| .vue-flow__handle-valid      | Connection line over handle with valid connection |
+| .vue-flow__handle.connectable         | Handle that can be connected                    |
+| .vue-flow__handle.connecting          | Handle the connection started from              |
+| .vue-flow__handle.connectionindicator | Handle highlighted as a valid connection target |


### PR DESCRIPTION
Group 4 (final) of the 2.0 guides refresh — after migration #2092, authoring #2093, and API/config/state #2103. Each guide audited against the real component sources in `@vue-flow/core`.

Context: the standalone `@vue-flow/{background,minimap,controls,node-resizer,node-toolbar}` packages were folded into `@vue-flow/core` for 2.0; all component styles now ship in `@vue-flow/core/dist/style.css`.

## Fixed

**`components/background.md`** — props table rebuilt from `BackgroundProps`: `patternColor` → `color`; `gap` default 10 → 20 (now `number | number[]`); `size` 0.4 → 1; removed the non-existent `bgColor` / `width` / `height`; added `id`, `lineWidth`, `offset`. Added a tip that there's no `bgColor` prop (style the `<VueFlow>` element instead).

**`components/minimap.md`** — fixed `nodeColor` (`var(--vf-minimap-node-bg, #e2e2e2)`), `nodeStrokeColor` (`transparent`), `maskColor` (`var(--vf-minimap-mask, rgb(240, 240, 240, 0.6))`); added the 10 undocumented props (`position`, `maskStrokeColor`, `maskStrokeWidth`, `maskBorderRadius`, `inversePan`, `zoomStep`, `offsetScale`, `width`, `height`, `ariaLabel`). Corrected the "import styles separately" note — they ship in core's `style.css`.

**`components/minimap-node.md`** — `strokeWidth` `string` → `number`; added `type` and `hidden`.

**`components/controls.md`** — added the `position` prop (`PanelPosition`, default `bottom-left`); corrected the styles note.

**`components/control-button.md`** — fixed the self-referential link → `/guide/components/controls`; added the `disabled` prop, the `click` emit, and the missing imports in the example.

**`components/node-resizer.md`** — `lineClassName` `number` → `string`, `lineStyle` `string` → `CSSProperties`; added `maxWidth`, `maxHeight`, `keepAspectRatio`, `shouldResize`, `autoScale`; removed an orphaned MiniMap sentence; noted `NodeResizeControl`.

**`components/node-toolbar.md`** — added the `align` prop; `nodeId` type `string array` → `string | string[]`.

**`getting-started.md`** — Vue **3.3 → 3.5** requirement; added the missing `data` prop to the JavaScript custom-node example (template used `{{ data.label }}` with no `data` prop → runtime crash).

**`theming.md`** — fixed three selectors that don't exist in the DOM: `.vue-flow__selectionpane` → `.vue-flow__pane`; `.vue-flow__handle-connecting` / `.vue-flow__handle-valid` → the real `.vue-flow__handle.connecting` / `.connectionindicator` (+ `.connectable`).

## Audited clean (no changes)
`troubleshooting.md`, `index.md` — imports, API usage and links already correct for 2.0.

This completes the guides refresh (all of `docs/src/guide/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)