### PR TITLE
feat(core)!: align connect/reconnect event payloads with xyflow + add selectionChange

### DIFF
--- a/.changeset/align-event-params-with-xyflow.md
+++ b/.changeset/align-event-params-with-xyflow.md
@@ -1,0 +1,11 @@
+---
+"@vue-flow/core": major
+---
+
+Align connection/reconnect event payloads with xyflow/react and add the `selectionChange` event:
+
+- `connectEnd` / `clickConnectEnd` now emit `{ event, connectionState }` (was the bare `MouseEvent | TouchEvent | undefined`). The `connectionState` is the `FinalConnectionState` (re-exported from `@xyflow/system`) — whether the connection was valid plus the from/to handles and nodes — mirroring react's `onConnectEnd`.
+- `reconnectStart` now emits `{ event, edge, handleType }` and `reconnectEnd` now emits `{ event, edge, handleType, connectionState }` (both were `{ event, edge }`). `handleType` is the handle being reconnected; `reconnectEnd` also carries the `FinalConnectionState`, matching react's `onReconnectStart`/`onReconnectEnd`.
+- Added a `selectionChange` event (`onSelectionChange` / `@selection-change`), emitting `{ nodes, edges }` whenever the set of selected nodes or edges changes — mirroring react's `onSelectionChange`. Previously selection was only observable through `nodesChange`/`edgesChange` select changes.
+
+Handlers that only read `edge` (reconnect) or ignore the payload are unaffected; handlers typed against the old `connectEnd`/`reconnect*` payloads need updating to the new object shapes.

--- a/examples/vite/src/Validation/ValidationExample.vue
+++ b/examples/vite/src/Validation/ValidationExample.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import type { Connection, Node, NodeProps, OnConnectStartParams, ValidConnectionFunc, VueFlowInstance } from '@vue-flow/core';
+import type { ConnectEndEvent, Connection, Node, NodeProps, OnConnectStartParams, ValidConnectionFunc, VueFlowInstance } from '@vue-flow/core';
 import { VueFlow } from '@vue-flow/core';
 import CustomInput from './CustomInput.vue';
 import CustomNode from './CustomNode.vue';
@@ -37,8 +37,8 @@ function onConnectStart({ nodeId, handleType }: OnConnectStartParams) {
   return console.log('on connect start', { nodeId, handleType });
 }
 
-function onConnectEnd(event: MouseEvent) {
-  return console.log('on connect end', event);
+function onConnectEnd({ event, connectionState }: ConnectEndEvent) {
+  return console.log('on connect end', event, connectionState);
 }
 
 function onConnect(params: Connection) {

--- a/packages/core/src/components/Edges/EdgeWrapper.ts
+++ b/packages/core/src/components/Edges/EdgeWrapper.ts
@@ -1,4 +1,4 @@
-import type { Connection, HandleType } from '@xyflow/system';
+import type { Connection, FinalConnectionState, HandleType } from '@xyflow/system';
 import type { Edge, EdgeComponent, GraphNode, MouseTouchEvent } from '../../types';
 import { ConnectionMode, getHandlePosition, getMarkerId, Position } from '@xyflow/system';
 import { computed, defineComponent, getCurrentInstance, h, inject, provide, resolveComponent, shallowRef, toRef } from 'vue';
@@ -315,8 +315,8 @@ const EdgeWrapper = defineComponent({
       emit.reconnect({ event, edge: storedEdge.value, connection });
     }
 
-    function onReconnectEnd(event: MouseTouchEvent) {
-      emit.reconnectEnd({ event, edge: storedEdge.value });
+    function onReconnectEnd(event: MouseTouchEvent, connectionState: FinalConnectionState<GraphNode>) {
+      emit.reconnectEnd({ event, edge: storedEdge.value, handleType: reconnectHandleType.value, connectionState });
       updating.value = false;
     }
 
@@ -332,7 +332,7 @@ const EdgeWrapper = defineComponent({
 
       reconnectHandleType.value = isSourceHandle ? 'target' : 'source';
 
-      emit.reconnectStart({ event, edge: storedEdge.value });
+      emit.reconnectStart({ event, edge: storedEdge.value, handleType: reconnectHandleType.value });
 
       handlePointerDown(event);
     }

--- a/packages/core/src/composables/useHandle.ts
+++ b/packages/core/src/composables/useHandle.ts
@@ -1,6 +1,6 @@
-import type { Connection, ConnectionState, HandleType, IsValidConnection as SystemIsValidConnection } from '@xyflow/system';
+import type { Connection, ConnectionState, FinalConnectionState, HandleType, IsValidConnection as SystemIsValidConnection } from '@xyflow/system';
 import type { MaybeRefOrGetter } from 'vue';
-import type { ConnectingHandle, MouseTouchEvent, ValidConnectionFunc } from '../types';
+import type { ConnectingHandle, GraphNode, MouseTouchEvent, ValidConnectionFunc } from '../types';
 import { getEventPosition, getHostForElement, Position, XYHandle } from '@xyflow/system';
 import { toValue } from 'vue';
 import { isValidHandle } from '../utils';
@@ -15,7 +15,7 @@ export interface UseHandleProps {
   isValidConnection?: MaybeRefOrGetter<ValidConnectionFunc | null>;
   reconnectHandleType?: MaybeRefOrGetter<HandleType>;
   onReconnect?: (event: MouseTouchEvent, connection: Connection) => void;
-  onReconnectEnd?: (event: MouseTouchEvent) => void;
+  onReconnectEnd?: (event: MouseTouchEvent, connectionState: FinalConnectionState<GraphNode>) => void;
 }
 
 function alwaysValid() {
@@ -181,10 +181,10 @@ export function useHandle({
           emits.connect(connection);
         }
       },
-      onConnectEnd: (evt) => {
-        emits.connectEnd(evt as MouseTouchEvent);
+      onConnectEnd: (evt, connectionState) => {
+        emits.connectEnd({ event: evt as MouseTouchEvent, connectionState });
         if (reconnectHandleType) {
-          onReconnectEnd?.(evt as MouseTouchEvent);
+          onReconnectEnd?.(evt as MouseTouchEvent, connectionState);
         }
       },
     });
@@ -258,7 +258,42 @@ export function useHandle({
       emits.connect(result.connection);
     }
 
-    emits.clickConnectEnd(event);
+    // the click path doesn't drive the system's connection state machine, so assemble the
+    // `FinalConnectionState` ourselves from the click-start handle + the resolved end handle, so
+    // `clickConnectEnd` carries the same payload shape as `connectEnd` (handles → system `Handle`s by
+    // padding the missing width/height, as `getFromHandle` does above).
+    const fromHandle = connectionClickStartHandle.value;
+    const fromNode = fromHandle ? getInternalNode(fromHandle.nodeId) : undefined;
+    const toHandle = result.toHandle;
+    const pointer = getEventPosition(event);
+    const connectionState: FinalConnectionState<GraphNode>
+      = fromHandle && fromNode
+        ? {
+            isValid: result.isValid,
+            from: { x: fromHandle.x, y: fromHandle.y },
+            fromHandle: { ...fromHandle, width: 0, height: 0 },
+            fromPosition: fromHandle.position,
+            fromNode,
+            to: toHandle ? { x: toHandle.x, y: toHandle.y } : pointer,
+            toHandle: toHandle ? { ...toHandle, width: 0, height: 0 } : null,
+            toPosition: toHandle?.position ?? null,
+            toNode: toHandle ? (getInternalNode(toHandle.nodeId) ?? null) : null,
+            pointer,
+          }
+        : {
+            isValid: null,
+            from: null,
+            fromHandle: null,
+            fromPosition: null,
+            fromNode: null,
+            to: null,
+            toHandle: null,
+            toPosition: null,
+            toNode: null,
+            pointer: null,
+          };
+
+    emits.clickConnectEnd({ event, connectionState });
 
     endConnection(event, true);
   }

--- a/packages/core/src/composables/useSelectionChange.ts
+++ b/packages/core/src/composables/useSelectionChange.ts
@@ -1,0 +1,30 @@
+import type { Edge, Node } from '../types';
+import { watch } from 'vue';
+import { useVueFlow } from './useVueFlow';
+
+/**
+ * Fires the `selectionChange` event whenever the set of selected nodes or edges changes, mirroring
+ * xyflow/react's `onSelectionChange`. Membership is tracked by id, so the event fires on select/deselect
+ * — not on unrelated node/edge mutations (which would re-run the `getSelected*` getters but not change ids).
+ *
+ * Takes the store explicitly because it runs inside `<VueFlow>`'s own setup, where `inject` can't see
+ * `<VueFlow>`'s own `provide` (see {@link useOnInitHandler}). Defaults to `useVueFlow()` for descendant callers.
+ *
+ * @internal
+ */
+export function useSelectionChange<NodeType extends Node = Node, EdgeType extends Edge = Edge>(
+  vfInstance = useVueFlow<NodeType, EdgeType>(),
+) {
+  watch(
+    [
+      () => vfInstance.getSelectedNodes.value.map(node => node.id).join(' '),
+      () => vfInstance.getSelectedEdges.value.map(edge => edge.id).join(' '),
+    ],
+    () => {
+      vfInstance.emits.selectionChange({
+        nodes: [...vfInstance.getSelectedNodes.value],
+        edges: [...vfInstance.getSelectedEdges.value],
+      });
+    },
+  );
+}

--- a/packages/core/src/container/VueFlow/VueFlow.vue
+++ b/packages/core/src/container/VueFlow/VueFlow.vue
@@ -8,6 +8,7 @@ import { storeToRefs } from '../../composables/storeToRefs';
 import { useColorModeClass } from '../../composables/useColorModeClass';
 import { useCreateVueFlow } from '../../composables/useCreateVueFlow';
 import { useOnInitHandler } from '../../composables/useOnInitHandler';
+import { useSelectionChange } from '../../composables/useSelectionChange';
 import { useStylesLoadedWarning } from '../../composables/useStylesLoadedWarning';
 import { useViewportSync } from '../../composables/useViewportSync';
 import { useWatchProps } from '../../composables/useWatchProps';
@@ -93,6 +94,8 @@ const disposeWatchers = useWatchProps({ nodes: modelNodes, edges: modelEdges }, 
 useHooks(emit, state.hooks);
 
 useOnInitHandler(instance);
+
+useSelectionChange(instance);
 
 useStylesLoadedWarning(instance);
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -94,6 +94,7 @@ export {
   type Dimensions,
   type EdgeRemoveChange,
   type EdgeSelectionChange,
+  type FinalConnectionState,
   type HandleType,
   type NodeConnection,
   type NodeDimensionChange,

--- a/packages/core/src/store/hooks.ts
+++ b/packages/core/src/store/hooks.ts
@@ -36,6 +36,7 @@ export function createHooks<NodeType extends Node = Node, EdgeType extends Edge 
     selectionContextMenu: createExtendedEventHook(),
     selectionStart: createExtendedEventHook(),
     selectionEnd: createExtendedEventHook(),
+    selectionChange: createExtendedEventHook(),
     viewportChangeStart: createExtendedEventHook(),
     viewportChange: createExtendedEventHook(),
     viewportChangeEnd: createExtendedEventHook(),

--- a/packages/core/src/types/flow.ts
+++ b/packages/core/src/types/flow.ts
@@ -7,7 +7,17 @@ import type { EdgeTypesObject, NodeTypesObject } from './components';
 import type { ConnectionLineOptions, ConnectionLineProps, Connector, OnConnectStartParams } from './connection';
 import type { DefaultEdgeOptions, Edge, EdgeProps, EdgeReconnectable } from './edge';
 import type { ValidConnectionFunc } from './handle';
-import type { EdgeMouseEvent, EdgeReconnectEvent, MouseTouchEvent, NodeDragEvent, NodeMouseEvent } from './hooks';
+import type {
+  ConnectEndEvent,
+  EdgeMouseEvent,
+  EdgeReconnectEndEvent,
+  EdgeReconnectEvent,
+  EdgeReconnectStartEvent,
+  MouseTouchEvent,
+  NodeDragEvent,
+  NodeMouseEvent,
+  SelectionChangeEvent,
+} from './hooks';
 import type { CoordinateExtent, CoordinateExtentRange, Node, NodeOrigin, NodeProps } from './node';
 import type { VueFlowInstance } from './store';
 import type { FitViewParams } from './zoom';
@@ -170,9 +180,9 @@ export interface FlowEmits<NodeType extends Node = Node, EdgeType extends Edge =
   miniMapNodeMouseLeave: [nodeMouseEvent: NodeMouseEvent<NodeType>];
   connect: [connectionEvent: Connection];
   connectStart: [connectionEvent: { event?: MouseEvent } & OnConnectStartParams];
-  connectEnd: [connectionEvent?: MouseEvent];
+  connectEnd: [connectionEvent: ConnectEndEvent<NodeType>];
   clickConnectStart: [connectionEvent: { event?: MouseEvent } & OnConnectStartParams];
-  clickConnectEnd: [connectionEvent?: MouseEvent];
+  clickConnectEnd: [connectionEvent: ConnectEndEvent<NodeType>];
   moveStart: [moveEvent: { event: MouseTouchEvent | null; viewport: Viewport }];
   move: [moveEvent: { event: MouseTouchEvent | null; viewport: Viewport }];
   moveEnd: [moveEvent: { event: MouseTouchEvent | null; viewport: Viewport }];
@@ -182,6 +192,7 @@ export interface FlowEmits<NodeType extends Node = Node, EdgeType extends Edge =
   selectionContextMenu: [selectionEvent: { event: MouseEvent; nodes: NodeType[] }];
   selectionStart: [selectionEvent: MouseEvent];
   selectionEnd: [selectionEvent: MouseEvent];
+  selectionChange: [selectionEvent: SelectionChangeEvent<NodeType, EdgeType>];
   viewportChangeStart: [viewport: Viewport];
   viewportChange: [viewport: Viewport];
   viewportChangeEnd: [viewport: Viewport];
@@ -201,9 +212,9 @@ export interface FlowEmits<NodeType extends Node = Node, EdgeType extends Edge =
   edgeMouseLeave: [edgeMouseEvent: EdgeMouseEvent<EdgeType>];
   edgeDoubleClick: [edgeMouseEvent: EdgeMouseEvent<EdgeType>];
   edgeClick: [edgeMouseEvent: EdgeMouseEvent<EdgeType>];
-  reconnectStart: [edgeMouseEvent: EdgeMouseEvent<EdgeType>];
+  reconnectStart: [edgeReconnectEvent: EdgeReconnectStartEvent<EdgeType>];
   reconnect: [reconnectEvent: EdgeReconnectEvent<EdgeType>];
-  reconnectEnd: [edgeMouseEvent: EdgeMouseEvent<EdgeType>];
+  reconnectEnd: [edgeReconnectEvent: EdgeReconnectEndEvent<NodeType, EdgeType>];
 
   nodeDoubleClick: [nodeMouseEvent: NodeMouseEvent<NodeType>];
   nodeClick: [nodeMouseEvent: NodeMouseEvent<NodeType>];

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -1,9 +1,9 @@
-import type { Connection, Viewport } from '@xyflow/system';
+import type { Connection, FinalConnectionState, HandleType, Viewport } from '@xyflow/system';
 import type { EventHookExtended, EventHookOn, EventHookTrigger, VueFlowError } from '../utils';
 import type { EdgeChange, NodeChange } from './changes';
 import type { OnConnectStartParams } from './connection';
 import type { Edge } from './edge';
-import type { Node } from './node';
+import type { GraphNode, Node } from './node';
 import type { VueFlowInstance } from './store';
 
 export type MouseTouchEvent = MouseEvent | TouchEvent;
@@ -30,6 +30,37 @@ export interface EdgeReconnectEvent<EdgeType extends Edge = Edge> {
   connection: Connection;
 }
 
+/**
+ * Payload for `connectEnd`/`clickConnectEnd` — the pointer event plus the {@link FinalConnectionState}
+ * (whether the connection was valid, the from/to handles and nodes), mirroring xyflow/react's `OnConnectEnd`.
+ */
+export interface ConnectEndEvent<NodeType extends Node = Node> {
+  event: MouseTouchEvent;
+  connectionState: FinalConnectionState<GraphNode<NodeType>>;
+}
+
+export interface EdgeReconnectStartEvent<EdgeType extends Edge = Edge> {
+  event: MouseTouchEvent;
+  edge: EdgeType;
+  /** the type of the handle being reconnected (the fixed end, opposite the grabbed anchor), as in xyflow/react */
+  handleType: HandleType;
+}
+
+export interface EdgeReconnectEndEvent<NodeType extends Node = Node, EdgeType extends Edge = Edge> {
+  event: MouseTouchEvent;
+  edge: EdgeType;
+  /** the type of the handle that was reconnected */
+  handleType: HandleType;
+  /** the {@link FinalConnectionState} at the moment the reconnect ended */
+  connectionState: FinalConnectionState<GraphNode<NodeType>>;
+}
+
+/** Payload for `selectionChange` — the currently selected nodes and edges, mirroring xyflow/react's `OnSelectionChange`. */
+export interface SelectionChangeEvent<NodeType extends Node = Node, EdgeType extends Edge = Edge> {
+  nodes: NodeType[];
+  edges: EdgeType[];
+}
+
 export interface FlowEvents<NodeType extends Node = Node, EdgeType extends Edge = Edge> {
   nodesChange: NodeChange<NodeType>[];
   edgesChange: EdgeChange<EdgeType>[];
@@ -53,11 +84,11 @@ export interface FlowEvents<NodeType extends Node = Node, EdgeType extends Edge 
   connectStart: {
     event?: MouseEvent | TouchEvent;
   } & OnConnectStartParams;
-  connectEnd: MouseEvent | TouchEvent | undefined;
+  connectEnd: ConnectEndEvent<NodeType>;
   clickConnectStart: {
     event?: MouseEvent | TouchEvent;
   } & OnConnectStartParams;
-  clickConnectEnd: MouseEvent | TouchEvent | undefined;
+  clickConnectEnd: ConnectEndEvent<NodeType>;
   init: VueFlowInstance<NodeType, EdgeType>;
   move: { event: MouseTouchEvent | null; viewport: Viewport };
   moveStart: { event: MouseTouchEvent | null; viewport: Viewport };
@@ -68,6 +99,7 @@ export interface FlowEvents<NodeType extends Node = Node, EdgeType extends Edge 
   selectionContextMenu: { event: MouseEvent; nodes: NodeType[] };
   selectionStart: MouseEvent;
   selectionEnd: MouseEvent;
+  selectionChange: SelectionChangeEvent<NodeType, EdgeType>;
   viewportChangeStart: Viewport;
   viewportChange: Viewport;
   viewportChangeEnd: Viewport;
@@ -83,9 +115,9 @@ export interface FlowEvents<NodeType extends Node = Node, EdgeType extends Edge 
   edgeMouseLeave: EdgeMouseEvent<EdgeType>;
   edgeDoubleClick: EdgeMouseEvent<EdgeType>;
   edgeClick: EdgeMouseEvent<EdgeType>;
-  reconnectStart: EdgeMouseEvent<EdgeType>;
+  reconnectStart: EdgeReconnectStartEvent<EdgeType>;
   reconnect: EdgeReconnectEvent<EdgeType>;
-  reconnectEnd: EdgeMouseEvent<EdgeType>;
+  reconnectEnd: EdgeReconnectEndEvent<NodeType, EdgeType>;
   error: VueFlowError;
 }
 
@@ -132,9 +164,9 @@ export interface EdgeEventsHandler<EdgeType extends Edge = Edge> {
   mouseMove: (event: EdgeMouseEvent<EdgeType>) => void | { off: () => void };
   mouseLeave: (event: EdgeMouseEvent<EdgeType>) => void | { off: () => void };
   contextMenu: (event: EdgeMouseEvent<EdgeType>) => void | { off: () => void };
-  reconnectStart: (event: EdgeMouseEvent<EdgeType>) => void | { off: () => void };
+  reconnectStart: (event: EdgeReconnectStartEvent<EdgeType>) => void | { off: () => void };
   reconnect: (event: EdgeReconnectEvent<EdgeType>) => void | { off: () => void };
-  reconnectEnd: (event: EdgeMouseEvent<EdgeType>) => void | { off: () => void };
+  reconnectEnd: (event: EdgeReconnectEndEvent<Node, EdgeType>) => void | { off: () => void };
 }
 
 export type EdgeEventsOn<EdgeType extends Edge = Edge> = {


### PR DESCRIPTION
Aligns vue-flow's event payloads with xyflow/react (and svelte) where they genuinely diverged. Follows an audit of every node/edge/pane/connection/selection event — most already matched (modulo vue's object-payload idiom) or are intentional vue supersets (`viewportChange*`, pane hover, minimap node events). This PR closes the three substantive gaps.

## Changes

**`connectEnd` / `clickConnectEnd` → `FinalConnectionState`**
- Payload `MouseEvent | TouchEvent | undefined` → `{ event, connectionState }`, mirroring react's `onConnectEnd`.
- `connectionState` is the system `FinalConnectionState` (re-exported from `@xyflow/system`): validity + from/to handles & nodes.
- Drag path passes the system's state through verbatim (zero conversion). Click path assembles an equivalent from the click-start handle + resolved end handle.

**`reconnectStart` / `reconnectEnd` → `handleType` (+ state)**
- `reconnectStart`: `{ event, edge }` → `{ event, edge, handleType }`
- `reconnectEnd`: `{ event, edge }` → `{ event, edge, handleType, connectionState }`
- `handleType` reuses the existing `reconnectHandleType`, which equals react's `oppositeHandle.type` (grab the source anchor → `'target'`), so the semantics already lined up.

**New `selectionChange` event** (`onSelectionChange` / `@selection-change`)
- Emits `{ nodes, edges }` when the selected set changes. Previously selection was only observable through `nodesChange`/`edgesChange` select changes.
- New internal `useSelectionChange` composable (modeled on `useOnInitHandler`) watches the selected-id sets and fires on membership change only (not on unrelated node mutations). Wired in `<VueFlow>`.

## Notes
- **Breaking** for handlers typed against the old `connectEnd`/`reconnect*` shapes; handlers that only read `edge` (reconnect) or ignore the payload are unaffected.
- Not changing `selectionDrag*`'s extra `node` field (the 4th divergence) — left as-is intentionally.
- `selectionChange` fires on post-mount changes, not on initial pre-selection.

## Verification
- `vue-tsc --noEmit`: clean. `pnpm --filter @vue-flow/core build`: clean (294 modules).
- Consumer sweep: `connect.cy.ts` only counts `onConnectEnd` (unaffected); `UpdatableEdge`/`edge.md` read only `edge` (still present); `SnappableConnectionLine` ignores the arg. Fixed the one genuine break — `ValidationExample`'s `onConnectEnd(event: MouseEvent)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)