### PR TITLE
refactor(core)!: align node extent typing with @xyflow/system

### DIFF
--- a/.changeset/node-extent-system-alignment.md
+++ b/.changeset/node-extent-system-alignment.md
@@ -1,0 +1,8 @@
+---
+"@vue-flow/core": major
+---
+
+Align node `extent` typing with `@xyflow/system`:
+
+- Collapse the local `CoordinateExtent` type onto `@xyflow/system`'s (they were identical) — it's now re-exported from `@xyflow/system`.
+- Remove `CoordinateExtentRange` and the per-node "clamp to parent **with padding**" extent form (`extent: { range, padding }`). `node.extent` and the `nodeExtent` prop now accept exactly what the system understands: `'parent' | CoordinateExtent | null`. Use `extent: 'parent'` to clamp a child to its parent. This drops a vue-flow-only workaround that couldn't be cleanly typed against `@xyflow/system`; if padded clamping returns it'll be a system-level feature. To inset from the parent in the meantime, apply the offset yourself.

--- a/examples/vite/src/Nesting/Nesting.vue
+++ b/examples/vite/src/Nesting/Nesting.vue
@@ -93,10 +93,7 @@ onMounted(() => {
     if (node) {
       flow.value?.updateNode('999', {
         expandParent: false,
-        extent: {
-          range: 'parent',
-          padding: [10],
-        } as any,
+        extent: 'parent',
       });
     }
   });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -91,6 +91,7 @@ export {
   type Connection,
   ConnectionLineType,
   ConnectionMode,
+  type CoordinateExtent,
   type Dimensions,
   type EdgeRemoveChange,
   type EdgeSelectionChange,

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -8,8 +8,6 @@ import type {
 } from '@xyflow/system';
 import type {
   Actions,
-  CoordinateExtent,
-  CoordinateExtentRange,
   Edge,
   EdgeAddChange,
   EdgeLookup,
@@ -38,12 +36,10 @@ import { useViewportHelper } from '../composables';
 import {
   adoptNodes,
   applyChanges,
-  calcNextPosition,
   createAdditionChange,
   createEdgeRemoveChange,
   createNodeRemoveChange,
   createSelectionChange,
-  getExtent,
   getSelectionChanges,
   isDef,
   isInternalNode,
@@ -142,7 +138,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
   function commitNodes(nodes: NodeType[]) {
     const { nodes: adopted, hasSelectedNodes } = adoptNodes(nodes, systemNodeLookup, systemParentLookup, state.hooks.error.trigger, {
       nodeOrigin: state.nodeOrigin,
-      nodeExtent: Array.isArray(state.nodeExtent) ? (state.nodeExtent as CoordinateExtent) : undefined,
+      nodeExtent: state.nodeExtent,
       elevateNodesOnSelect: state.elevateNodesOnSelect,
     });
 
@@ -205,25 +201,6 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
    * graphs with child nodes — or when `forceFullPass` says inputs changed without a re-adoption.
    */
   function recomputeAbsolutePositions(forceFullPass = false) {
-    // `@xyflow/system` has no concept of vue-flow's `CoordinateExtentRange` (`{ range, padding }`) and
-    // its `isCoordinateExtent` treats any non-`'parent'`/non-nullish value as a coordinate-extent array,
-    // so it would index `extent[0]` on the range object and crash. Transiently coerce such extents to
-    // their `range` (`'parent'` or a plain `CoordinateExtent`, both system-understood) for the system
-    // pass and restore afterwards. The system clamp can't express the range `padding`, so it's re-applied
-    // separately in the padding-clamp pass below (after absolute positions are fresh).
-    // `node.extent` is typed `'parent' | CoordinateExtent | null` (deliberately narrow so `InternalNode`
-    // stays structurally assignable to system's `NodeBase`), but at runtime vue-flow also supports a
-    // `CoordinateExtentRange` ({ range, padding }) — see utils/drag.ts. Hence the localized casts: the
-    // type can't express this without breaking system compat. We restore the original extent after.
-    const coercedExtents: { node: InternalNode<NodeType>; extent: 'parent' | CoordinateExtent | null | undefined }[] = [];
-    for (const node of systemNodeLookup.values()) {
-      const extent = node.extent as CoordinateExtentRange | 'parent' | CoordinateExtent | null | undefined;
-      if (extent && typeof extent === 'object' && !Array.isArray(extent) && 'range' in extent) {
-        coercedExtents.push({ node, extent: node.extent });
-        node.extent = extent.range;
-      }
-    }
-
     // `adoptUserNodes` already computed the clamped `positionAbsolute` + `z` for every changed node
     // (reused nodes keep their still-valid values) and cascades parented nodes inline, so after a commit
     // the full pass is only needed when child nodes exist — a moved parent must cascade to REUSED
@@ -232,55 +209,9 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
     if (forceFullPass || systemParentLookup.size > 0) {
       updateAbsolutePositions(systemNodeLookup, systemParentLookup, {
         nodeOrigin: state.nodeOrigin,
-        nodeExtent: Array.isArray(state.nodeExtent) ? (state.nodeExtent as CoordinateExtent) : undefined,
+        nodeExtent: state.nodeExtent,
         elevateNodesOnSelect: state.elevateNodesOnSelect,
       });
-    }
-
-    for (const { node, extent } of coercedExtents) {
-      node.extent = extent;
-    }
-
-    // Apply the range `padding` the system clamp can't express. `updateAbsolutePositions` only understands
-    // `'parent'`/`CoordinateExtent` (we coerced `{ range, padding }` to its bare `range` above), so it
-    // clamps to the parent/extent bounds *without* the inset. Now that absolute positions are fresh on the
-    // lookup InternalNodes, re-clamp each padded node against the padded extent via the
-    // same `calcNextPosition`/`getExtent` math the keyboard-move path uses — restoring the padding the
-    // pre-system-migration NodeWrapper watcher used to apply. Idempotent (an in-bounds node is unchanged),
-    // and `expandParent` nodes are skipped (they grow the parent instead of being clamped into it).
-    for (const { node } of coercedExtents) {
-      if (node.expandParent) {
-        continue;
-      }
-
-      const parent = node.parentId ? systemNodeLookup.get(node.parentId) : undefined;
-
-      // The padding clamp needs measured dimensions: `getExtent` indexes into the computed extent array
-      // and would throw on the unmeasured fallback (the global extent may be undefined). Skip until the
-      // node — and, for a `'parent'` range, its parent — are measured; the next recompute (triggered by
-      // `updateNodeDimensions` once dimensions land) re-runs this.
-      if (!node.measured?.width || !node.measured?.height) {
-        continue;
-      }
-
-      const extent = node.extent as unknown as CoordinateExtentRange;
-      if (extent.range === 'parent' && (!parent?.measured?.width || !parent?.measured?.height)) {
-        continue;
-      }
-
-      const { position, computedPosition } = calcNextPosition(
-        node,
-        node.internals.positionAbsolute,
-        state.hooks.error.trigger,
-        state.nodeExtent,
-        parent,
-      );
-
-      node.position = position;
-      node.internals.positionAbsolute = computedPosition
-      // mirror the padding-clamped position onto the user node (the canonical array element) so v-model /
-      // getNodes reflect it (the InternalNode's `position` is internal-only otherwise).
-      ;(node.internals.userNode as Node).position = position;
     }
 
     syncLookups();
@@ -439,7 +370,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
           if (node.expandParent && node.parentId) {
             const parent = getInternalNode(node.parentId);
             let positionAbsolute = node.internals.positionAbsolute;
-            const extent = node.extent as CoordinateExtentRange | 'parent' | CoordinateExtent | null | undefined;
+            const extent = node.extent;
 
             if (extent === 'parent' && parent) {
               positionAbsolute = clampPositionToParent(positionAbsolute, dimensions, parent);
@@ -447,21 +378,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
             else if (Array.isArray(extent)) {
               positionAbsolute = clampPosition(positionAbsolute, extent, dimensions);
             }
-            else if (
-              extent
-              && typeof extent === 'object'
-              && 'range' in extent
-              && parent?.measured.width
-              && parent.measured.height
-            ) {
-              // vue-flow range form → its padded coordinate extent
-              positionAbsolute = clampPosition(
-                positionAbsolute,
-                getExtent(node, state.hooks.error.trigger, state.nodeExtent, parent),
-                dimensions,
-              );
-            }
-            else if (Array.isArray(state.nodeExtent)) {
+            else {
               positionAbsolute = clampPosition(positionAbsolute, state.nodeExtent, dimensions);
             }
 

--- a/packages/core/src/types/flow.ts
+++ b/packages/core/src/types/flow.ts
@@ -1,5 +1,5 @@
 import type { KeyFilter } from '@vueuse/core';
-import type { ColorMode, Connection, ConnectionMode, PanOnScrollMode, SelectionMode, SnapGrid, Viewport } from '@xyflow/system';
+import type { ColorMode, Connection, ConnectionMode, CoordinateExtent, PanOnScrollMode, SelectionMode, SnapGrid, Viewport } from '@xyflow/system';
 import type { CSSProperties } from 'vue';
 import type { VueFlowError } from '../utils';
 import type { EdgeChange, NodeChange } from './changes';
@@ -18,7 +18,7 @@ import type {
   NodeMouseEvent,
   SelectionChangeEvent,
 } from './hooks';
-import type { CoordinateExtent, CoordinateExtentRange, Node, NodeOrigin, NodeProps } from './node';
+import type { Node, NodeOrigin, NodeProps } from './node';
 import type { VueFlowInstance } from './store';
 import type { FitViewParams } from './zoom';
 
@@ -138,7 +138,7 @@ export interface FlowProps<NodeType extends Node = Node, EdgeType extends Edge =
   /** controlled viewport (`v-model:viewport`) — keeps the flow's transform in sync with the bound value */
   viewport?: Viewport;
   translateExtent?: CoordinateExtent;
-  nodeExtent?: CoordinateExtent | CoordinateExtentRange;
+  nodeExtent?: CoordinateExtent;
   /** origin of all nodes relative to their position — `[0, 0]` top-left, `[0.5, 0.5]` center, `[1, 1]` bottom-right */
   nodeOrigin?: NodeOrigin;
   /** light/dark/system — applies the resolved `light`/`dark` class to the flow container; `system` follows `prefers-color-scheme` @default 'light' */

--- a/packages/core/src/types/node.ts
+++ b/packages/core/src/types/node.ts
@@ -1,20 +1,7 @@
-import type { InternalNodeBase, NodeBase, Padding } from '@xyflow/system';
+import type { InternalNodeBase, NodeBase } from '@xyflow/system';
 import type { HTMLAttributes } from 'vue';
 import type { ClassValue, Styles } from './flow';
 import type { HandleElement } from './handle';
-
-/** Defined as [[x-from, y-from], [x-to, y-to]] */
-export type CoordinateExtent = [extentFrom: [fromX: number, fromY: number], extentTo: [toX: number, toY: number]];
-
-export interface CoordinateExtentRange {
-  range: 'parent' | CoordinateExtent;
-  /**
-   * Padding inside the parent's bounds (`@xyflow/system`'s `Padding`). A single value applies to all
-   * sides; the object form sets sides individually (`x`/`y` are horizontal/vertical shorthands). A `%`
-   * value resolves against the parent's width/height.
-   */
-  padding: Padding;
-}
 
 /**
  * Origin of a node relative to its position. `[0, 0]` is top-left, `[0.5, 0.5]` centers it, `[1, 1]` is bottom-right.
@@ -30,11 +17,7 @@ export interface NodeHandleBounds {
 }
 
 /**
- * User-facing node type — reuses `@xyflow/system`'s `NodeBase` (xyflow/react does
- * `Node = NodeBase & {…}`) plus vue-flow-specific fields. `extent` stays `NodeBase`'s narrow
- * `'parent' | CoordinateExtent | null` deliberately (so `InternalNode`/`Node` stay structurally
- * assignable to system's types); the richer `CoordinateExtentRange` is a runtime-only extension
- * handled with localized casts (see `store/actions.ts` `recomputeAbsolutePositions`).
+ * User-facing node type — reuses `@xyflow/system`'s `NodeBase`.
  */
 export type Node<
   NodeData extends Record<string, unknown> = Record<string, unknown>,
@@ -65,25 +48,12 @@ export type Node<
  * The enriched, store-internal node — what `nodeLookup`/`getInternalNode(id)`/`useInternalNode(id)` return,
  * once a user-provided `Node` has been processed by the store. Carries the user `Node`
  * (`internals.userNode`) plus the store-computed `internals.{positionAbsolute, z, handleBounds}` and
- * authoritative `measured`. Named to mirror xyflow/react's `InternalNode`, so the public split
- * (`getNode`/`v-model` = user `Node`, `getInternalNode` = `InternalNode`) reads the same across frameworks.
- *
- * Structurally assignable to `@xyflow/system`'s `InternalNodeBase<NodeType>` so we can hand `nodeLookup`
- * to `XYResizer` / `XYDrag` / `getHandlePosition` without casts. Read absolute position via
- * `internals.positionAbsolute`, z-index via `internals.z`, handle bounds via `internals.handleBounds`, and
- * dimensions via `measured`; the "is this a parent?" check lives on `parentLookup` (storage).
+ * authoritative `measured`.
  */
 export type InternalNode<NodeType extends Node = Node> = InternalNodeBase<NodeType>;
 
 /**
- * Props passed to custom node components, parameterized on a `NodeType` (xyflow/react convention:
- * `NodeProps<MyNode>`).
- *
- * Declared as a generic **interface** with indexed access (`NodeType['data']`), NOT a `Pick`/`Required`
- * **type alias**: `@vue/compiler-sfc`'s macro resolver can instantiate generic interfaces in
- * `defineProps<NodeProps<MyNode>>()` but cannot instantiate generic utility-type aliases — the alias
- * form silently fails to resolve. (Indexed access resolves even through `NodeType['type']` when the
- * underlying type is `@xyflow/system`'s conditional `NodeBase`.)
+ * Props passed to custom node components, parameterized on a `NodeType`.
  */
 export interface NodeProps<NodeType extends Node = Node> {
   id: string;

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -3,6 +3,7 @@ import type {
   ColorMode,
   Connection,
   ConnectionMode,
+  CoordinateExtent,
   Dimensions,
   HandleType,
   NodeConnection,
@@ -25,7 +26,7 @@ import type { DefaultEdgeOptions, Edge, EdgeReconnectable } from './edge';
 import type { FlowExportObject, FlowProps, OnBeforeDelete } from './flow';
 import type { ConnectingHandle, ValidConnectionFunc } from './handle';
 import type { FlowHooks, FlowHooksEmit, FlowHooksOn } from './hooks';
-import type { BuiltInNode, CoordinateExtent, CoordinateExtentRange, InternalNode, Node, NodeOrigin } from './node';
+import type { BuiltInNode, InternalNode, Node, NodeOrigin } from './node';
 
 export type NodeLookup<NodeType extends Node = Node> = Map<string, InternalNode<NodeType>>;
 
@@ -72,7 +73,7 @@ export interface State<NodeType extends Node = Node, EdgeType extends Edge = Edg
   defaultViewport: Partial<Viewport>;
   /** use setTranslateExtent action to change translateExtent */
   translateExtent: CoordinateExtent;
-  nodeExtent: CoordinateExtent | CoordinateExtentRange;
+  nodeExtent: CoordinateExtent;
   nodeOrigin: NodeOrigin;
   colorMode: ColorMode;
 
@@ -316,7 +317,7 @@ export interface Actions<NodeType extends Node = Node, EdgeType extends Edge = E
   /** apply translate extent to panzoom */
   setTranslateExtent: (translateExtent: CoordinateExtent) => void;
   /** apply extent to nodes */
-  setNodeExtent: (nodeExtent: CoordinateExtent | CoordinateExtentRange) => void;
+  setNodeExtent: (nodeExtent: CoordinateExtent) => void;
   setPaneClickDistance: (distance: number) => void;
   /** enable/disable node interaction (dragging, selecting etc) */
   setInteractive: (isInteractive: boolean) => void;

--- a/packages/core/src/utils/drag.ts
+++ b/packages/core/src/utils/drag.ts
@@ -1,54 +1,10 @@
-import type { PaddingWithUnit, XYPosition } from '@xyflow/system';
-import type { CoordinateExtent, CoordinateExtentRange, InternalNode, NodeDragItem, State } from '../types';
+import type { CoordinateExtent, XYPosition } from '@xyflow/system';
+import type { InternalNode, NodeDragItem, State } from '../types';
 import { clampPosition, getNodeDimensions } from '@xyflow/system';
 import { ErrorCode, VueFlowError } from '.';
 
-// Resolve one `PaddingWithUnit` against a reference length — `%` is relative, `px`/number is absolute.
-function resolvePadding(value: PaddingWithUnit | undefined, reference: number): number {
-  if (typeof value === 'number') {
-    return value;
-  }
-
-  if (!value) {
-    return 0;
-  }
-
-  const numeric = Number.parseFloat(value);
-
-  if (Number.isNaN(numeric)) {
-    return 0;
-  }
-
-  return value.endsWith('%') ? (numeric / 100) * reference : numeric;
-}
-
-// Resolve system `Padding` into absolute [top, right, bottom, left] within a parent of width × height.
-function getExtentPadding(
-  padding: CoordinateExtentRange['padding'],
-  width: number,
-  height: number,
-): [number, number, number, number] {
-  if (typeof padding === 'number' || typeof padding === 'string') {
-    return [resolvePadding(padding, height), resolvePadding(padding, width), resolvePadding(padding, height), resolvePadding(padding, width)];
-  }
-
-  return [
-    resolvePadding(padding.top ?? padding.y, height),
-    resolvePadding(padding.right ?? padding.x, width),
-    resolvePadding(padding.bottom ?? padding.y, height),
-    resolvePadding(padding.left ?? padding.x, width),
-  ];
-}
-
-function getParentExtent(
-  currentExtent: CoordinateExtentRange | 'parent',
-  node: InternalNode | NodeDragItem,
-  parent: InternalNode,
-): CoordinateExtent | false {
-  const [top, right, bottom, left] = typeof currentExtent !== 'string'
-    ? getExtentPadding(currentExtent.padding, parent.measured.width ?? 0, parent.measured.height ?? 0)
-    : [0, 0, 0, 0];
-
+// The absolute bounds of `parent` — the extent a child with `extent: 'parent'` is clamped to.
+function getParentExtent(parent: InternalNode): CoordinateExtent | false {
   if (
     parent
     && typeof parent.internals.positionAbsolute.x !== 'undefined'
@@ -57,10 +13,10 @@ function getParentExtent(
     && typeof parent.measured.height !== 'undefined'
   ) {
     return [
-      [parent.internals.positionAbsolute.x + left, parent.internals.positionAbsolute.y + top],
+      [parent.internals.positionAbsolute.x, parent.internals.positionAbsolute.y],
       [
-        parent.internals.positionAbsolute.x + parent.measured.width - right,
-        parent.internals.positionAbsolute.y + parent.measured.height - bottom,
+        parent.internals.positionAbsolute.x + parent.measured.width,
+        parent.internals.positionAbsolute.y + parent.measured.height,
       ],
     ];
   }
@@ -76,12 +32,9 @@ export function getExtent<T extends NodeDragItem | InternalNode>(
 ) {
   let currentExtent = item.extent || extent;
 
-  if (
-    (currentExtent === 'parent' || (!Array.isArray(currentExtent) && currentExtent?.range === 'parent'))
-    && !item.expandParent
-  ) {
+  if (currentExtent === 'parent' && !item.expandParent) {
     if (item.parentId && parent && item.measured.width && item.measured.height) {
-      const parentExtent = getParentExtent(currentExtent, item, parent);
+      const parentExtent = getParentExtent(parent);
 
       if (parentExtent) {
         currentExtent = parentExtent;
@@ -100,19 +53,6 @@ export function getExtent<T extends NodeDragItem | InternalNode>(
     currentExtent = [
       [currentExtent[0][0] + parentX, currentExtent[0][1] + parentY],
       [currentExtent[1][0] + parentX, currentExtent[1][1] + parentY],
-    ];
-  }
-  else if (currentExtent !== 'parent' && currentExtent?.range && Array.isArray(currentExtent.range)) {
-    const width = currentExtent.range[1][0] - currentExtent.range[0][0];
-    const height = currentExtent.range[1][1] - currentExtent.range[0][1];
-    const [top, right, bottom, left] = getExtentPadding(currentExtent.padding, width, height);
-
-    const parentX = parent?.internals.positionAbsolute.x || 0;
-    const parentY = parent?.internals.positionAbsolute.y || 0;
-
-    currentExtent = [
-      [currentExtent.range[0][0] + parentX + left, currentExtent.range[0][1] + parentY + top],
-      [currentExtent.range[1][0] + parentX - right, currentExtent.range[1][1] + parentY - bottom],
     ];
   }
 

--- a/packages/core/src/utils/store.ts
+++ b/packages/core/src/utils/store.ts
@@ -1,5 +1,6 @@
 import type {
   Connection,
+  CoordinateExtent,
   NodeConnection,
   NodeLookup as SystemNodeLookup,
   ParentLookup as SystemParentLookup,
@@ -7,8 +8,6 @@ import type {
 import type {
   Actions,
   ConnectionLookup,
-  CoordinateExtent,
-  CoordinateExtentRange,
   DefaultEdgeOptions,
   Edge,
   InternalNode,
@@ -142,38 +141,7 @@ export function adoptNodes<NodeType extends Node = Node>(
     validNodes.push(markRaw(toRaw(node)));
   }
 
-  // `@xyflow/system`'s `adoptUserNodes` (and the `clampPosition` it calls) only understand
-  // `'parent' | CoordinateExtent`. A vue-flow `CoordinateExtentRange` ({ range, padding }) extent would
-  // make `clampPosition` index `extent[0][0]` on the object and throw. Feed `adoptUserNodes` shallow
-  // copies whose extent is coerced to the bare `range`, then restore the original range+padding onto the
-  // adopted `InternalNode` below — the padding inset is applied later by `recomputeAbsolutePositions`.
-  const rangeExtents = new Map<string, CoordinateExtentRange>();
-  const adoptable = validNodes.map((node): NodeType => {
-    const extent = node.extent as CoordinateExtentRange | 'parent' | CoordinateExtent | null | undefined;
-    if (extent && typeof extent === 'object' && !Array.isArray(extent) && 'range' in extent) {
-      rangeExtents.set(node.id, extent);
-      return { ...node, extent: extent.range };
-    }
-    return node;
-  });
-
-  const { hasSelectedNodes } = adoptUserNodes(adoptable, nodeLookup, parentLookup, { ...options, checkEquality: true });
-
-  // For range-extent nodes we fed `adoptUserNodes` a COPY (different reference): restore the original
-  // `{ range, padding }` extent and re-point `internals.userNode` at the un-coerced node so
-  // `getNode`/`getNodes` surface the exact user object the array holds.
-  for (const node of validNodes) {
-    const range = rangeExtents.get(node.id);
-    if (!range) {
-      continue;
-    }
-
-    const internal = nodeLookup.get(node.id);
-    if (internal) {
-      ;(internal as { extent?: CoordinateExtentRange }).extent = range;
-      internal.internals.userNode = node;
-    }
-  }
+  const { hasSelectedNodes } = adoptUserNodes(validNodes, nodeLookup, parentLookup, { ...options, checkEquality: true });
 
   for (const node of validNodes) {
     if (node.parentId && !nodeLookup.has(node.parentId)) {

--- a/tests/cypress/component/2-vue-flow/expand-parent.cy.ts
+++ b/tests/cypress/component/2-vue-flow/expand-parent.cy.ts
@@ -1,10 +1,10 @@
 import type { VueFlowStore } from '@vue-flow/core';
 import { getStore } from '../../support/component';
 
-// Covers the `@xyflow/system` `handleExpandParent` integration (drag + measurement + the range-extent
-// padding clamp). Parent at the origin so a drag item's absolute position equals its parent-relative
+// Covers the `@xyflow/system` `handleExpandParent` integration (drag + measurement + the `extent: 'parent'`
+// clamp). Parent at the origin so a drag item's absolute position equals its parent-relative
 // position — keeps the assertions independent of the abs/rel convention in `updateNodePositions`.
-describe('expandParent + range-extent', () => {
+describe('expandParent + extent: parent', () => {
   let store: VueFlowStore;
 
   function mount(childExtra: Record<string, any> = {}, childPosition = { x: 10, y: 10 }) {
@@ -140,32 +140,6 @@ describe('expandParent + range-extent', () => {
           expect(parent.measured.width, 'parent not over-expanded').to.be.lessThan(230);
           // child is clamped to sit inside the parent (200 − child width ≈ 100)
           expect(child.internals.positionAbsolute.x, 'child clamped inside parent').to.be.lessThan(120);
-        },
-        { timeout: 3000 },
-      );
-    });
-  });
-
-  describe('range-extent padding clamps the child', () => {
-    // child placed far outside the parent, constrained to the parent inset by 10px on every side
-    beforeEach(() =>
-      mount({ extent: { range: 'parent', padding: 10 }, width: 20, height: 20, style: { width: '20px', height: '20px' } }, {
-        x: 200,
-        y: 200,
-      }),
-    );
-
-    it('clamps the child to the padded parent bounds', () => {
-      // child placed at (200,200) → clamped so its right/bottom edge sits at the parent's padded
-      // boundary: parent 100 − padding 10 − child width = max relative position.
-      cy.tryAssertion(
-        () => {
-          const child = store.getInternalNode('c')!;
-          const expected = 90 - child.measured.width; // 90 = parent (100) − padding (10)
-          expect(child.internals.positionAbsolute.x, 'clamped to padded bound x').to.be.closeTo(expected, 1);
-          expect(child.internals.positionAbsolute.y, 'clamped to padded bound y').to.be.closeTo(expected, 1);
-          // and it actually moved in from the original 200
-          expect(child.internals.positionAbsolute.x).to.be.lessThan(100);
         },
         { timeout: 3000 },
       );


### PR DESCRIPTION
Makes node `extent` exactly what `@xyflow/system` understands, dropping a vue-flow-only workaround that couldn't be cleanly typed.

## What

1. **Collapse `CoordinateExtent`** onto `@xyflow/system`'s (they were structurally identical — vue-flow's just had labeled tuple elements). Now re-exported from `@xyflow/system`.
2. **Drop `CoordinateExtentRange`** and the per-node "clamp to parent **with padding**" extent form (`extent: { range, padding }`). `node.extent` and the `nodeExtent` prop are now `'parent' | CoordinateExtent | null` — the system shape. Use `extent: 'parent'` to clamp to a parent.

## Why

The padded-extent form was a vue-flow-only extension. Typing `node.extent` to accept it breaks `Node extends NodeBase`, and typing `InternalNode` to accept it cascades to **43** type errors (every point where `nodeLookup` is handed to a system fn — `XYDrag`, `getNodesInside`, `getHandlePosition`, …), because `InternalNode` is deliberately kept structurally assignable to `@xyflow/system`'s `InternalNodeBase` for cast-free interop. So the feature was only reachable via `as any` (as the Nesting example was doing) and was propped up by a pile of workaround machinery:

- the adopt-time coerce-to-bare-`range` / restore-`{range,padding}` dance in `adoptNodes`,
- a second "padding re-clamp" pass in `recomputeAbsolutePositions`,
- padding resolution (`resolvePadding`/`getExtentPadding`) + range branches in `drag.ts`.

All of that drops. If padded clamping returns, it should be a system-level feature (so it flows through `@xyflow/system` like everything else). In the meantime, apply the inset yourself.

**Net ~230 lines removed.** `recomputeAbsolutePositions` keeps only its real job — cascading absolute positions to *reused* children when a parent moves, plus syncing the system lookup into the reactive one (both unrelated to padding).

## Breaking changes

- `CoordinateExtentRange` removed from the public API.
- `node.extent` / `nodeExtent` no longer accept `{ range, padding }`.

## Verification

- `vue-tsc` + lint clean; core builds (bundle ~2KB smaller).
- `expand-parent` (4), `parentExtentResize` (1), `drag` (1) specs green — `extent: 'parent'` clamping + nested-drag still work. The `range-extent padding` test block (which exercised the removed feature) was removed; the `Nesting` example switched from `{ range: 'parent', padding } as any` to `extent: 'parent'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)