### PR TITLE
feat(core): add connectionDragThreshold prop

### DIFF
--- a/.changeset/connection-drag-threshold.md
+++ b/.changeset/connection-drag-threshold.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Add a `connectionDragThreshold` prop (mirrors xyflow/react and xyflow/svelte). It's the distance in pixels the pointer must move from a handle before a connection line starts to drag — useful to prevent accidental connections when you just click a handle. Defaults to `1`; set it higher (e.g. `connectionDragThreshold="25"`) to require a more deliberate drag, or `0` to start the connection immediately on pointer-down. Below the threshold, neither `connectStart` nor `connectEnd` fires.

--- a/packages/core/src/composables/useHandle.ts
+++ b/packages/core/src/composables/useHandle.ts
@@ -50,6 +50,7 @@ export function useHandle({
     transform,
     connectionMode,
     connectionRadius,
+    connectionDragThreshold,
     connectOnClick,
     connectionStartHandle,
     connectionClickStartHandle,
@@ -109,6 +110,7 @@ export function useHandle({
       // system's own param name stays `edgeUpdaterType`; our prop is `reconnectHandleType`
       edgeUpdaterType: toValue(reconnectHandleType),
       autoPanSpeed: autoPanSpeed.value,
+      dragThreshold: connectionDragThreshold.value,
       handleDomNode,
       panBy,
       isValidConnection: buildSystemIsValidConnection(),

--- a/packages/core/src/store/state.ts
+++ b/packages/core/src/store/state.ts
@@ -72,6 +72,7 @@ export function useState<NodeType extends Node = Node, EdgeType extends Edge = E
     connectionClickStartHandle: null,
     connectionPosition: { x: Number.NaN, y: Number.NaN },
     connectionRadius: 20,
+    connectionDragThreshold: 1,
     connectOnClick: true,
     connectionStatus: null,
     isValidConnection: null,

--- a/packages/core/src/types/flow.ts
+++ b/packages/core/src/types/flow.ts
@@ -106,6 +106,12 @@ export interface FlowProps<NodeType extends Node = Node, EdgeType extends Edge =
   connectionMode?: ConnectionMode;
   connectionLineOptions?: ConnectionLineOptions;
   connectionRadius?: number;
+  /**
+   * The threshold in pixels that the pointer must move before a connection line starts to drag.
+   * Useful to prevent accidental connections when clicking on a handle.
+   * @default 1
+   */
+  connectionDragThreshold?: number;
   isValidConnection?: ValidConnectionFunc | null;
   /** consulted before delete-key/`deleteElements` removals — cancel, confirm, or filter the set */
   onBeforeDelete?: OnBeforeDelete<NodeType, EdgeType> | null;

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -99,6 +99,7 @@ export interface State<NodeType extends Node = Node, EdgeType extends Edge = Edg
   connectionClickStartHandle: ConnectingHandle | null;
   connectionPosition: XYPosition;
   connectionRadius: number;
+  connectionDragThreshold: number;
   connectionStatus: ConnectionStatus | null;
   isValidConnection: ValidConnectionFunc | null;
   onBeforeDelete: OnBeforeDelete<NodeType, EdgeType> | null;

--- a/tests/cypress/component/2-vue-flow/connectionDragThreshold.cy.ts
+++ b/tests/cypress/component/2-vue-flow/connectionDragThreshold.cy.ts
@@ -1,0 +1,87 @@
+import type { VueFlowStore } from '@vue-flow/core';
+import { getStore } from '../../support/component';
+
+// `connectionDragThreshold` is the distance the pointer must travel from a handle before a connection
+// line starts to drag. The gating itself lives in `@xyflow/system`'s `XYHandle.onPointerDown`; these
+// specs assert vue-flow threads the prop through so the start is deferred until the threshold is crossed.
+describe('connectionDragThreshold', () => {
+  let store: VueFlowStore;
+
+  function mountWithThreshold(threshold: number) {
+    cy.vueFlow({
+      fitView: false,
+      connectionDragThreshold: threshold,
+      nodes: [
+        { id: '1', data: { label: 'Node 1' }, position: { x: 0, y: 0 } },
+        { id: '2', data: { label: 'Node 2' }, position: { x: 300, y: 300 } },
+      ],
+      autoConnect: true,
+    });
+
+    cy.then(() => {
+      store = getStore();
+    });
+  }
+
+  // a single native drag on the source handle by `dx`/`dy` px, released in place. XYHandle starts on
+  // `mousedown` then listens for `mousemove`/`mouseup` on `document`, so we dispatch natively in one block
+  // (a cypress command between steps would cancel the in-progress connection — see `dragConnection`).
+  function dragSourceHandleBy(nodeId: string, dx: number, dy: number) {
+    cy.get(`[data-nodeid="${nodeId}"].source`).then(($src) => {
+      const el = $src[0];
+      const win = el.ownerDocument.defaultView as Window;
+      const doc = el.ownerDocument;
+
+      const fire = (target: EventTarget, type: string, x: number, y: number, buttons: number) =>
+        target.dispatchEvent(new win.MouseEvent(type, { bubbles: true, cancelable: true, view: win, button: 0, buttons, clientX: x, clientY: y }));
+      const settle = () => new Promise<void>(resolve => win.setTimeout(resolve, 24));
+
+      const r = el.getBoundingClientRect();
+      const sx = r.x + r.width / 2;
+      const sy = r.y + r.height / 2;
+
+      return (async () => {
+        fire(el, 'mousedown', sx, sy, 1);
+        await settle();
+        fire(doc, 'mousemove', sx + dx, sy + dy, 1);
+        await settle();
+        fire(doc, 'mouseup', sx + dx, sy + dy, 0);
+        await settle();
+      })();
+    });
+  }
+
+  it('does not start a connection while the pointer stays within the threshold', () => {
+    mountWithThreshold(100);
+
+    let startCount = 0;
+    cy.then(() => {
+      store.onConnectStart(() => startCount++);
+    });
+
+    // ~14px of movement — well under the 100px threshold
+    dragSourceHandleBy('1', 10, 10);
+
+    cy.then(() => {
+      expect(startCount, 'onConnectStart did not fire below the threshold').to.eq(0);
+      expect(store.connectionStartHandle.value, 'no connection was started').to.eq(null);
+      expect(store.edges.value, 'no edge was created').to.have.length(0);
+    });
+  });
+
+  it('starts the connection once the pointer moves past the threshold', () => {
+    mountWithThreshold(20);
+
+    let startCount = 0;
+    cy.then(() => {
+      store.onConnectStart(() => startCount++);
+    });
+
+    // ~57px of movement — past the 20px threshold
+    dragSourceHandleBy('1', 40, 40);
+
+    cy.then(() => {
+      expect(startCount, 'onConnectStart fired once past the threshold').to.eq(1);
+    });
+  });
+});


### PR DESCRIPTION
Ports [xyflow/xyflow#5344](https://github.com/xyflow/xyflow/pull/5344) — adds a `connectionDragThreshold` prop, matching `@xyflow/react` and `@xyflow/svelte`.

## What

The distance in pixels the pointer must move from a handle before a connection line starts to drag. This prevents accidental connections when you just *click* a handle (e.g. to select the node behind it). Defaults to `1`; set it higher to require a more deliberate drag, or `0` to start the connection immediately on pointer-down (the pre-threshold behavior).

```vue
<VueFlow :connection-drag-threshold="25" />
```

## How

The gating logic already lives in `@xyflow/system`'s `XYHandle.onPointerDown` (it defers `startConnection()` — the `updateConnection` + `onConnectStart` — until the pointer passes `dragThreshold`). Our installed system (`0.0.77`) already ships the `dragThreshold` param, so vue-flow only threads the store value through:

- `connectionDragThreshold?: number` on `FlowProps` (default `1`), `connectionDragThreshold: number` on `State`, default `1` in `state.ts`. The generic prop→store sync in `useWatchProps` wires it up automatically.
- `useHandle` passes `dragThreshold: connectionDragThreshold.value` into the single `XYHandle.onPointerDown` call (shared by both the fresh-connect and reconnect paths, matching React which reads the same store value for `Handle` and `EdgeUpdateAnchors`).

Below the threshold neither `connectStart` nor `connectEnd` fires (a plain sub-threshold click only runs `cancelConnection`, as before) — same semantics as RF/SF.

## Verification

- `vue-tsc` + lint clean; core builds.
- New `connectionDragThreshold.cy.ts` (real-Chrome native drag), both passing:
  - below threshold → no `connectStart`, no connection started, no edge
  - past threshold → `connectStart` fires once
- Existing `connect` / `isValidConnection` / `strictConnectionMode` specs still green (default threshold `1`, no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)