### PR TITLE
fix(core): clear nodes-selection box when no selected nodes remain

### DIFF
--- a/.changeset/clear-nodes-selection-active.md
+++ b/.changeset/clear-nodes-selection-active.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Clear the visual nodes-selection box when no selected nodes remain. `nodesSelectionActive` only ever turns on via a user drag-select, but it could get stuck `true` after the selected nodes were removed (e.g. deleted) — so a later programmatic select would wrongly render the `NodesSelection` rect around an unrelated node. Re-adopting nodes now turns it back off whenever the selection is empty. Mirrors xyflow/react #5727.

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -140,11 +140,18 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
    * `checkEquality` would re-adopt the stale `InternalNode`.
    */
   function commitNodes(nodes: NodeType[]) {
-    state.nodes = adoptNodes(nodes, systemNodeLookup, systemParentLookup, state.hooks.error.trigger, {
+    const { nodes: adopted, hasSelectedNodes } = adoptNodes(nodes, systemNodeLookup, systemParentLookup, state.hooks.error.trigger, {
       nodeOrigin: state.nodeOrigin,
       nodeExtent: Array.isArray(state.nodeExtent) ? (state.nodeExtent as CoordinateExtent) : undefined,
       elevateNodesOnSelect: state.elevateNodesOnSelect,
     });
+
+    state.nodes = adopted;
+
+    // clear a stale visual selection box: `nodesSelectionActive` only ever turns on via a user drag-select,
+    // so once the selection empties out (e.g. the selected nodes were deleted) it must turn back off — else
+    // a later programmatic select would wrongly render the `NodesSelection` rect (xyflow/react #5727).
+    state.nodesSelectionActive = state.nodesSelectionActive && hasSelectedNodes;
 
     recomputeAbsolutePositions();
   }

--- a/packages/core/src/utils/store.ts
+++ b/packages/core/src/utils/store.ts
@@ -111,8 +111,10 @@ export interface CreateInternalNodesOptions {
  * reuses the existing `InternalNode` by reference whenever the user node is unchanged, so re-adopting on
  * every change is O(changed) and `measured`/`handleBounds` survive for unchanged nodes for free.
  *
- * Returns the validated user nodes (to be stored as the canonical `state.nodes` array). The InternalNodes
- * live only in `nodeLookup`; `internals.userNode` references the exact user object stored in the array.
+ * Returns the validated user nodes (to be stored as the canonical `state.nodes` array) plus
+ * `hasSelectedNodes` (whether any adopted node is `selected`, surfaced by `adoptUserNodes` for free — the
+ * caller uses it to clear a stale `nodesSelectionActive`). The InternalNodes live only in `nodeLookup`;
+ * `internals.userNode` references the exact user object stored in the array.
  */
 export function adoptNodes<NodeType extends Node = Node>(
   nodes: NodeType[],
@@ -120,7 +122,7 @@ export function adoptNodes<NodeType extends Node = Node>(
   parentLookup: SystemParentLookup<InternalNode<NodeType>>,
   triggerError: State['hooks']['error']['trigger'],
   options?: CreateInternalNodesOptions,
-): NodeType[] {
+): { nodes: NodeType[]; hasSelectedNodes: boolean } {
   const validNodes: NodeType[] = [];
   for (let i = 0; i < nodes.length; ++i) {
     const node = nodes[i];
@@ -155,7 +157,7 @@ export function adoptNodes<NodeType extends Node = Node>(
     return node;
   });
 
-  adoptUserNodes(adoptable, nodeLookup, parentLookup, { ...options, checkEquality: true });
+  const { hasSelectedNodes } = adoptUserNodes(adoptable, nodeLookup, parentLookup, { ...options, checkEquality: true });
 
   // For range-extent nodes we fed `adoptUserNodes` a COPY (different reference): restore the original
   // `{ range, padding }` extent and re-point `internals.userNode` at the un-coerced node so
@@ -165,10 +167,11 @@ export function adoptNodes<NodeType extends Node = Node>(
     if (!range) {
       continue;
     }
+
     const internal = nodeLookup.get(node.id);
     if (internal) {
-      ;(internal as { extent?: CoordinateExtentRange }).extent = range
-      ;(internal.internals as { userNode: Node }).userNode = node;
+      ;(internal as { extent?: CoordinateExtentRange }).extent = range;
+      internal.internals.userNode = node;
     }
   }
 
@@ -178,7 +181,7 @@ export function adoptNodes<NodeType extends Node = Node>(
     }
   }
 
-  return validNodes;
+  return { nodes: validNodes, hasSelectedNodes };
 }
 
 /**

--- a/tests/cypress/component/2-vue-flow/nodesSelectionActive.cy.ts
+++ b/tests/cypress/component/2-vue-flow/nodesSelectionActive.cy.ts
@@ -1,0 +1,71 @@
+import type { VueFlowStore } from '@vue-flow/core';
+import { getStore } from '../../support/component';
+
+// `nodesSelectionActive` (the visual multi-selection box) only ever turns on via a user drag-select. If the
+// selected nodes later empty out (e.g. they were deleted), it must turn back off — otherwise a subsequent
+// programmatic select would wrongly render the `NodesSelection` rect. See xyflow/react #5727.
+describe('nodesSelectionActive auto-clear', () => {
+  let store: VueFlowStore;
+
+  function mount(nodes: { id: string; position: { x: number; y: number }; data: object; selected?: boolean }[]) {
+    cy.vueFlow({ fitView: false, nodes });
+    cy.then(() => {
+      store = getStore();
+    });
+  }
+
+  it('clears when the last selected node is removed', () => {
+    mount([{ id: '1', position: { x: 0, y: 0 }, data: {}, selected: true }]);
+
+    cy.then(() => {
+      // simulate the state left behind by a drag-select
+      store.nodesSelectionActive.value = true;
+      // re-commit nodes with nothing selected (mirrors deleting the selected node)
+      store.setNodes([{ id: '2', position: { x: 100, y: 100 }, data: {} }]);
+    });
+
+    cy.tryAssertion(() => {
+      expect(store.nodesSelectionActive.value, 'selection box cleared once no node is selected').to.eq(false);
+    });
+  });
+
+  it('does not clear while a selected node remains', () => {
+    mount([{ id: '1', position: { x: 0, y: 0 }, data: {}, selected: true }]);
+
+    cy.then(() => {
+      store.nodesSelectionActive.value = true;
+      // re-commit nodes while keeping the selection (adds a node, node 1 stays selected)
+      store.setNodes([
+        { id: '1', position: { x: 0, y: 0 }, data: {}, selected: true },
+        { id: '2', position: { x: 100, y: 100 }, data: {} },
+      ]);
+    });
+
+    cy.then(() => {
+      expect(store.nodesSelectionActive.value, 'selection box kept while a node is selected').to.eq(true);
+    });
+  });
+
+  it('does not revive the selection box for a later programmatic select', () => {
+    // the full #5727 repro: select → delete (box goes stale) → add + select a new node → box must stay off
+    mount([{ id: '1', position: { x: 0, y: 0 }, data: {}, selected: true }]);
+
+    cy.then(() => {
+      store.nodesSelectionActive.value = true;
+      store.setNodes([]); // delete the selected node → box clears
+    });
+
+    cy.tryAssertion(() => {
+      expect(store.nodesSelectionActive.value).to.eq(false);
+    });
+
+    cy.then(() => {
+      // add and immediately select a brand-new node
+      store.setNodes([{ id: '2', position: { x: 100, y: 100 }, data: {}, selected: true }]);
+    });
+
+    cy.then(() => {
+      expect(store.nodesSelectionActive.value, 'no stale selection box around the new node').to.eq(false);
+    });
+  });
+});


### PR DESCRIPTION
Ports [xyflow/xyflow#5727](https://github.com/xyflow/xyflow/pull/5727) (fixes xyflow#5726).

## The bug

`nodesSelectionActive` (the visual multi-selection rect drawn by `NodesSelection`) only ever turns **on** via a user drag-select. But it could get stuck `true` after the selected nodes were removed (e.g. deleted via a context menu). Then a later **programmatic** select would render the selection rect around that node, even though the user never drew a box around it.

Repro (matches the upstream issue):
1. Drag-select a node.
2. Delete it (now zero selected, but `nodesSelectionActive` stays `true`).
3. Add a new node and immediately select it → the `NodesSelection` rect wrongly appears around it.

## The fix

`commitNodes` is vue-flow's single node-write path (every `setNodes` / `addNodes` / `removeNodes` / `applyNodeChanges` / delete routes through it). It now reads the `hasSelectedNodes` flag that `@xyflow/system`'s `adoptUserNodes` **already computes** (our installed system `0.0.77` returns `{ nodesInitialized, hasSelectedNodes }`) and clears the box when the selection is empty:

```ts
state.nodesSelectionActive = state.nodesSelectionActive && hasSelectedNodes;
```

`adoptNodes` is extended to surface that flag (it previously discarded `adoptUserNodes`'s return) — no extra node iteration, matching the upstream perf note. `nodesSelectionActive` can only be turned *off* here, never on, so the user-drag-select path is untouched.

## Verification

- `vue-tsc` + lint clean; core builds.
- New `nodesSelectionActive.cy.ts` (real Chrome), 3 passing:
  - clears when the last selected node is removed
  - does **not** clear while a selected node remains (no false positives)
  - the full #5726 repro: select → delete → add+select a new node → no stale box
- Existing `selectionKeyCode` spec still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)