### PR TITLE
feat(core): autoPanOnNodeFocus — pan to off-screen nodes on keyboard focus

### DIFF
--- a/.changeset/auto-pan-on-node-focus.md
+++ b/.changeset/auto-pan-on-node-focus.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Add `autoPanOnNodeFocus` (default `true`), mirroring xyflow/react. When a node receives keyboard focus (Tab) and isn't within the viewport, the viewport pans to center it — so keyboard navigation never lands on an off-screen node. Only reacts to keyboard focus (`:focus-visible`), not pointer/programmatic focus. Set `auto-pan-on-node-focus="false"` (or pass `false`) to disable.

--- a/packages/core/src/components/Nodes/NodeWrapper.ts
+++ b/packages/core/src/components/Nodes/NodeWrapper.ts
@@ -1,4 +1,5 @@
 import type { BuiltInNode, MouseTouchEvent, NodeComponent } from '../../types';
+import { getNodesInside } from '@xyflow/system';
 import {
   computed,
   defineComponent,
@@ -44,6 +45,7 @@ const NodeWrapper = defineComponent({
       updateNodeDimensions,
       onUpdateNodeInternals,
       getNodeTypes,
+      setCenter,
     } = useVueFlow();
 
     const {
@@ -58,6 +60,9 @@ const NodeWrapper = defineComponent({
       elementsSelectable,
       nodesConnectable,
       nodesFocusable,
+      autoPanOnNodeFocus,
+      transform,
+      dimensions,
       hooks,
     } = storeToRefs(useStore());
 
@@ -270,6 +275,7 @@ const NodeWrapper = defineComponent({
           'onClick': onSelectNode,
           'onDblclick': onDoubleClick,
           'onKeydown': onKeyDown,
+          'onFocus': isFocusable.value ? onFocus : undefined,
         },
         [
           h(nodeCmp.value === false ? (getNodeTypes.value.default as NodeComponent<BuiltInNode>) : (nodeCmp.value as any), {
@@ -395,6 +401,32 @@ const NodeWrapper = defineComponent({
             y: arrowKeyDiffs[event.key].y,
           },
           event.shiftKey,
+        );
+      }
+    }
+
+    // Pan the viewport to a node that receives KEYBOARD focus (Tab) and isn't currently visible, so
+    // tabbing through nodes never lands on an off-screen one. `:focus-visible` keeps this to keyboard
+    // focus (not pointer/programmatic).
+    function onFocus() {
+      const node = nodeRef.value;
+      if (!node || disableKeyboardA11y.value || !autoPanOnNodeFocus.value || !nodeElement.value?.matches(':focus-visible')) {
+        return;
+      }
+
+      const withinViewport
+        = getNodesInside(
+          new Map([[node.id, node]]),
+          { x: 0, y: 0, width: dimensions.value.width, height: dimensions.value.height },
+          transform.value,
+          true,
+        ).length > 0;
+
+      if (!withinViewport) {
+        setCenter(
+          node.internals.positionAbsolute.x + (node.measured.width ?? 0) / 2,
+          node.internals.positionAbsolute.y + (node.measured.height ?? 0) / 2,
+          { zoom: transform.value[2] },
         );
       }
     }

--- a/packages/core/src/container/VueFlow/VueFlow.vue
+++ b/packages/core/src/container/VueFlow/VueFlow.vue
@@ -44,6 +44,7 @@ const props = withDefaults(defineProps<FlowProps<NodeType, EdgeType>>(), {
   nodesFocusable: undefined,
   autoPanOnConnect: undefined,
   autoPanOnNodeDrag: undefined,
+  autoPanOnNodeFocus: undefined,
   isValidConnection: undefined,
   onBeforeDelete: undefined,
   deleteKeyCode: undefined,

--- a/packages/core/src/store/state.ts
+++ b/packages/core/src/store/state.ts
@@ -112,6 +112,7 @@ export function useState<NodeType extends Node = Node, EdgeType extends Edge = E
 
     autoPanOnNodeDrag: true,
     autoPanOnConnect: true,
+    autoPanOnNodeFocus: true,
     autoPanSpeed: 15,
 
     disableKeyboardA11y: false,

--- a/packages/core/src/types/flow.ts
+++ b/packages/core/src/types/flow.ts
@@ -189,6 +189,12 @@ export interface FlowProps<NodeType extends Node = Node, EdgeType extends Edge =
 
   autoPanOnConnect?: boolean;
   autoPanOnNodeDrag?: boolean;
+  /**
+   * Pan the viewport to a node when it receives keyboard focus (Tab) and isn't currently within the
+   * viewport — keeps keyboard navigation from landing on off-screen nodes.
+   * @default true
+   */
+  autoPanOnNodeFocus?: boolean;
   autoPanSpeed?: number;
 }
 

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -153,6 +153,7 @@ export interface State<NodeType extends Node = Node, EdgeType extends Edge = Edg
 
   autoPanOnConnect: boolean;
   autoPanOnNodeDrag: boolean;
+  autoPanOnNodeFocus: boolean;
   /**
    * The speed at which the viewport pans while dragging a node or a selection box.
    * @default 15


### PR DESCRIPTION
Ports [xyflow/xyflow#5308](https://github.com/xyflow/xyflow/pull/5308) (a11y) to vue-flow.

## What
When a node receives **keyboard** focus (Tab) and isn't currently within the viewport, the viewport pans to center it — so tabbing through nodes never lands on an off-screen one. New prop **`autoPanOnNodeFocus`** (default `true`), matching xyflow/react.

- Gated on `:focus-visible`, so it only fires for keyboard focus — not pointer/programmatic focus.
- Uses the flat `setCenter` from `useVueFlow()` + `getNodesInside` (both already in the public/system surface) — no new primitives.
- Opt out with `auto-pan-on-node-focus="false"`.

## Files
- `types/flow.ts` / `types/store.ts` / `store/state.ts`: the `autoPanOnNodeFocus` prop + state + default (`true`).
- `container/VueFlow/VueFlow.vue`: `autoPanOnNodeFocus: undefined` in `withDefaults` — **required**, since a boolean prop otherwise casts to `false` and overrides the store default (same pattern as the other `autoPan*` props).
- `components/Nodes/NodeWrapper.ts`: the `onFocus` handler + `@focus` binding (when focusable).

## Verification (Chrome)
On the overview example (nodes extend below the fold): tabbing to an on-screen node does nothing; tabbing to an off-screen node pans the viewport to center it. Confirmed via real keyboard `Tab` (so `:focus-visible` matches) — and caught + fixed the `withDefaults` boolean-cast bug in the process (without it, `autoPanOnNodeFocus` was silently `false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)