### PR TITLE
fix(core): keep node dimensions in toObject so restored flows render

### DIFF
--- a/.changeset/fix-toobject-save-restore.md
+++ b/.changeset/fix-toobject-save-restore.md
@@ -1,0 +1,7 @@
+---
+"@vue-flow/core": patch
+---
+
+Fix save/restore leaving nodes invisible. `toObject()` now mirrors xyflow/react: it shallow-clones each node/edge (keeping `measured` and the other fields) and reads the viewport off the transform, instead of stripping fields and round-tripping through `JSON.stringify`/`parse`.
+
+Previously `measured` was stripped from the export, so restoring a saved flow (`setNodes` with the same node ids) produced nodes with no measured size. A node stays `visibility: hidden` until it's measured, and because the restored nodes reuse their existing DOM elements (same id → no re-mount), the `ResizeObserver` never re-fires to re-measure them — so they were stuck hidden. Keeping `measured` in the export means a restored flow renders immediately.

--- a/examples/vite/index.css
+++ b/examples/vite/index.css
@@ -1,8 +1,5 @@
-/* import the required styles */
+/* import the full theme (style.css now ships the complete default theme; theme-default.css was removed) */
 @import 'node_modules/@vue-flow/core/dist/style.css';
-
-/* import the default theme (optional) */
-@import 'node_modules/@vue-flow/core/dist/theme-default.css';
 
 body {
   color: #111;

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -1045,33 +1045,15 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
     }
   };
 
-  const toObject: Actions<NodeType>['toObject'] = () => {
-    const nodes: Node[] = [];
-    const edges: Edge[] = [];
-
-    for (const node of state.nodes) {
-      // `state.nodes` are already user `Node`s (no `internals`); strip the transient runtime fields for export
-      const { selected: _, resizing: __, dragging: ___, measured: ____, ...rest } = node;
-
-      nodes.push(rest);
-    }
-
-    for (const edge of state.edges) {
-      // `state.edges` are the user `Edge`s verbatim; strip the transient runtime field for export
-      const { selected: _, ...rest } = edge;
-
-      edges.push(rest);
-    }
-
-    // we have to stringify/parse so objects containing refs (like nodes and edges) can potentially be saved in a storage
-    return JSON.parse(
-      JSON.stringify({
-        nodes,
-        edges,
-        viewport: { x: state.transform[0], y: state.transform[1], zoom: state.transform[2] },
-      } as FlowExportObject),
-    );
-  };
+  // Mirror xyflow/react's `toObject`: shallow-clone each node/edge and read the viewport off the transform.
+  // No field stripping (notably `measured` is kept, so a restored flow renders immediately instead of
+  // staying `visibility: hidden` until re-measured) and no JSON round-trip — the nodes/edges are already
+  // plain `markRaw`'d user objects, and callers that persist the result serialize it (`JSON.stringify(...)`).
+  const toObject: Actions<NodeType>['toObject'] = () => ({
+    nodes: state.nodes.map(node => ({ ...node })),
+    edges: state.edges.map(edge => ({ ...edge })),
+    viewport: { x: state.transform[0], y: state.transform[1], zoom: state.transform[2] },
+  });
 
   const $reset: Actions<NodeType, EdgeType>['$reset'] = () => {
     const { nodes: _nodes, edges: _edges, ...resetState } = useState<NodeType, EdgeType>();

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -13,7 +13,6 @@ import type {
   Edge,
   EdgeAddChange,
   EdgeLookup,
-  FlowExportObject,
   InternalNode,
   Node,
   NodeAddChange,


### PR DESCRIPTION
## The bug
In the save & restore example, loading a saved flow left the nodes **invisible** — they're in the DOM but `visibility: hidden`, with a floating edge connecting nothing.

## Root cause
`toObject()` stripped `measured` from every exported node (and round-tripped through `JSON.stringify`/`parse`). A node is rendered `visibility: hidden` until it has been measured (`NodeWrapper` gates on `node.measured.width/height`). On restore, `setNodes(saved.nodes)` re-sets nodes with the **same ids**, so Vue **reuses their existing DOM elements** (no re-mount). Since the restored nodes carry no `measured`, `adoptUserNodes` builds fresh internal nodes with `measured: undefined`, and because the DOM element didn't change size the `ResizeObserver` never re-fires to re-measure them — so they stay hidden forever. (Freshly `addNodes`'d nodes get new ids → new DOM → measured → visible, which is why only the *restored* nodes were affected.)

## Fix
Make `toObject()` match `@xyflow/react`'s:
```ts
toObject: () => ({
  nodes: state.nodes.map(node => ({ ...node })),
  edges: state.edges.map(edge => ({ ...edge })),
  viewport: { x: transform[0], y: transform[1], zoom: transform[2] },
})
```
Shallow-clone, no field stripping (so `measured` survives), no JSON round-trip (the nodes are already `markRaw`'d plain objects, and callers serialize the result themselves, e.g. `JSON.stringify(toObject())`). A restored flow now renders immediately.

Also: drop the stale `@vue-flow/core/dist/theme-default.css` import from `examples/vite/index.css` (that file was removed in the CSS alignment — `style.css` is now the full theme). It was throwing a postcss `ENOENT` overlay that blocked the example from rendering at all; found while reproducing this.

## Verification (Chrome)
Reproduced the original bug (restored nodes `visibility: hidden`), applied the fix, and confirmed across **save → full page reload → restore** that all nodes — including the initial ones — are `visibility: visible`. `measured` (`{width, height}`) correctly survives the localStorage JSON round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)