### PR TITLE
refactor(core)!: rename GraphNode to InternalNode

### DIFF
--- a/.changeset/rename-graphnode-internalnode.md
+++ b/.changeset/rename-graphnode-internalnode.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": major
+---
+
+Rename `GraphNode` to `InternalNode` (and the `isGraphNode` type guard to `isInternalNode`), mirroring xyflow/react. `InternalNode` is the enriched, store-internal node returned by `getInternalNode` / `useInternalNode` / `nodeLookup`. The `GraphNode` name is removed — replace `GraphNode<T>` with `InternalNode<T>` and `isGraphNode(…)` with `isInternalNode(…)`.

--- a/docs/examples/helper-lines/Flow.vue
+++ b/docs/examples/helper-lines/Flow.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { GraphNode, Node, NodeChange } from '@vue-flow/core';
+import type { InternalNode, Node, NodeChange } from '@vue-flow/core';
 import { useVueFlow, VueFlow } from '@vue-flow/core';
 import { ref } from 'vue';
 import HelperLines from './HelperLines.vue';
@@ -13,7 +13,7 @@ const nodes = ref<Node[]>(initialNodes);
 const helperLineHorizontal = ref<number | undefined>(undefined);
 const helperLineVertical = ref<number | undefined>(undefined);
 
-function updateHelperLines(changes: NodeChange[], nodes: GraphNode[]) {
+function updateHelperLines(changes: NodeChange[], nodes: InternalNode[]) {
   helperLineHorizontal.value = undefined;
   helperLineVertical.value = undefined;
 
@@ -34,7 +34,7 @@ function updateHelperLines(changes: NodeChange[], nodes: GraphNode[]) {
 }
 
 function onNodesChange(changes: NodeChange[]) {
-  const updatedChanges = updateHelperLines(changes, nodes.value as GraphNode[]);
+  const updatedChanges = updateHelperLines(changes, nodes.value as InternalNode[]);
   nodes.value = applyNodeChanges(updatedChanges);
 }
 </script>

--- a/docs/examples/helper-lines/utils.ts
+++ b/docs/examples/helper-lines/utils.ts
@@ -1,4 +1,4 @@
-import type { GraphNode, NodePositionChange, XYPosition } from '@vue-flow/core';
+import type { InternalNode, NodePositionChange, XYPosition } from '@vue-flow/core';
 
 interface GetHelperLinesResult {
   horizontal?: number;
@@ -8,7 +8,7 @@ interface GetHelperLinesResult {
 
 // this utility function can be called with a position change (inside onNodesChange)
 // it checks all other nodes and calculated the helper line positions and the position where the current node should snap to
-export function getHelperLines(change: NodePositionChange, nodes: GraphNode[], distance = 5): GetHelperLinesResult {
+export function getHelperLines(change: NodePositionChange, nodes: InternalNode[], distance = 5): GetHelperLinesResult {
   const defaultResult = {
     horizontal: undefined,
     vertical: undefined,

--- a/docs/examples/layout-simple/useLayout.js
+++ b/docs/examples/layout-simple/useLayout.js
@@ -27,7 +27,7 @@ export function useLayout() {
     previousDirection.value = direction;
 
     for (const node of nodes) {
-      // if you need width+height of nodes for your layout, you can use the dimensions property of the internal node (`GraphNode` type)
+      // if you need width+height of nodes for your layout, you can use the dimensions property of the internal node (`InternalNode` type)
       const graphNode = getNode(node.id);
 
       dagreGraph.setNode(node.id, { width: graphNode.measured?.width || 150, height: graphNode.measured?.height || 50 });

--- a/docs/examples/layout/useLayout.js
+++ b/docs/examples/layout/useLayout.js
@@ -25,7 +25,7 @@ export function useLayout() {
     dagreGraph.setGraph({ rankdir: direction });
 
     for (const node of nodes) {
-      // if you need width+height of nodes for your layout, you can use the dimensions property of the internal node (`GraphNode` type)
+      // if you need width+height of nodes for your layout, you can use the dimensions property of the internal node (`InternalNode` type)
       const graphNode = getNode(node.id);
 
       if (!graphNode) {

--- a/docs/src/examples/nodes/update-node.md
+++ b/docs/src/examples/nodes/update-node.md
@@ -1,7 +1,7 @@
 # Update Node
 
 Updating internal node data is simple.
-After initializing your elements and parsing them into either `GraphNode` or `GraphEdge`
+After initializing your elements and processing them into their internal `InternalNode` / `Edge` form,
 Vue Flow will emit the changes back into your initial `ref`.
 
 That means you can manipulate any property of your original nodes, and it will trigger changes in the graph.

--- a/docs/src/guide/migration.md
+++ b/docs/src/guide/migration.md
@@ -271,8 +271,12 @@ far the pointer may move and still count as a node click.
 
 - **`NodeProps`/`EdgeProps` take the element type**, not the data type:
   `NodeProps<MyData>` → `NodeProps<Node<MyData, 'myType'>>` (same for `EdgeProps<Edge<MyData, 'myType'>>`).
-- **`useVueFlow<NodeType, EdgeType>()`** is fully typed on both generics (xyflow order). `GraphNode<NodeType>`
-  / `GraphEdge` is now `GraphEdge<EdgeType>`.
+- **`GraphNode` is renamed to `InternalNode`** (mirroring xyflow/react), and the `isGraphNode` guard to
+  `isInternalNode`. It's the enriched, store-internal node returned by
+  `getInternalNode`/`useInternalNode`/`nodeLookup`; the `GraphNode` name is removed, so replace
+  `GraphNode<T>` with `InternalNode<T>`.
+- **`useVueFlow<NodeType, EdgeType>()`** is fully typed on both generics (xyflow order); `getInternalNode`
+  /`nodeLookup` return `InternalNode<NodeType>`.
 - **Padding uses `@xyflow/system`'s `Padding` type** for both `fitView`/`fitBounds` options and a node
   `extent`'s `{ range, padding }`. A plain number still works; you can also pass a `'10px'`/`'5%'` string or a
   per-side object `{ top, right, bottom, left }` (with `x`/`y` shorthands). The old positional-tuple extent
@@ -288,7 +292,7 @@ far the pointer may move and still count as a node click.
 - **Change types mirror `@xyflow/system`:**
   - `NodeDimensionChange.updateStyle` → `setAttributes` (`true | 'width' | 'height'`)
   - `NodePositionChange.from` → `positionAbsolute`
-  - `NodeAddChange.item` / `EdgeAddChange.item` are the user `Node` / `Edge` (not `GraphNode`/`GraphEdge`); both gain an optional `index`
+  - `NodeAddChange.item` / `EdgeAddChange.item` are the user `Node` / `Edge` (not the internal `InternalNode`); both gain an optional `index`
   - `EdgeRemoveChange` is `{ id, type: 'remove' }` only — read `source`/`target`/handles from the edge via `getEdge(id)` before the change applies
 - **`ConnectionLineType` is `@xyflow/system`'s enum.** Its `SimpleBezier` member's value changed from
   `'simple-bezier'` to `'simplebezier'` (matching system and vue-flow's own `'simplebezier'` edge-type key).

--- a/examples/vite/src/EasyConnect/utils.ts
+++ b/examples/vite/src/EasyConnect/utils.ts
@@ -1,9 +1,9 @@
-import type { GraphNode, XYPosition } from '@vue-flow/core';
+import type { InternalNode, XYPosition } from '@vue-flow/core';
 import { Position } from '@vue-flow/core';
 
 // this helper function returns the intersection point
 // of the line between the center of the intersectionNode and the target node
-function getNodeIntersection(intersectionNode: GraphNode, targetNode: GraphNode) {
+function getNodeIntersection(intersectionNode: InternalNode, targetNode: InternalNode) {
   // https://math.stackexchange.com/questions/1724792/an-algorithm-for-finding-the-intersection-point-between-a-center-of-vision-and-a
   const {
     measured: { width: intersectionNodeWidth, height: intersectionNodeHeight },
@@ -31,7 +31,7 @@ function getNodeIntersection(intersectionNode: GraphNode, targetNode: GraphNode)
 }
 
 // returns the position (top,right,bottom or right) passed node compared to the intersection point
-function getEdgePosition(node: GraphNode, intersectionPoint: XYPosition) {
+function getEdgePosition(node: InternalNode, intersectionPoint: XYPosition) {
   const n = { ...node.internals.positionAbsolute, ...node.measured };
   const nx = Math.round(n.x);
   const ny = Math.round(n.y);
@@ -55,7 +55,7 @@ function getEdgePosition(node: GraphNode, intersectionPoint: XYPosition) {
 }
 
 // returns the parameters (sx, sy, tx, ty, sourcePos, targetPos) you need to create an edge
-export function getEdgeParams(source: GraphNode, target: GraphNode) {
+export function getEdgeParams(source: InternalNode, target: InternalNode) {
   const sourceIntersectionPoint = getNodeIntersection(source, target);
   const targetIntersectionPoint = getNodeIntersection(target, source);
 

--- a/examples/vite/src/FloatingEdges/FloatingConnectionLine.vue
+++ b/examples/vite/src/FloatingEdges/FloatingConnectionLine.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import type { GraphNode, Position } from '@vue-flow/core';
+import type { InternalNode, Position } from '@vue-flow/core';
 import { getBezierPath } from '@vue-flow/core';
 import { getEdgeParams } from './floating-edge-utils';
 
@@ -8,7 +8,7 @@ interface FloatingConnectionLineProps {
   targetY: number;
   sourcePosition: Position;
   targetPosition: Position;
-  sourceNode: GraphNode;
+  sourceNode: InternalNode;
 }
 
 const props = defineProps<FloatingConnectionLineProps>();
@@ -18,7 +18,7 @@ const targetNode = computed(() => {
     id: 'connection-target',
     internals: { positionAbsolute: { x: props.targetX, y: props.targetY }, z: 0 },
     measured: { width: 1, height: 1 },
-  } as unknown as GraphNode;
+  } as unknown as InternalNode;
 });
 
 const edgeParams = computed(() => getEdgeParams(props.sourceNode, targetNode.value));

--- a/examples/vite/src/FloatingEdges/floating-edge-utils.ts
+++ b/examples/vite/src/FloatingEdges/floating-edge-utils.ts
@@ -1,9 +1,9 @@
-import type { Edge, GraphNode, XYPosition } from '@vue-flow/core';
+import type { Edge, InternalNode, XYPosition } from '@vue-flow/core';
 import { MarkerType, Position } from '@vue-flow/core';
 
 // this helper function returns the intersection point
 // of the line between the center of the intersectionNode and the target node
-function getNodeIntersection(intersectionNode: GraphNode, targetNode: GraphNode): XYPosition {
+function getNodeIntersection(intersectionNode: InternalNode, targetNode: InternalNode): XYPosition {
   // https://math.stackexchange.com/questions/1724792/an-algorithm-for-finding-the-intersection-point-between-a-center-of-vision-and-a
   const {
     measured: { width: intersectionNodeWidth, height: intersectionNodeHeight },
@@ -31,7 +31,7 @@ function getNodeIntersection(intersectionNode: GraphNode, targetNode: GraphNode)
 }
 
 // returns the position (top,right,bottom or right) passed node compared to the intersection point
-function getEdgePosition(node: GraphNode, intersectionPoint: XYPosition) {
+function getEdgePosition(node: InternalNode, intersectionPoint: XYPosition) {
   const n = { ...node.internals.positionAbsolute, ...node.measured };
   const nx = Math.round(n.x);
   const ny = Math.round(n.y);
@@ -55,7 +55,7 @@ function getEdgePosition(node: GraphNode, intersectionPoint: XYPosition) {
 }
 
 // returns the parameters (sx, sy, tx, ty, sourcePos, targetPos) you need to create an edge
-export function getEdgeParams(source: GraphNode, target: GraphNode) {
+export function getEdgeParams(source: InternalNode, target: InternalNode) {
   const sourceIntersectionPoint = getNodeIntersection(source, target);
   const targetIntersectionPoint = getNodeIntersection(target, source);
 

--- a/examples/vite/src/Layouting/composables/useLayout.ts
+++ b/examples/vite/src/Layouting/composables/useLayout.ts
@@ -28,7 +28,7 @@ export function useLayout() {
     dagreGraph.setGraph({ rankdir: direction });
 
     for (const node of nodes) {
-      // if you need width+height of nodes for your layout, you can use the dimensions property of the internal node (`GraphNode` type)
+      // if you need width+height of nodes for your layout, you can use the dimensions property of the internal node (`InternalNode` type)
       const graphNode = getNode(node.id);
 
       if (!graphNode) {

--- a/examples/vite/src/SnapHandle/SnappableConnectionLine.vue
+++ b/examples/vite/src/SnapHandle/SnappableConnectionLine.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import type { ConnectingHandle, GraphNode, HandleElement, Position } from '@vue-flow/core';
+import type { ConnectingHandle, InternalNode, HandleElement, Position } from '@vue-flow/core';
 import { getBezierPath, storeToRefs, useStore, useVueFlow } from '@vue-flow/core';
 
 interface CustomConnectionLineProps {
@@ -12,7 +12,7 @@ interface CustomConnectionLineProps {
 }
 
 interface ClosestElements {
-  node: GraphNode | null;
+  node: InternalNode | null;
   handle: HandleElement | null;
   startHandle: ConnectingHandle | null;
 }
@@ -63,7 +63,7 @@ watch([() => props.targetY, () => props.targetX], (_, __, onCleanup) => {
     },
     {
       distance: Number.MAX_VALUE,
-      node: null as GraphNode | null,
+      node: null as InternalNode | null,
     },
   );
 

--- a/packages/core/src/components/Edges/EdgeWrapper.ts
+++ b/packages/core/src/components/Edges/EdgeWrapper.ts
@@ -1,5 +1,5 @@
 import type { Connection, FinalConnectionState, HandleType } from '@xyflow/system';
-import type { Edge, EdgeComponent, GraphNode, MouseTouchEvent } from '../../types';
+import type { Edge, EdgeComponent, InternalNode, MouseTouchEvent } from '../../types';
 import { ConnectionMode, getHandlePosition, getMarkerId, Position } from '@xyflow/system';
 import { computed, defineComponent, getCurrentInstance, h, inject, provide, resolveComponent, shallowRef, toRef } from 'vue';
 import { storeToRefs, useEdgeHooks, useHandle, useStore, useVueFlow } from '../../composables';
@@ -13,7 +13,7 @@ interface Props {
 
 // candidate handles for one end of an edge: strict mode = only the matching side; loose mode = both
 // sides, matching side first (so `getEdgeHandle` prefers it)
-function getNodeHandles(node: GraphNode, side: 'source' | 'target', strict: boolean) {
+function getNodeHandles(node: InternalNode, side: 'source' | 'target', strict: boolean) {
   const bounds = node.internals.handleBounds;
   if (strict) {
     return bounds?.[side] ?? null;
@@ -315,7 +315,7 @@ const EdgeWrapper = defineComponent({
       emit.reconnect({ event, edge: storedEdge.value, connection });
     }
 
-    function onReconnectEnd(event: MouseTouchEvent, connectionState: FinalConnectionState<GraphNode>) {
+    function onReconnectEnd(event: MouseTouchEvent, connectionState: FinalConnectionState<InternalNode>) {
       emit.reconnectEnd({ event, edge: storedEdge.value, handleType: reconnectHandleType.value, connectionState });
       updating.value = false;
     }

--- a/packages/core/src/components/MiniMap/MiniMap.vue
+++ b/packages/core/src/components/MiniMap/MiniMap.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import type { XYMinimapInstance } from '@xyflow/system';
-import type { GraphNode } from '../../types';
+import type { InternalNode } from '../../types';
 import type { MiniMapEmits, MiniMapNodeFunc, MiniMapProps, MiniMapSlots, ShapeRendering } from './types';
 import { getBoundsOfRects, getConnectedEdges, getNodeDimensions, getNodesBounds, XYMinimap } from '@xyflow/system';
 import { computed, onMounted, onUnmounted, provide, shallowRef, toRef, useAttrs, watch } from 'vue';
@@ -180,31 +180,31 @@ function onSvgClick(event: MouseEvent) {
   emit('click', { event, position: { x, y } });
 }
 
-function onNodeClick(event: MouseEvent, node: GraphNode) {
+function onNodeClick(event: MouseEvent, node: InternalNode) {
   const param = { event, node: node.internals.userNode, connectedEdges: getConnectedEdges([node], edges.value) };
   emits.miniMapNodeClick(param);
   emit('nodeClick', param);
 }
 
-function onNodeDblClick(event: MouseEvent, node: GraphNode) {
+function onNodeDblClick(event: MouseEvent, node: InternalNode) {
   const param = { event, node: node.internals.userNode, connectedEdges: getConnectedEdges([node], edges.value) };
   emits.miniMapNodeDoubleClick(param);
   emit('nodeDblclick', param);
 }
 
-function onNodeMouseEnter(event: MouseEvent, node: GraphNode) {
+function onNodeMouseEnter(event: MouseEvent, node: InternalNode) {
   const param = { event, node: node.internals.userNode, connectedEdges: getConnectedEdges([node], edges.value) };
   emits.miniMapNodeMouseEnter(param);
   emit('nodeMouseenter', param);
 }
 
-function onNodeMouseMove(event: MouseEvent, node: GraphNode) {
+function onNodeMouseMove(event: MouseEvent, node: InternalNode) {
   const param = { event, node: node.internals.userNode, connectedEdges: getConnectedEdges([node], edges.value) };
   emits.miniMapNodeMouseMove(param);
   emit('nodeMousemove', param);
 }
 
-function onNodeMouseLeave(event: MouseEvent, node: GraphNode) {
+function onNodeMouseLeave(event: MouseEvent, node: InternalNode) {
   const param = { event, node: node.internals.userNode, connectedEdges: getConnectedEdges([node], edges.value) };
   emits.miniMapNodeMouseLeave(param);
   emit('nodeMouseleave', param);

--- a/packages/core/src/components/MiniMap/types.ts
+++ b/packages/core/src/components/MiniMap/types.ts
@@ -1,9 +1,9 @@
 import type { Dimensions, PanelPosition, XYPosition } from '@xyflow/system';
 import type { CSSProperties, InjectionKey } from 'vue';
-import type { GraphNode, NodeMouseEvent } from '../../types';
+import type { InternalNode, NodeMouseEvent } from '../../types';
 
 /** expects a node and returns a color value */
-export type MiniMapNodeFunc = (node: GraphNode) => string;
+export type MiniMapNodeFunc = (node: InternalNode) => string;
 
 export type ShapeRendering = CSSProperties['shapeRendering'];
 

--- a/packages/core/src/components/NodeToolbar/NodeToolbar.vue
+++ b/packages/core/src/components/NodeToolbar/NodeToolbar.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import type { CSSProperties } from 'vue';
-import type { GraphNode } from '../../types';
+import type { InternalNode } from '../../types';
 import type { NodeToolbarProps } from './types';
 import { getNodesBounds, getNodeToolbarTransform, Position } from '@xyflow/system';
 import { computed, inject } from 'vue';
@@ -25,7 +25,7 @@ const { viewportRef } = storeToRefs(useStore());
 const nodes = computed(() => {
   const nodeIds = Array.isArray(props.nodeId) ? props.nodeId : [props.nodeId || contextNodeId || ''];
 
-  return nodeIds.reduce<GraphNode[]>((acc, id) => {
+  return nodeIds.reduce<InternalNode[]>((acc, id) => {
     const node = getInternalNode(id);
 
     if (node) {
@@ -33,7 +33,7 @@ const nodes = computed(() => {
     }
 
     return acc;
-  }, [] as GraphNode[]);
+  }, [] as InternalNode[]);
 });
 
 const isActive = computed(() =>

--- a/packages/core/src/components/NodesSelection/NodesSelection.vue
+++ b/packages/core/src/components/NodesSelection/NodesSelection.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import type { GraphNode } from '../../types';
+import type { InternalNode } from '../../types';
 import { getNodesBounds } from '@xyflow/system';
 import { computed, onMounted, shallowRef } from 'vue';
 import { storeToRefs, useDrag, useStore, useUpdateNodePositions, useVueFlow } from '../../composables';
@@ -38,7 +38,7 @@ onMounted(() => {
 });
 
 // getSelectedNodes is readonly (public guard); getNodesBounds only reads it (dims come from nodeLookup)
-const selectedNodesBBox = computed(() => getNodesBounds(getSelectedNodes.value as GraphNode[], { nodeLookup }));
+const selectedNodesBBox = computed(() => getNodesBounds(getSelectedNodes.value as InternalNode[], { nodeLookup }));
 
 const innerStyle = computed(() => ({
   width: `${selectedNodesBBox.value.width}px`,

--- a/packages/core/src/composables/useConnection.ts
+++ b/packages/core/src/composables/useConnection.ts
@@ -1,5 +1,5 @@
 import type { ComputedRef } from 'vue';
-import type { ConnectionState, GraphNode, Node } from '../types';
+import type { ConnectionState, InternalNode, Node } from '../types';
 import { computed } from 'vue';
 import { storeToRefs } from './storeToRefs';
 import { useStore } from './useStore';
@@ -48,12 +48,12 @@ export function useConnection<NodeType extends Node = Node>(): ComputedRef<Conne
       from: { x: fromHandle.x, y: fromHandle.y },
       fromHandle,
       fromPosition: fromHandle.position,
-      fromNode: fromNode as GraphNode<NodeType>,
+      fromNode: fromNode as InternalNode<NodeType>,
       // `to` snaps to the hovered end handle; falls back to the raw pointer when over empty canvas
       to: toHandle ? { x: toHandle.x, y: toHandle.y } : pointer,
       toHandle: toHandle ?? null,
       toPosition: toHandle?.position ?? null,
-      toNode: ((toHandle ? getInternalNode(toHandle.nodeId) : undefined) ?? null) as GraphNode<NodeType> | null,
+      toNode: ((toHandle ? getInternalNode(toHandle.nodeId) : undefined) ?? null) as InternalNode<NodeType> | null,
       pointer,
     };
   });

--- a/packages/core/src/composables/useHandle.ts
+++ b/packages/core/src/composables/useHandle.ts
@@ -1,6 +1,6 @@
 import type { Connection, ConnectionState, FinalConnectionState, HandleType, IsValidConnection as SystemIsValidConnection } from '@xyflow/system';
 import type { MaybeRefOrGetter } from 'vue';
-import type { ConnectingHandle, GraphNode, MouseTouchEvent, ValidConnectionFunc } from '../types';
+import type { ConnectingHandle, InternalNode, MouseTouchEvent, ValidConnectionFunc } from '../types';
 import { getEventPosition, getHostForElement, Position, XYHandle } from '@xyflow/system';
 import { toValue } from 'vue';
 import { isValidHandle } from '../utils';
@@ -15,7 +15,7 @@ export interface UseHandleProps {
   isValidConnection?: MaybeRefOrGetter<ValidConnectionFunc | null>;
   reconnectHandleType?: MaybeRefOrGetter<HandleType>;
   onReconnect?: (event: MouseTouchEvent, connection: Connection) => void;
-  onReconnectEnd?: (event: MouseTouchEvent, connectionState: FinalConnectionState<GraphNode>) => void;
+  onReconnectEnd?: (event: MouseTouchEvent, connectionState: FinalConnectionState<InternalNode>) => void;
 }
 
 function alwaysValid() {
@@ -26,7 +26,7 @@ function alwaysValid() {
  * Connection-drag composable. Drag-to-connect is delegated to `@xyflow/system`'s `XYHandle` instance
  * (same pattern as `XYDrag` / `XYResizer`). Click-to-connect stays vue-flow specific because the click
  * path interacts with the richer `ValidConnectionFunc` signature (which receives full source/target
- * `GraphNode`s on top of the bare `Connection`).
+ * `InternalNode`s on top of the bare `Connection`).
  *
  * Generally it's recommended to use the `<Handle />` component instead of this composable.
  *
@@ -266,7 +266,7 @@ export function useHandle({
     const fromNode = fromHandle ? getInternalNode(fromHandle.nodeId) : undefined;
     const toHandle = result.toHandle;
     const pointer = getEventPosition(event);
-    const connectionState: FinalConnectionState<GraphNode>
+    const connectionState: FinalConnectionState<InternalNode>
       = fromHandle && fromNode
         ? {
             isValid: result.isValid,

--- a/packages/core/src/composables/useNodesData.ts
+++ b/packages/core/src/composables/useNodesData.ts
@@ -1,10 +1,10 @@
 import type { ComputedRef, MaybeRefOrGetter } from 'vue';
-import type { GraphNode, Node } from '../types';
+import type { InternalNode, Node } from '../types';
 import { computed, toValue } from 'vue';
 import { warn } from '../utils';
 import { useVueFlow } from './useVueFlow';
 
-interface NodeData<NodeType extends Node = GraphNode> {
+interface NodeData<NodeType extends Node = InternalNode> {
   id: string;
   type: NodeType['type'];
   data: NonNullable<NodeType['data']>;
@@ -18,13 +18,13 @@ interface NodeData<NodeType extends Node = GraphNode> {
  * @param guard - Optional guard function to narrow down the node type
  * @returns An array of data objects
  */
-export function useNodesData<NodeType extends Node = GraphNode>(
+export function useNodesData<NodeType extends Node = InternalNode>(
   nodeId: MaybeRefOrGetter<string>,
 ): ComputedRef<NodeData<NodeType> | null>;
-export function useNodesData<NodeType extends Node = GraphNode>(
+export function useNodesData<NodeType extends Node = InternalNode>(
   nodeIds: MaybeRefOrGetter<string[]>,
 ): ComputedRef<NodeData<NodeType>[]>;
-export function useNodesData<NodeType extends Node = GraphNode>(
+export function useNodesData<NodeType extends Node = InternalNode>(
   nodeIds: MaybeRefOrGetter<string[]>,
   guard: (node: Node) => node is NodeType,
 ): ComputedRef<NodeData<NodeType>[]>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,7 +58,7 @@ export * from './types';
 export { applyChanges, applyEdgeChanges, applyNodeChanges } from './utils/changes';
 export { defaultEdgeTypes, defaultNodeTypes } from './utils/defaultNodesEdges';
 export { ErrorCode, isErrorOfType, VueFlowError } from './utils/errors';
-export { connectionExists, isEdge, isGraphNode, isNode } from './utils/graph';
+export { connectionExists, isEdge, isInternalNode, isNode } from './utils/graph';
 
 // re-export these utils from system
 export { getBezierEdgeCenter, getBezierPath, getSmoothStepPath, getStraightPath } from '@xyflow/system';

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -14,7 +14,7 @@ import type {
   EdgeAddChange,
   EdgeLookup,
   FlowExportObject,
-  GraphNode,
+  InternalNode,
   Node,
   NodeAddChange,
   NodeLookup,
@@ -47,7 +47,7 @@ import {
   getExtent,
   getSelectionChanges,
   isDef,
-  isGraphNode,
+  isInternalNode,
   isNode,
   reconnectEdgeAction,
   updateConnectionLookup,
@@ -58,7 +58,7 @@ import { storeOptionsToSkip, useState } from './state';
 export function useActions<NodeType extends Node = Node, EdgeType extends Edge = Edge>(
   state: State<NodeType, EdgeType>,
   nodeLookup: NodeLookup<NodeType>,
-  parentLookup: Map<string, Map<string, GraphNode<NodeType>>>,
+  parentLookup: Map<string, Map<string, InternalNode<NodeType>>>,
   edgeLookup: EdgeLookup<EdgeType>,
 ): Actions<NodeType, EdgeType> {
   const viewportHelper = useViewportHelper(state, nodeLookup);
@@ -71,7 +71,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
   // targeted `.set`/`.delete`, so only entries whose `InternalNode` reference actually changed trigger —
   // per-frame render invalidation stays O(changed) instead of O(n).
   const systemNodeLookup: NodeLookup<NodeType> = new Map();
-  const systemParentLookup: Map<string, Map<string, GraphNode<NodeType>>> = new Map();
+  const systemParentLookup: Map<string, Map<string, InternalNode<NodeType>>> = new Map();
 
   function sameMapEntries<K, V>(a: Map<K, V>, b: Map<K, V>) {
     if (a.size !== b.size) {
@@ -205,11 +205,11 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
     // their `range` (`'parent'` or a plain `CoordinateExtent`, both system-understood) for the system
     // pass and restore afterwards. The system clamp can't express the range `padding`, so it's re-applied
     // separately in the padding-clamp pass below (after absolute positions are fresh).
-    // `node.extent` is typed `'parent' | CoordinateExtent | null` (deliberately narrow so `GraphNode`
+    // `node.extent` is typed `'parent' | CoordinateExtent | null` (deliberately narrow so `InternalNode`
     // stays structurally assignable to system's `NodeBase`), but at runtime vue-flow also supports a
     // `CoordinateExtentRange` ({ range, padding }) — see utils/drag.ts. Hence the localized casts: the
     // type can't express this without breaking system compat. We restore the original extent after.
-    const coercedExtents: { node: GraphNode<NodeType>; extent: 'parent' | CoordinateExtent | null | undefined }[] = [];
+    const coercedExtents: { node: InternalNode<NodeType>; extent: 'parent' | CoordinateExtent | null | undefined }[] = [];
     for (const node of systemNodeLookup.values()) {
       const extent = node.extent as CoordinateExtentRange | 'parent' | CoordinateExtent | null | undefined;
       if (extent && typeof extent === 'object' && !Array.isArray(extent) && 'range' in extent) {
@@ -920,7 +920,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
     const isRectObj = isRectObject(nodeOrRect);
     // use `getInternalNode` (not getNode): `nodeToRect` below needs `internals`/`measured`, which live on
     // the InternalNode, not the user `Node` that getNode returns
-    const node = isRectObj ? null : isGraphNode(nodeOrRect) ? nodeOrRect : getInternalNode(nodeOrRect.id);
+    const node = isRectObj ? null : isInternalNode(nodeOrRect) ? nodeOrRect : getInternalNode(nodeOrRect.id);
 
     if (!isRectObj && !node) {
       return [null, null, isRectObj];
@@ -943,7 +943,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
       return [];
     }
 
-    const intersections: GraphNode<NodeType>[] = [];
+    const intersections: InternalNode<NodeType>[] = [];
     for (const n of nodes) {
       if (!isRect && (n.id === node!.id || !n.internals.positionAbsolute)) {
         continue;

--- a/packages/core/src/store/createStore.ts
+++ b/packages/core/src/store/createStore.ts
@@ -3,7 +3,7 @@ import type {
   Edge,
   EdgeLookup,
   FlowProps,
-  GraphNode,
+  InternalNode,
   Node,
   NodeLookup,
   VueFlowInstance,
@@ -107,10 +107,10 @@ export function createVueFlowStore<NodeType extends Node = Node, EdgeType extend
   // edges) — no derivation watcher, no rebuild thrash.
   //
   // The `as` casts undo `reactive()`'s `UnwrapNestedRefs` widening over a Map of the *generic*
-  // `GraphNode<NodeType>` (TS can't prove the element type has no refs to unwrap); at runtime the proxy is
-  // exactly a `Map<string, GraphNode>`, so the assertion is sound (documented Vue + generics friction).
+  // `InternalNode<NodeType>` (TS can't prove the element type has no refs to unwrap); at runtime the proxy is
+  // exactly a `Map<string, InternalNode>`, so the assertion is sound (documented Vue + generics friction).
   const nodeLookup = reactiveState.nodeLookup as NodeLookup<NodeType>;
-  const parentLookup = reactiveState.parentLookup as Map<string, Map<string, GraphNode<NodeType>>>;
+  const parentLookup = reactiveState.parentLookup as Map<string, Map<string, InternalNode<NodeType>>>;
   const edgeLookup = reactiveState.edgeLookup as EdgeLookup<EdgeType>;
 
   const getters = useGetters<NodeType, EdgeType>(reactiveState, nodeLookup);

--- a/packages/core/src/types/changes.ts
+++ b/packages/core/src/types/changes.ts
@@ -42,7 +42,7 @@ export interface NodeDragItem {
  *   - `NodePositionChange.from` (the OLD absolute position) → dropped. Use `positionAbsolute` (the NEW
  *     absolute position) which now matches xyflow/react / xyflow/svelte.
  *
- * Item shapes on add changes are the user-provided `Node` / `Edge` types (not the internal `GraphNode`).
+ * Item shapes on add changes are the user-provided `Node` / `Edge` types (not the internal `InternalNode`).
  */
 export interface NodeAddChange<NodeType extends Node = Node> {
   item: NodeType;

--- a/packages/core/src/types/connection.ts
+++ b/packages/core/src/types/connection.ts
@@ -3,7 +3,7 @@ import type { CSSProperties } from 'vue';
 import type { Edge, EdgeMarkerType } from './edge';
 import type { ClassValue } from './flow';
 import type { ConnectingHandle, HandleElement } from './handle';
-import type { GraphNode, Node } from './node';
+import type { InternalNode, Node } from './node';
 
 export interface ConnectionLineOptions {
   type?: ConnectionLineType;
@@ -21,7 +21,7 @@ export type ConnectionStatus = 'valid' | 'invalid';
 
 /**
  * An ongoing connection, mirroring xyflow/react's `ConnectionState` (returned by `useConnection`).
- * Handles are vue-flow `ConnectingHandle`s and nodes are `GraphNode`s (the resolved `InternalNode`s).
+ * Handles are vue-flow `ConnectingHandle`s and nodes are `InternalNode`s (the resolved `InternalNode`s).
  */
 export interface ConnectionInProgress<NodeType extends Node = Node> {
   inProgress: true;
@@ -34,7 +34,7 @@ export interface ConnectionInProgress<NodeType extends Node = Node> {
   /** the side of the start handle */
   fromPosition: Position;
   /** the node the connection started from */
-  fromNode: GraphNode<NodeType>;
+  fromNode: InternalNode<NodeType>;
   /** xy end position of the connection (the current pointer position) */
   to: XYPosition;
   /** the handle the connection currently ends on, or `null` */
@@ -42,7 +42,7 @@ export interface ConnectionInProgress<NodeType extends Node = Node> {
   /** the side of the end handle, or `null` */
   toPosition: Position | null;
   /** the node the connection currently ends on, or `null` */
-  toNode: GraphNode<NodeType> | null;
+  toNode: InternalNode<NodeType> | null;
   /** the current pointer position */
   pointer: XYPosition;
 }
@@ -91,11 +91,11 @@ export interface ConnectionLineProps {
   /** the side of the end handle */
   toPosition: Position;
   /** the node the connection started from */
-  fromNode: GraphNode;
+  fromNode: InternalNode;
   /** the handle the connection started from (not the DOM element) */
   fromHandle: HandleElement | null;
   /** the node the connection currently ends on, or `null` */
-  toNode: GraphNode | null;
+  toNode: InternalNode | null;
   /** the handle the connection currently ends on (not the DOM element), or `null` */
   toHandle: HandleElement | null;
   /** marker url */

--- a/packages/core/src/types/handle.ts
+++ b/packages/core/src/types/handle.ts
@@ -1,6 +1,6 @@
 import type { Connection, ConnectionMode, Dimensions, HandleType, Position, XYPosition } from '@xyflow/system';
 import type { Edge } from './edge';
-import type { GraphNode, Node } from './node';
+import type { InternalNode, Node } from './node';
 
 export interface HandleElement extends XYPosition, Dimensions {
   id?: string | null;
@@ -19,10 +19,10 @@ export interface ConnectingHandle extends XYPosition {
 /** A valid connection function can determine if an attempted connection is valid or not, i.e. abort creating a new edge */
 export type ValidConnectionFunc = (
   connection: Connection,
-  elements: { edges: Edge[]; nodes: Node[]; sourceNode: GraphNode; targetNode: GraphNode },
+  elements: { edges: Edge[]; nodes: Node[]; sourceNode: InternalNode; targetNode: InternalNode },
 ) => boolean;
 
-export type HandleConnectableFunc = (node: GraphNode, connectedEdges: Edge[]) => boolean;
+export type HandleConnectableFunc = (node: InternalNode, connectedEdges: Edge[]) => boolean;
 
 /**
  * set to true to allow unlimited connections,

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -3,7 +3,7 @@ import type { EventHookExtended, EventHookOn, EventHookTrigger, VueFlowError } f
 import type { EdgeChange, NodeChange } from './changes';
 import type { OnConnectStartParams } from './connection';
 import type { Edge } from './edge';
-import type { GraphNode, Node } from './node';
+import type { InternalNode, Node } from './node';
 import type { VueFlowInstance } from './store';
 
 export type MouseTouchEvent = MouseEvent | TouchEvent;
@@ -36,7 +36,7 @@ export interface EdgeReconnectEvent<EdgeType extends Edge = Edge> {
  */
 export interface ConnectEndEvent<NodeType extends Node = Node> {
   event: MouseTouchEvent;
-  connectionState: FinalConnectionState<GraphNode<NodeType>>;
+  connectionState: FinalConnectionState<InternalNode<NodeType>>;
 }
 
 export interface EdgeReconnectStartEvent<EdgeType extends Edge = Edge> {
@@ -52,7 +52,7 @@ export interface EdgeReconnectEndEvent<NodeType extends Node = Node, EdgeType ex
   /** the type of the handle that was reconnected */
   handleType: HandleType;
   /** the {@link FinalConnectionState} at the moment the reconnect ended */
-  connectionState: FinalConnectionState<GraphNode<NodeType>>;
+  connectionState: FinalConnectionState<InternalNode<NodeType>>;
 }
 
 /** Payload for `selectionChange` — the currently selected nodes and edges, mirroring xyflow/react's `OnSelectionChange`. */

--- a/packages/core/src/types/node.ts
+++ b/packages/core/src/types/node.ts
@@ -32,7 +32,7 @@ export interface NodeHandleBounds {
 /**
  * User-facing node type — reuses `@xyflow/system`'s `NodeBase` (xyflow/react does
  * `Node = NodeBase & {…}`) plus vue-flow-specific fields. `extent` stays `NodeBase`'s narrow
- * `'parent' | CoordinateExtent | null` deliberately (so `GraphNode`/`Node` stay structurally
+ * `'parent' | CoordinateExtent | null` deliberately (so `InternalNode`/`Node` stay structurally
  * assignable to system's types); the richer `CoordinateExtentRange` is a runtime-only extension
  * handled with localized casts (see `store/actions.ts` `recomputeAbsolutePositions`).
  */
@@ -62,25 +62,18 @@ export type Node<
   >;
 };
 /**
- * Internal node shape used after a user-provided `Node` has been processed by the store.
+ * The enriched, store-internal node — what `nodeLookup`/`getInternalNode(id)`/`useInternalNode(id)` return,
+ * once a user-provided `Node` has been processed by the store. Carries the user `Node`
+ * (`internals.userNode`) plus the store-computed `internals.{positionAbsolute, z, handleBounds}` and
+ * authoritative `measured`. Named to mirror xyflow/react's `InternalNode`, so the public split
+ * (`getNode`/`v-model` = user `Node`, `getInternalNode` = `InternalNode`) reads the same across frameworks.
  *
  * Structurally assignable to `@xyflow/system`'s `InternalNodeBase<NodeType>` so we can hand `nodeLookup`
- * to `XYResizer` / `XYDrag` / `getHandlePosition` without casts.
- *
- * Consumers should read absolute position via `internals.positionAbsolute`, z-index via `internals.z`,
- * handle bounds via `internals.handleBounds`, and dimensions via `measured`. The "is this a parent?"
- * check moved off the node and lives on `parentLookup` (storage).
+ * to `XYResizer` / `XYDrag` / `getHandlePosition` without casts. Read absolute position via
+ * `internals.positionAbsolute`, z-index via `internals.z`, handle bounds via `internals.handleBounds`, and
+ * dimensions via `measured`; the "is this a parent?" check lives on `parentLookup` (storage).
  */
-export type GraphNode<NodeType extends Node = Node> = InternalNodeBase<NodeType>;
-
-/**
- * The enriched, store-internal node — what `nodeLookup`/`getInternalNode(id)`/`useInternalNode(id)` return.
- * Carries the user `Node` (`internals.userNode`) plus the store-computed `internals.{positionAbsolute, z,
- * handleBounds}` and authoritative `measured`. Alias of {@link GraphNode}; named to mirror xyflow/react's
- * `InternalNode` so the public split (`getNode`/`v-model` = user `Node`, `getInternalNode` = `InternalNode`)
- * reads the same across frameworks.
- */
-export type InternalNode<NodeType extends Node = Node> = GraphNode<NodeType>;
+export type InternalNode<NodeType extends Node = Node> = InternalNodeBase<NodeType>;
 
 /**
  * Props passed to custom node components, parameterized on a `NodeType` (xyflow/react convention:

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -25,9 +25,9 @@ import type { DefaultEdgeOptions, Edge, EdgeReconnectable } from './edge';
 import type { FlowExportObject, FlowProps, OnBeforeDelete } from './flow';
 import type { ConnectingHandle, ValidConnectionFunc } from './handle';
 import type { FlowHooks, FlowHooksEmit, FlowHooksOn } from './hooks';
-import type { BuiltInNode, CoordinateExtent, CoordinateExtentRange, GraphNode, Node, NodeOrigin } from './node';
+import type { BuiltInNode, CoordinateExtent, CoordinateExtentRange, InternalNode, Node, NodeOrigin } from './node';
 
-export type NodeLookup<NodeType extends Node = Node> = Map<string, GraphNode<NodeType>>;
+export type NodeLookup<NodeType extends Node = Node> = Map<string, InternalNode<NodeType>>;
 
 export type EdgeLookup<EdgeType extends Edge = Edge> = Map<string, EdgeType>;
 
@@ -56,8 +56,8 @@ export interface State<NodeType extends Node = Node, EdgeType extends Edge = Edg
 
   /** id → enriched `InternalNode` (`internals`/`measured`); the canonical source for node-derived data */
   readonly nodeLookup: NodeLookup<NodeType>;
-  /** parentId → map of child id → child `GraphNode`. Matches `@xyflow/system`'s `ParentLookup`. */
-  readonly parentLookup: Map<string, Map<string, GraphNode<NodeType>>>;
+  /** parentId → map of child id → child `InternalNode`. Matches `@xyflow/system`'s `ParentLookup`. */
+  readonly parentLookup: Map<string, Map<string, InternalNode<NodeType>>>;
   /** id → user-facing `Edge` */
   readonly edgeLookup: EdgeLookup<EdgeType>;
   connectionLookup: ConnectionLookup;
@@ -238,25 +238,25 @@ export type GetNode<NodeType extends Node = Node> = (id: string | undefined | nu
  * authoritative `measured`) for an id, mirroring xyflow/react's `getInternalNode`. This is the accessor
  * for store-computed data; `getNode` exposes the user-facing node.
  */
-export type GetInternalNode<NodeType extends Node = Node> = (id: string | undefined | null) => GraphNode<NodeType> | undefined;
+export type GetInternalNode<NodeType extends Node = Node> = (id: string | undefined | null) => InternalNode<NodeType> | undefined;
 
 export type GetEdge<EdgeType extends Edge = Edge> = (id: string | undefined | null) => EdgeType | undefined;
 
 export type GetIntersectingNodes<NodeType extends Node = Node> = (
   node: (Partial<NodeType> & { id: NodeType['id'] }) | Rect,
   partially?: boolean,
-  nodes?: GraphNode<NodeType>[],
-) => GraphNode<NodeType>[];
+  nodes?: InternalNode<NodeType>[],
+) => InternalNode<NodeType>[];
 
 export type UpdateNode<NodeType extends Node = Node> = (
   id: string,
-  nodeUpdate: Partial<NodeType> | ((node: GraphNode<NodeType>) => Partial<NodeType>),
+  nodeUpdate: Partial<NodeType> | ((node: InternalNode<NodeType>) => Partial<NodeType>),
   options?: { replace: boolean },
 ) => void;
 
 export type UpdateNodeData<NodeType extends Node = Node> = (
   id: string,
-  dataUpdate: Partial<NodeType['data']> | ((node: GraphNode<NodeType>) => Partial<NodeType['data']>),
+  dataUpdate: Partial<NodeType['data']> | ((node: InternalNode<NodeType>) => Partial<NodeType['data']>),
   options?: { replace: boolean },
 ) => void;
 

--- a/packages/core/src/utils/changes.ts
+++ b/packages/core/src/utils/changes.ts
@@ -9,7 +9,7 @@ import type {
   EdgeAddChange,
   EdgeChange,
   ElementChange,
-  GraphNode,
+  InternalNode,
   Node,
   NodeAddChange,
   NodeChange,
@@ -24,11 +24,11 @@ import { isNode } from '.';
  * reference and re-adopt a stale internal node. Reusing unchanged refs keeps re-adoption O(changed).
  *
  * `position`/`dimensions` changes are gated on `isNode` (user `Node`s have no `internals`, so the old
- * `isGraphNode` guard would skip them) — edges never receive those change types anyway.
+ * `isInternalNode` guard would skip them) — edges never receive those change types anyway.
  */
 export function applyChanges<
   T extends Node | Edge = Node | Edge,
-  C extends ElementChange = T extends GraphNode ? NodeChange : EdgeChange,
+  C extends ElementChange = T extends InternalNode ? NodeChange : EdgeChange,
 >(changes: C[], elements: T[]): T[] {
   // bucket changes: field updates by id, plus add/remove
   const updatesById = new Map<string, C[]>();
@@ -138,7 +138,7 @@ export function applyEdgeChanges(changes: EdgeChange[], edges: Edge[]) {
 }
 
 /** @deprecated Prefer the store instance's apply methods (from `useVueFlow` or the `onInit` instance). */
-export function applyNodeChanges(changes: NodeChange[], nodes: GraphNode[]) {
+export function applyNodeChanges(changes: NodeChange[], nodes: InternalNode[]) {
   return applyChanges(changes, nodes);
 }
 

--- a/packages/core/src/utils/drag.ts
+++ b/packages/core/src/utils/drag.ts
@@ -1,5 +1,5 @@
 import type { PaddingWithUnit, XYPosition } from '@xyflow/system';
-import type { CoordinateExtent, CoordinateExtentRange, GraphNode, NodeDragItem, State } from '../types';
+import type { CoordinateExtent, CoordinateExtentRange, InternalNode, NodeDragItem, State } from '../types';
 import { clampPosition, getNodeDimensions } from '@xyflow/system';
 import { ErrorCode, VueFlowError } from '.';
 
@@ -42,8 +42,8 @@ function getExtentPadding(
 
 function getParentExtent(
   currentExtent: CoordinateExtentRange | 'parent',
-  node: GraphNode | NodeDragItem,
-  parent: GraphNode,
+  node: InternalNode | NodeDragItem,
+  parent: InternalNode,
 ): CoordinateExtent | false {
   const [top, right, bottom, left] = typeof currentExtent !== 'string'
     ? getExtentPadding(currentExtent.padding, parent.measured.width ?? 0, parent.measured.height ?? 0)
@@ -68,11 +68,11 @@ function getParentExtent(
   return false;
 }
 
-export function getExtent<T extends NodeDragItem | GraphNode>(
+export function getExtent<T extends NodeDragItem | InternalNode>(
   item: T,
   triggerError: State['hooks']['error']['trigger'],
   extent?: State['nodeExtent'],
-  parent?: GraphNode,
+  parent?: InternalNode,
 ) {
   let currentExtent = item.extent || extent;
 
@@ -127,11 +127,11 @@ export function getExtent<T extends NodeDragItem | GraphNode>(
 }
 
 export function calcNextPosition(
-  node: GraphNode | NodeDragItem,
+  node: InternalNode | NodeDragItem,
   nextPosition: XYPosition,
   triggerError: State['hooks']['error']['trigger'],
   nodeExtent?: State['nodeExtent'],
-  parentNode?: GraphNode,
+  parentNode?: InternalNode,
 ) {
   const measured = getNodeDimensions(node);
 

--- a/packages/core/src/utils/graph.ts
+++ b/packages/core/src/utils/graph.ts
@@ -1,5 +1,5 @@
 import type { Connection } from '@xyflow/system';
-import type { Edge, GraphNode, Node } from '../types';
+import type { Edge, InternalNode, Node } from '../types';
 import { isEdgeBase, isInternalNodeBase, isNodeBase } from '@xyflow/system';
 
 export function isEdge<EdgeType extends Edge = Edge>(element: unknown): element is EdgeType {
@@ -10,7 +10,7 @@ export function isNode<NodeType extends Node = Node>(element: unknown): element 
   return !!element && typeof element === 'object' && isNodeBase(element);
 }
 
-export function isGraphNode<NodeType extends Node = Node>(element: unknown): element is GraphNode<NodeType> {
+export function isInternalNode<NodeType extends Node = Node>(element: unknown): element is InternalNode<NodeType> {
   return !!element && typeof element === 'object' && isInternalNodeBase(element);
 }
 

--- a/packages/core/src/utils/node.ts
+++ b/packages/core/src/utils/node.ts
@@ -1,9 +1,9 @@
 import type { Ref } from 'vue';
-import type { Actions, GraphNode } from '../types';
+import type { Actions, InternalNode } from '../types';
 import { nextTick } from 'vue';
 
 export function handleNodeClick(
-  node: GraphNode,
+  node: InternalNode,
   multiSelectionActive: boolean,
   addSelectedNodes: Actions['addSelectedNodes'],
   removeSelectedNodes: Actions['removeSelectedNodes'],

--- a/packages/core/src/utils/store.ts
+++ b/packages/core/src/utils/store.ts
@@ -11,7 +11,7 @@ import type {
   CoordinateExtentRange,
   DefaultEdgeOptions,
   Edge,
-  GraphNode,
+  InternalNode,
   Node,
   NodeOrigin,
   State,
@@ -94,7 +94,7 @@ export function reconnectEdgeAction(
   };
 }
 
-export interface CreateGraphNodesOptions {
+export interface CreateInternalNodesOptions {
   nodeOrigin?: NodeOrigin;
   nodeExtent?: CoordinateExtent;
   elevateNodesOnSelect?: boolean;
@@ -116,10 +116,10 @@ export interface CreateGraphNodesOptions {
  */
 export function adoptNodes<NodeType extends Node = Node>(
   nodes: NodeType[],
-  nodeLookup: SystemNodeLookup<GraphNode<NodeType>>,
-  parentLookup: SystemParentLookup<GraphNode<NodeType>>,
+  nodeLookup: SystemNodeLookup<InternalNode<NodeType>>,
+  parentLookup: SystemParentLookup<InternalNode<NodeType>>,
   triggerError: State['hooks']['error']['trigger'],
-  options?: CreateGraphNodesOptions,
+  options?: CreateInternalNodesOptions,
 ): NodeType[] {
   const validNodes: NodeType[] = [];
   for (let i = 0; i < nodes.length; ++i) {


### PR DESCRIPTION
Consolidates the enriched, store-internal node type on the xyflow/react name. vue-flow already shipped **both** `GraphNode` and `InternalNode` as *identical* public types (`InternalNode<T>` was a literal alias of `GraphNode<T>`, and both `= @xyflow/system`'s `InternalNodeBase<T>`) — two names for one thing. This removes `GraphNode` and keeps `InternalNode`, which pairs with the existing `getInternalNode` / `useInternalNode` / `nodeLookup` split.

## Changes
- `GraphNode<T>` → `InternalNode<T>` (the `GraphNode` name is **removed**)
- `isGraphNode(…)` type guard → `isInternalNode(…)`
- Swept across `packages/core/src`, `examples/`, and the `docs/examples/` REPL files
- Migration guide entry added; also fixed two stale `migration.md` bullets that referenced the (already-removed) `GraphEdge`

## Why it's safe
Because `InternalNode` was already defined as `= GraphNode`, the rename is **structurally a no-op** for type-checking — every `GraphNode` and `InternalNode` already resolved to the same `InternalNodeBase`.

## Verification
- Core `vue-tsc --noEmit`: clean.
- `pnpm --filter @vue-flow/core build` + `types`: clean; fresh `dist` contains zero `GraphNode`.
- Examples `vue-tsc`: **19 errors before = 19 after** (all pre-existing 2.0 example drift — `ConnectionLineProps` `source*`/`from*`, `markerEnd`, `TS2589`, `RGBFlow` — none introduced here).

## Notes
- Left untouched (flagged for your call): four **pending changesets** (`align-types-with-xyflow-system`, `node-internal-split`, `tier4-adopt-user-nodes`, `align-system-guards-padding`) and the released `CHANGELOG.md` still mention `GraphNode` as the name those earlier PRs used at the time. Retroactively renaming them would misrepresent what shipped in each PR; happy to scrub them if you'd prefer a fully `GraphNode`-free 2.0 changelog.
- Generated artifacts (`dist`, `docs/src/public/*.mjs`, typedocs) are gitignored and regenerate on build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)