### PR TITLE
refactor(core)!: drop redundant public viewportHelper from useVueFlow

### DIFF
--- a/.changeset/drop-public-viewport-helper.md
+++ b/.changeset/drop-public-viewport-helper.md
@@ -1,0 +1,8 @@
+---
+"@vue-flow/core": major
+---
+
+Remove the redundant `viewportHelper` `ComputedRef` from the `useVueFlow()` instance. The viewport functions (`setCenter`, `fitView`, `zoomIn`, `zoomOut`, `zoomTo`, `setViewport`, `getViewport`, `fitBounds`, `screenToFlowPosition`, `flowToScreenPosition`) are already exposed **flat** on the instance — mirroring `useReactFlow` / `useSvelteFlow` — so the nested `viewportHelper` was duplicate surface.
+
+- `useVueFlow().viewportHelper.value.setCenter(…)` → `useVueFlow().setCenter(…)` (and likewise for the other viewport functions).
+- The init flag moves to a flat `viewportInitialized` (`ComputedRef<boolean>`): `useVueFlow().viewportHelper.value.viewportInitialized` → `useVueFlow().viewportInitialized.value`.

--- a/packages/core/src/composables/useOnInitHandler.ts
+++ b/packages/core/src/composables/useOnInitHandler.ts
@@ -15,7 +15,7 @@ export function useOnInitHandler<NodeType extends Node = Node, EdgeType extends 
   vfInstance = useVueFlow<NodeType, EdgeType>(),
 ) {
   watch(
-    () => vfInstance.viewportHelper.value.viewportInitialized,
+    () => vfInstance.viewportInitialized.value,
     (isInitialized) => {
       if (isInitialized) {
         vfInstance.emits.init(vfInstance);

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -33,7 +33,7 @@ import {
   panBy as panBySystem,
   updateAbsolutePositions,
 } from '@xyflow/system';
-import { markRaw, toRaw } from 'vue';
+import { computed, markRaw, toRaw } from 'vue';
 import { useViewportHelper } from '../composables';
 import {
   adoptNodes,
@@ -1122,7 +1122,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
     flowToScreenPosition: params => viewportHelper.value.flowToScreenPosition(params),
     toObject,
     updateNodeInternals,
-    viewportHelper,
+    viewportInitialized: computed(() => viewportHelper.value.viewportInitialized),
     $reset,
     $destroy: () => {},
   };

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -345,8 +345,8 @@ export interface Actions<NodeType extends Node = Node, EdgeType extends Edge = E
   getHandleConnections: ({ id, type, nodeId }: { id?: string | null; type: HandleType; nodeId: string }) => NodeConnection[];
   /** pan the viewport; return indicates if a transform has happened or not */
   panBy: (delta: XYPosition) => Promise<boolean>;
-  /** viewport helper instance */
-  viewportHelper: ComputedRef<ViewportHelper>;
+  /** whether the viewport (panzoom) is initialized — `true` once `<ZoomPane>` has mounted and measured */
+  viewportInitialized: ComputedRef<boolean>;
 
   /** reset state to defaults */
   $reset: () => void;

--- a/tests/cypress/component/2-vue-flow/onInit.cy.ts
+++ b/tests/cypress/component/2-vue-flow/onInit.cy.ts
@@ -18,7 +18,7 @@ describe('VueFlow `@init` event', () => {
       expect(instance, 'init receives the flow instance').to.exist;
       expect(typeof instance.fitView, 'instance is usable').to.eq('function');
       // the viewport must be set up by the time init fires (the whole point of deferring the emit)
-      expect(instance.viewportHelper.value.viewportInitialized, 'viewport initialized at init time').to.eq(true);
+      expect(instance.viewportInitialized.value, 'viewport initialized at init time').to.eq(true);
       expect(instance.viewport.value.zoom, 'viewport transform applied').to.be.a('number');
     });
   });


### PR DESCRIPTION
Follow-up to the `autoPanOnNodeFocus` work (#2113), where I noticed the curated `useVueFlow()` surface exposed both flat viewport functions **and** a nested `viewportHelper` `ComputedRef` — duplicate surface.

## Why
`useVueFlow()` is meant to mirror `useReactFlow()` / `useSvelteFlow()`, which expose the viewport functions **flat**. vue-flow already does too — `Actions extends Omit<ViewportHelper, 'viewportInitialized'>`, so `setCenter`, `fitView`, `zoomIn`, `zoomOut`, `zoomTo`, `setViewport`, `getViewport`, `fitBounds`, `screenToFlowPosition`, `flowToScreenPosition` are all directly callable. The extra `viewportHelper: ComputedRef<ViewportHelper>` was therefore redundant public surface (its only non-duplicate member was `viewportInitialized`).

## Changes
- Remove `viewportHelper` from the `Actions`/instance type and the returned instance object.
- Expose the init flag flat: **`viewportInitialized: ComputedRef<boolean>`** (`useVueFlow().viewportInitialized.value`).
- The internal panzoom-aware `viewportHelper` computed (`useViewportHelper`) stays — it still powers the flat function wrappers + `viewportInitialized`.
- Migrated the only consumers: `useOnInitHandler` and the `onInit` cypress test.

## Breaking
- `useVueFlow().viewportHelper.value.setCenter(…)` → `useVueFlow().setCenter(…)` (and the other viewport fns).
- `useVueFlow().viewportHelper.value.viewportInitialized` → `useVueFlow().viewportInitialized.value`.

Nothing in docs/examples used `viewportHelper` for the functions (only the generated typedocs/REPL bundle reference it). `vue-tsc`, lint, and build are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)