### PR TITLE
feat(core): add autoPanOnSelection

### DIFF
--- a/.changeset/auto-pan-on-selection.md
+++ b/.changeset/auto-pan-on-selection.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Add an `autoPanOnSelection` prop (mirrors xyflow/react and xyflow/svelte). When `true` (the default), the viewport pans automatically as the cursor reaches the edge of the viewport while dragging a selection box, so you can select nodes beyond the visible area in one gesture. Set `:auto-pan-on-selection="false"` to keep the viewport fixed during selection.

--- a/packages/core/src/container/Pane/Pane.vue
+++ b/packages/core/src/container/Pane/Pane.vue
@@ -1,16 +1,16 @@
 <script lang="ts" setup>
+import type { XYPosition } from '@xyflow/system';
 import type { EdgeChange, NodeChange } from '../../types';
-import { areSetsEqual, getEventPosition, getNodesInside, SelectionMode } from '@xyflow/system';
-import { shallowRef, toRef, watch } from 'vue';
+import { areSetsEqual, calcAutoPan, getEventPosition, getNodesInside, pointToRendererPoint, rendererPointToPoint, SelectionMode } from '@xyflow/system';
+import { onUnmounted, shallowRef, toRef, watch } from 'vue';
 import NodesSelection from '../../components/NodesSelection/NodesSelection.vue';
 import UserSelection from '../../components/UserSelection/UserSelection.vue';
 import { storeToRefs, useKeyPress, useStore, useVueFlow } from '../../composables';
 import { getSelectionChanges } from '../../utils';
-import { getMousePosition } from './utils';
 
 const { isSelecting, selectionKeyPressed } = defineProps<{ isSelecting: boolean; selectionKeyPressed: boolean }>();
 
-const { emits, removeSelectedNodes, removeSelectedEdges, getSelectedEdges, getSelectedNodes, deleteElements } = useVueFlow();
+const { emits, removeSelectedNodes, removeSelectedEdges, getSelectedEdges, getSelectedNodes, deleteElements, panBy } = useVueFlow();
 
 const { edgeLookup, nodeLookup } = useStore();
 
@@ -29,6 +29,8 @@ const {
   defaultEdgeOptions,
   connectionStartHandle,
   panOnDrag,
+  autoPanOnSelection,
+  autoPanSpeed,
 } = storeToRefs(useStore());
 
 const container = shallowRef<HTMLDivElement | null>(null);
@@ -46,6 +48,11 @@ const connectionInProgress = toRef(() => connectionStartHandle.value !== null);
 // Used to prevent click events when the user lets go of the selectionKey during a selection
 let selectionInProgress = false;
 let selectionStarted = false;
+
+// Auto-pan while dragging the selection box near the edges of the container
+let autoPanId = 0;
+let autoPanStarted = false;
+let lastPointerPosition: XYPosition = { x: 0, y: 0 };
 
 const deleteKeyPressed = useKeyPress(deleteKeyCode, { actInsideInputWithModifier: false });
 
@@ -67,6 +74,10 @@ watch(deleteKeyPressed, (isKeyPressed) => {
 
 watch(multiSelectKeyPressed, (isKeyPressed) => {
   multiSelectionActive.value = isKeyPressed;
+});
+
+onUnmounted(() => {
+  cleanupAutoPan();
 });
 
 function wrapHandler(handler: Function, containerRef: HTMLDivElement | null) {
@@ -121,19 +132,23 @@ function onPointerDown(event: PointerEvent) {
 
   ;(event.target as Element)?.setPointerCapture?.(event.pointerId);
 
-  const { x, y } = getMousePosition(event, containerBounds.value);
+  const { x, y } = getEventPosition(event, containerBounds.value);
 
   selectionStarted = true;
   selectionInProgress = false;
+  autoPanStarted = false;
 
   removeSelectedNodes();
   removeSelectedEdges();
 
+  // store the origin in flow coordinates so it stays anchored to the canvas while auto-panning
+  const flowStart = pointToRendererPoint({ x, y }, transform.value);
+
   userSelectionRect.value = {
     width: 0,
     height: 0,
-    startX: x,
-    startY: y,
+    startX: flowStart.x,
+    startY: flowStart.y,
     x,
     y,
   };
@@ -141,23 +156,25 @@ function onPointerDown(event: PointerEvent) {
   emits.selectionStart(event);
 }
 
-function onPointerMove(event: PointerEvent) {
-  if (!containerBounds.value || !userSelectionRect.value) {
+// Recompute the selection rect (and the selected nodes/edges) from the current pointer position. Called
+// both on pointer move and on every auto-pan frame, so the selection keeps growing while the viewport pans.
+function commitUserSelectionRect(mouseX: number, mouseY: number) {
+  if (!userSelectionRect.value) {
     return;
   }
 
-  selectionInProgress = true;
-
-  const { x: mouseX, y: mouseY } = getEventPosition(event, containerBounds.value);
+  // `startX`/`startY` are stored in flow coordinates (so the origin stays put while panning); convert
+  // back to screen coordinates to build the rect, which `getNodesInside` and `UserSelection` consume.
   const { startX = 0, startY = 0 } = userSelectionRect.value;
+  const screenStart = rendererPointToPoint({ x: startX, y: startY }, transform.value);
 
   const nextUserSelectRect = {
     startX,
     startY,
-    x: mouseX < startX ? mouseX : startX,
-    y: mouseY < startY ? mouseY : startY,
-    width: Math.abs(mouseX - startX),
-    height: Math.abs(mouseY - startY),
+    x: mouseX < screenStart.x ? mouseX : screenStart.x,
+    y: mouseY < screenStart.y ? mouseY : screenStart.y,
+    width: Math.abs(mouseX - screenStart.x),
+    height: Math.abs(mouseY - screenStart.y),
   };
 
   const prevSelectedNodeIds = selectedNodeIds.value;
@@ -201,6 +218,48 @@ function onPointerMove(event: PointerEvent) {
   nodesSelectionActive.value = false;
 }
 
+// rAF loop that pans the viewport while the pointer sits near a container edge during a selection, then
+// re-commits the selection rect from the (unchanged) pointer position so it grows toward the new viewport.
+function autoPan() {
+  if (!autoPanOnSelection.value || !containerBounds.value) {
+    return;
+  }
+
+  const [xMovement, yMovement] = calcAutoPan(lastPointerPosition, containerBounds.value, autoPanSpeed.value);
+
+  panBy({ x: xMovement, y: yMovement }).then((panned) => {
+    if (selectionInProgress && panned) {
+      commitUserSelectionRect(lastPointerPosition.x, lastPointerPosition.y);
+    }
+
+    autoPanId = requestAnimationFrame(autoPan);
+  });
+}
+
+function cleanupAutoPan() {
+  cancelAnimationFrame(autoPanId);
+  autoPanId = 0;
+  autoPanStarted = false;
+}
+
+function onPointerMove(event: PointerEvent) {
+  if (!containerBounds.value || !userSelectionRect.value) {
+    return;
+  }
+
+  selectionInProgress = true;
+
+  const { x: mouseX, y: mouseY } = getEventPosition(event, containerBounds.value);
+  lastPointerPosition = { x: mouseX, y: mouseY };
+
+  if (!autoPanStarted) {
+    autoPan();
+    autoPanStarted = true;
+  }
+
+  commitUserSelectionRect(mouseX, mouseY);
+}
+
 function onPointerUp(event: PointerEvent) {
   if (event.button !== 0 || !selectionStarted) {
     return;
@@ -227,6 +286,13 @@ function onPointerUp(event: PointerEvent) {
   }
 
   selectionStarted = false;
+
+  cleanupAutoPan();
+}
+
+function onPointerCancel(event: PointerEvent) {
+  ;(event.target as Element)?.releasePointerCapture?.(event.pointerId);
+  cleanupAutoPan();
 }
 </script>
 
@@ -249,6 +315,7 @@ export default {
     @pointerdown="(event) => (hasActiveSelection ? onPointerDown(event) : emits.paneMouseMove(event))"
     @pointermove="(event) => (hasActiveSelection ? onPointerMove(event) : emits.paneMouseMove(event))"
     @pointerup="(event) => (hasActiveSelection ? onPointerUp(event) : undefined)"
+    @pointercancel="(event) => (hasActiveSelection ? onPointerCancel(event) : undefined)"
     @pointerleave="emits.paneMouseLeave($event)"
   >
     <slot />

--- a/packages/core/src/container/Pane/utils.ts
+++ b/packages/core/src/container/Pane/utils.ts
@@ -1,8 +1,0 @@
-import type { XYPosition } from '@xyflow/system';
-
-export function getMousePosition(event: MouseEvent, containerBounds: DOMRect): XYPosition {
-  return {
-    x: event.clientX - containerBounds.left,
-    y: event.clientY - containerBounds.top,
-  };
-}

--- a/packages/core/src/container/VueFlow/VueFlow.vue
+++ b/packages/core/src/container/VueFlow/VueFlow.vue
@@ -45,6 +45,7 @@ const props = withDefaults(defineProps<FlowProps<NodeType, EdgeType>>(), {
   autoPanOnConnect: undefined,
   autoPanOnNodeDrag: undefined,
   autoPanOnNodeFocus: undefined,
+  autoPanOnSelection: undefined,
   isValidConnection: undefined,
   onBeforeDelete: undefined,
   deleteKeyCode: undefined,

--- a/packages/core/src/store/state.ts
+++ b/packages/core/src/store/state.ts
@@ -114,6 +114,7 @@ export function useState<NodeType extends Node = Node, EdgeType extends Edge = E
     autoPanOnNodeDrag: true,
     autoPanOnConnect: true,
     autoPanOnNodeFocus: true,
+    autoPanOnSelection: true,
     autoPanSpeed: 15,
 
     disableKeyboardA11y: false,

--- a/packages/core/src/types/flow.ts
+++ b/packages/core/src/types/flow.ts
@@ -201,6 +201,12 @@ export interface FlowProps<NodeType extends Node = Node, EdgeType extends Edge =
    * @default true
    */
   autoPanOnNodeFocus?: boolean;
+  /**
+   * Pan the viewport automatically when the cursor reaches the edge of the viewport while dragging a
+   * selection box.
+   * @default true
+   */
+  autoPanOnSelection?: boolean;
   autoPanSpeed?: number;
 }
 

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -155,6 +155,7 @@ export interface State<NodeType extends Node = Node, EdgeType extends Edge = Edg
   autoPanOnConnect: boolean;
   autoPanOnNodeDrag: boolean;
   autoPanOnNodeFocus: boolean;
+  autoPanOnSelection: boolean;
   /**
    * The speed at which the viewport pans while dragging a node or a selection box.
    * @default 15

--- a/tests/cypress/component/2-vue-flow/autoPanOnSelection.cy.ts
+++ b/tests/cypress/component/2-vue-flow/autoPanOnSelection.cy.ts
@@ -1,0 +1,87 @@
+import type { VueFlowStore } from '@vue-flow/core';
+import { getStore } from '../../support/component';
+import { getElements } from '../../utils';
+
+const { nodes, edges } = getElements();
+
+// `autoPanOnSelection` pans the viewport when the selection box is dragged near a container edge. The pan
+// is an rAF loop driven by the last pointer position, so a single pointer move to the edge keeps the
+// viewport drifting until the pointer is released — we assert on that drift.
+describe('autoPanOnSelection', () => {
+  // Pane calls `setPointerCapture` on pointerdown, which throws on synthetic pointer events (no active
+  // pointer). It's irrelevant to the auto-pan logic, so neutralize it to drive the real handlers.
+  beforeEach(() => {
+    cy.window().then((win) => {
+      win.Element.prototype.setPointerCapture = () => {};
+      win.Element.prototype.releasePointerCapture = () => {};
+    });
+  });
+
+  // `selectionKeyCode: true` + `panOnDrag: false` puts the pane in selection mode without holding a key
+  // (see the `isSelecting` derivation in ZoomPane), so a plain pointer drag draws a selection box.
+  function mountSelecting(autoPanOnSelection: boolean) {
+    cy.vueFlow({
+      nodes,
+      edges,
+      fitView: false,
+      panOnDrag: false,
+      selectionKeyCode: true,
+      autoPanOnSelection,
+    });
+  }
+
+  function dragSelectionToTopLeftEdge() {
+    cy.window().then((win) => {
+      cy.get('.vue-flow__pane')
+        .should('exist')
+        .trigger('pointerdown', { button: 0, clientX: 200, clientY: 200, force: true, view: win })
+        // a move within 40px of the top-left edge keeps `calcAutoPan` returning a non-zero velocity
+        .trigger('pointermove', { clientX: 10, clientY: 10, force: true, view: win });
+    });
+  }
+
+  it('pans the viewport when the selection box reaches the edge', () => {
+    mountSelecting(true);
+
+    let store: VueFlowStore;
+    let baseline: { x: number; y: number };
+    cy.then(() => {
+      store = getStore();
+      baseline = { ...store.viewport.value };
+    });
+
+    dragSelectionToTopLeftEdge();
+
+    // the rAF loop keeps panning while the pointer is held near the edge
+    cy.tryAssertion(() => {
+      const { x, y } = store.viewport.value;
+      expect(x !== baseline.x || y !== baseline.y, 'viewport panned during selection').to.eq(true);
+    });
+
+    cy.get('.vue-flow__pane').trigger('pointerup', { button: 0, force: true });
+  });
+
+  it('does not pan when autoPanOnSelection is disabled', () => {
+    mountSelecting(false);
+
+    let store: VueFlowStore;
+    let baseline: { x: number; y: number };
+    cy.then(() => {
+      store = getStore();
+      baseline = { ...store.viewport.value };
+    });
+
+    dragSelectionToTopLeftEdge();
+
+    // give the rAF loop ample time to fire if it were going to — it shouldn't
+    cy.wait(300);
+
+    cy.then(() => {
+      const { x, y } = store.viewport.value;
+      expect(x, 'viewport x unchanged').to.eq(baseline.x);
+      expect(y, 'viewport y unchanged').to.eq(baseline.y);
+    });
+
+    cy.get('.vue-flow__pane').trigger('pointerup', { button: 0, force: true });
+  });
+});


### PR DESCRIPTION
Ports [xyflow/xyflow#5677](https://github.com/xyflow/xyflow/pull/5677) — auto-pan the viewport when a selection box is dragged to its edge.

## What

When `true` (the default), dragging a selection box to the edge of the viewport pans the canvas, so you can select nodes beyond the visible area in a single gesture — matching `@xyflow/react` / `@xyflow/svelte`. New prop `autoPanOnSelection`; set `:auto-pan-on-selection="false"` to keep the viewport fixed during selection.

## How

The bulk of the work is in `Pane.vue`:

- **Flow-coordinate origin.** The selection rect's `startX`/`startY` are now stored in flow coordinates (`pointToRendererPoint` on pointer-down) so the origin stays anchored to the canvas as the viewport pans. `commitUserSelectionRect` converts it back to screen coordinates (`rendererPointToPoint`) to build the rect that `getNodesInside` / `UserSelection` consume. Round-trips identically when not panning, so non-autopan behavior is unchanged.
- **rAF loop.** On the first pointer move, an `autoPan` loop starts: each frame it computes a velocity with `calcAutoPan(lastPointerPosition, bounds, autoPanSpeed)`, calls `panBy`, and re-commits the rect from the (unchanged) pointer position so the selection grows toward the newly-revealed area. Cancelled on `pointerup`, a new `pointercancel` handler, and `onUnmounted`.
- `panBy` works mid-selection because the underlying `@xyflow/system` attaches its d3 pan/zoom handlers even while `userSelectionActive` (already the case in our installed system `0.0.77`).

Prop wired through `FlowProps` / `State` / `state.ts` (default `true`) / `VueFlow.vue` `withDefaults` (`undefined`, so the boolean isn't cast to `false` over the store default).

Also **drops the local `getMousePosition` helper** (`container/Pane/utils.ts`) in favor of system's `getEventPosition` — it was an exact duplicate for mouse events.

## Verification

- `vue-tsc` + lint clean; core builds.
- New `autoPanOnSelection.cy.ts` (real Chrome), both passing:
  - enabled → dragging the selection box to the top-left edge pans the viewport (the rAF loop drifts the transform)
  - disabled → the same drag leaves the viewport fixed
- Existing `selectionKeyCode` / `connect` / `connectionDragThreshold` specs still green (no regression).

> Note: the test neutralizes `Element.setPointerCapture` (it throws on synthetic pointer events, which is irrelevant to the auto-pan logic) to drive the real `Pane` handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)