### PR TITLE
refactor(core): convert emit overloads to object notation

### DIFF
--- a/.changeset/emits-object-notation.md
+++ b/.changeset/emits-object-notation.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Convert the component emit type definitions (`MiniMapEmits`, `MiniMapNodeEmits`, `ControlEmits`, `NodeResizerEmits`, and `ControlButton`'s inline emit) from the call-signature overload form to Vue 3.3+ object notation (`{ eventName: [args] }`), matching `FlowEmits`. Event names and payloads are unchanged and `defineEmits` accepts both forms, so component usage is unaffected — only update if you imported one of these interfaces and relied on its old callable shape. Also types the `MiniMap` `click` payload's `position` as `XYPosition` (was an inline `{ x, y }`).

--- a/packages/core/src/components/Controls/ControlButton.vue
+++ b/packages/core/src/components/Controls/ControlButton.vue
@@ -4,7 +4,7 @@ defineProps<{
 }>();
 
 defineEmits<{
-  (event: 'click', payload: MouseEvent): void;
+  click: [payload: MouseEvent];
 }>();
 </script>
 

--- a/packages/core/src/components/Controls/types.ts
+++ b/packages/core/src/components/Controls/types.ts
@@ -35,8 +35,8 @@ export interface ControlProps {
 }
 
 export interface ControlEmits {
-  (event: 'zoomIn'): void;
-  (event: 'zoomOut'): void;
-  (event: 'fitView'): void;
-  (event: 'interactionChange', isInteractive: boolean): void;
+  zoomIn: [];
+  zoomOut: [];
+  fitView: [];
+  interactionChange: [isInteractive: boolean];
 }

--- a/packages/core/src/components/MiniMap/types.ts
+++ b/packages/core/src/components/MiniMap/types.ts
@@ -63,20 +63,20 @@ export interface MiniMapNodeProps {
 }
 
 export interface MiniMapEmits {
-  (event: 'click', params: { event: MouseEvent; position: { x: number; y: number } }): void;
-  (event: 'nodeClick', params: NodeMouseEvent): void;
-  (event: 'nodeDblclick', params: NodeMouseEvent): void;
-  (event: 'nodeMouseenter', params: NodeMouseEvent): void;
-  (event: 'nodeMousemove', params: NodeMouseEvent): void;
-  (event: 'nodeMouseleave', params: NodeMouseEvent): void;
+  click: [params: { event: MouseEvent; position: XYPosition }];
+  nodeClick: [params: NodeMouseEvent];
+  nodeDblclick: [params: NodeMouseEvent];
+  nodeMouseenter: [params: NodeMouseEvent];
+  nodeMousemove: [params: NodeMouseEvent];
+  nodeMouseleave: [params: NodeMouseEvent];
 }
 
 export interface MiniMapNodeEmits {
-  (event: 'click', params: MouseEvent): void;
-  (event: 'dblclick', params: MouseEvent): void;
-  (event: 'mouseenter', params: MouseEvent): void;
-  (event: 'mousemove', params: MouseEvent): void;
-  (event: 'mouseleave', params: MouseEvent): void;
+  click: [params: MouseEvent];
+  dblclick: [params: MouseEvent];
+  mouseenter: [params: MouseEvent];
+  mousemove: [params: MouseEvent];
+  mouseleave: [params: MouseEvent];
 }
 
 export interface MiniMapSlots extends Record<`node-${string}`, (nodeProps: MiniMapNodeProps) => any> {}

--- a/packages/core/src/components/NodeResizer/types.ts
+++ b/packages/core/src/components/NodeResizer/types.ts
@@ -56,9 +56,9 @@ export interface NodeResizerProps {
 }
 
 export interface NodeResizerEmits {
-  (event: 'resizeStart', resizeEvent: OnResizeStart): void;
-  (event: 'resize', resizeEvent: OnResize): void;
-  (event: 'resizeEnd', resizeEvent: OnResizeStart): void;
+  resizeStart: [resizeEvent: OnResizeStart];
+  resize: [resizeEvent: OnResize];
+  resizeEnd: [resizeEvent: OnResizeStart];
 }
 
 export interface ResizeControlProps extends NodeResizerProps {


### PR DESCRIPTION
Converts the remaining call-signature emit declarations to Vue 3.3+ object notation (`{ eventName: [args] }`), matching `FlowEmits` (#2097).

| type | from | to |
|------|------|----|
| `MiniMapEmits` | `(event: 'click', params: …): void` | `click: [params: …]` (×6) |
| `MiniMapNodeEmits` | `(event: 'click', params: MouseEvent): void` | `click: [params: MouseEvent]` (×5) |
| `ControlEmits` | `(event: 'zoomIn'): void` | `zoomIn: []` (×4) |
| `NodeResizerEmits` | `(event: 'resizeStart', …): void` | `resizeStart: [resizeEvent: …]` (×3) |
| `ControlButton.vue` | inline `(event: 'click', payload): void` | `click: [payload: MouseEvent]` |

Also types the `MiniMap` `click` payload's `position` as `XYPosition` (was an inline `{ x: number; y: number }`).

`defineEmits<…>()` accepts both notations, so event names, payloads, and the `emit(...)` call sites are unchanged — `vue-tsc` passes. The only consumer-visible change is the exported interfaces' shape (callable → object); patch changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)