### PR TITLE
feat(core)!: align useNodeConnections params with xyflow

### DIFF
--- a/.changeset/usenodeconnections-id-handletype.md
+++ b/.changeset/usenodeconnections-id-handletype.md
@@ -1,0 +1,8 @@
+---
+"@vue-flow/core": major
+---
+
+Align `useNodeConnections` params with xyflow/react and xyflow/svelte:
+
+- Rename the `nodeId` param to `id` (`useNodeConnections({ nodeId })` → `useNodeConnections({ id })`). Like before, it's optional and falls back to the node id from the `useNodeId` context injection.
+- `handleId` now requires `handleType` to be set. Passing `handleId` on its own is a type error — `handleId` is meaningless at runtime without a `handleType`, and the type now points you at the fix (mirrors xyflow/react & xyflow/svelte). Runtime behavior is unchanged.

--- a/docs/src/guide/composables.md
+++ b/docs/src/guide/composables.md
@@ -80,11 +80,12 @@ const sourceConnections = useNodeConnections({
 })
 
 const handleConnections = useNodeConnections({
-  handleId: 'handle-1', // you can explicitly pass a handle id if you want to get connections of a specific handle
+  handleType: 'source',
+  handleId: 'handle-1', // pass a handle id to narrow to a specific handle (requires `handleType`)
 })
 
 const connections = useNodeConnections({
-  nodeId: '1', // you can explicitly pass a node id, otherwise it's used from the `NodeId  injection
+  id: '1', // you can explicitly pass a node id, otherwise it's used from the `NodeId` injection
   handleType: 'target',
   onConnect: (connections: NodeConnection[]) => {
     // do something with the connections

--- a/examples/vite/src/Math/ResultNode.vue
+++ b/examples/vite/src/Math/ResultNode.vue
@@ -16,7 +16,7 @@ const sourceConnections = useNodeConnections({
 // Get the source connections of the operator node
 const operatorSourceConnections = useNodeConnections({
   handleType: 'target',
-  nodeId: () => sourceConnections.value[0]?.source,
+  id: () => sourceConnections.value[0]?.source,
 });
 
 const operatorData = useNodesData<Node<OperatorNodeData, 'operator'>>(() =>

--- a/packages/core/src/composables/useNodeConnections.ts
+++ b/packages/core/src/composables/useNodeConnections.ts
@@ -6,13 +6,21 @@ import { storeToRefs } from './storeToRefs';
 import { useNodeId } from './useNodeId';
 import { useStore } from './useStore';
 
-export interface UseNodeConnectionsParams {
-  handleType?: MaybeRefOrGetter<HandleType | null | undefined>;
-  handleId?: MaybeRefOrGetter<string | null | undefined>;
-  nodeId?: MaybeRefOrGetter<string | null | undefined>;
+export type UseNodeConnectionsParams = {
+  /** node id - if not provided, the node id from the `useNodeId` context injection is used */
+  id?: MaybeRefOrGetter<string | null | undefined>;
   onConnect?: (connections: NodeConnection[]) => void;
   onDisconnect?: (connections: NodeConnection[]) => void;
-}
+} & (
+  | {
+    /** handle type `source` or `target` */
+    handleType: MaybeRefOrGetter<HandleType | null | undefined>;
+    /** the handle id (only needed if the node has multiple handles of the same type). Requires `handleType` to be set. */
+    handleId?: MaybeRefOrGetter<string | null | undefined>;
+  }
+  // without `handleType` a `handleId` is meaningless at runtime, so the type forbids it (mirrors xyflow/react & xyflow/svelte)
+  | { handleType?: MaybeRefOrGetter<HandleType | null | undefined>; handleId?: never }
+);
 
 /**
  * Hook to retrieve all edges connected to a node. Can be filtered by handle type and id.
@@ -20,26 +28,26 @@ export interface UseNodeConnectionsParams {
  * @public
  * @param params
  * @param params.handleType - handle type `source` or `target`
- * @param params.nodeId - node id - if not provided, the node id from the `useNodeId` (meaning, the context-based injection) is used
- * @param params.handleId - the handle id (this is required if the node has multiple handles of the same type)
+ * @param params.id - node id - if not provided, the node id from the `useNodeId` (meaning, the context-based injection) is used
+ * @param params.handleId - the handle id (only needed if the node has multiple handles of the same type; requires `handleType` to be set)
  * @param params.onConnect - gets called when a connection is created
  * @param params.onDisconnect - gets called when a connection is removed
  *
  * @returns An array of connections
  */
 export function useNodeConnections(params: UseNodeConnectionsParams = {}) {
-  const { handleType, handleId, nodeId, onConnect, onDisconnect } = params;
+  const { handleType, handleId, id, onConnect, onDisconnect } = params;
 
   const { connectionLookup } = storeToRefs(useStore());
 
-  const _nodeId = useNodeId();
+  const nodeId = useNodeId();
 
   const prevConnections = shallowRef<Map<string, NodeConnection> | null>(null);
 
   const connections = shallowRef<Map<string, NodeConnection>>();
 
   const lookupKey = computed(() => {
-    const currNodeId = toValue(nodeId) ?? _nodeId;
+    const currNodeId = toValue(id) ?? nodeId;
     const currentHandleType = toValue(handleType);
     const currHandleId = toValue(handleId);
 


### PR DESCRIPTION
Ports [xyflow/xyflow#5791](https://github.com/xyflow/xyflow/pull/5791) and aligns the `useNodeConnections` param names with `@xyflow/react` / `@xyflow/svelte`.

## What

Two changes to `UseNodeConnectionsParams`:

1. **`nodeId` → `id`.** Matches system/react/svelte. Still optional; still falls back to the node id from the `useNodeId` context injection when omitted.
2. **`handleId` now requires `handleType`.** Passing `handleId` on its own is a **type error** — at runtime `handleId` is ignored unless a `handleType` is set (the lookup key only appends the handle suffix when a `handleType` is present), so the type now points you at the fix instead of silently doing nothing. This mirrors the discriminated-union upstream added.

Runtime behavior is unchanged — this is purely the param name + a tighter type.

```ts
// before
useNodeConnections({ nodeId: '1', handleType: 'target' })
useNodeConnections({ handleId: 'h1' }) // silently ignored handleId

// after
useNodeConnections({ id: '1', handleType: 'target' })
useNodeConnections({ handleId: 'h1' }) // ❌ type error: handleId requires handleType
useNodeConnections({ handleType: 'source', handleId: 'h1' }) // ✅
```

## How

The param type stays **Vue-specific** (every field `MaybeRefOrGetter`-wrapped, `NodeConnection[]` callbacks), so unlike react/svelte we keep our own type rather than re-exporting system's — but it now uses the same discriminated-union shape:

```ts
export type UseNodeConnectionsParams = {
  id?: MaybeRefOrGetter<string | null | undefined>;
  onConnect?: (connections: NodeConnection[]) => void;
  onDisconnect?: (connections: NodeConnection[]) => void;
} & (
  | { handleType: MaybeRefOrGetter<HandleType | null | undefined>; handleId?: MaybeRefOrGetter<string | null | undefined> }
  | { handleType?: MaybeRefOrGetter<HandleType | null | undefined>; handleId?: never }
);
```

In-repo callers updated to `id` (the Math example + the composables guide), and the guide's handle-filter snippet now passes `handleType` alongside `handleId` (it was the exact `handleId`-without-`handleType` mistake this constraint catches).

## Verification

- `vue-tsc` + lint clean; core builds.
- Type-checked the union with a throwaway `@ts-expect-error` fixture: `{ handleId: 'h1' }` and `{ id: '1', handleId: 'h1' }` error as expected, while `{}`, `{ handleType }`, `{ handleType, handleId }`, `{ id, handleType }`, and ref/getter forms all compile.

## Breaking change

`useNodeConnections({ nodeId })` → `useNodeConnections({ id })`. Batched into the 2.0.0 major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)