### PR TITLE
refactor(core): improve useNodesData return type with DistributivePick

### DIFF
--- a/.changeset/usenodesdata-distributive-pick.md
+++ b/.changeset/usenodesdata-distributive-pick.md
@@ -1,0 +1,14 @@
+---
+"@vue-flow/core": patch
+---
+
+Improve `useNodesData`'s return type (mirrors xyflow/react & xyflow/svelte). It now uses `@xyflow/system`'s `DistributivePick` instead of a merged object type, so when you pass a union node type the result is a discriminated union — checking `.type` narrows `.data`:
+
+```ts
+const node = useNodesData<MyNode>(id) // MyNode = TextNode | NumberNode
+if (node.value?.type === 'text') {
+  node.value.data.text // narrowed to TextNode's data
+}
+```
+
+For a single (non-union) node type the result is unchanged.

--- a/packages/core/src/composables/useNodesData.ts
+++ b/packages/core/src/composables/useNodesData.ts
@@ -1,14 +1,13 @@
+import type { DistributivePick } from '@xyflow/system';
 import type { ComputedRef, MaybeRefOrGetter } from 'vue';
 import type { InternalNode, Node } from '../types';
 import { computed, toValue } from 'vue';
 import { warn } from '../utils';
 import { useVueFlow } from './useVueFlow';
 
-interface NodeData<NodeType extends Node = InternalNode> {
-  id: string;
-  type: NodeType['type'];
-  data: NonNullable<NodeType['data']>;
-}
+// `DistributivePick` (over `Pick`) distributes across a union `NodeType`, so the result is a discriminated
+// union — checking `.type` narrows `.data`. Mirrors xyflow/react & xyflow/svelte.
+type NodeData<NodeType extends Node = InternalNode> = DistributivePick<NodeType, 'id' | 'type' | 'data'>;
 
 /**
  * Composable for receiving data of one or multiple nodes


### PR DESCRIPTION
Ports [xyflow/xyflow#5703](https://github.com/xyflow/xyflow/pull/5703) — narrow `useNodesData`'s result by node type.

## What

`useNodesData`'s return type now uses `@xyflow/system`'s `DistributivePick<NodeType, 'id' | 'type' | 'data'>` instead of a merged object type. When you pass a **union** node type, the result is a discriminated union, so checking `.type` narrows `.data`:

```ts
type MyNode = TextNode | NumberNode
const node = useNodesData<MyNode>(id)
if (node.value?.type === 'text') {
  node.value.data.text // ✅ narrowed to TextNode's data
}
```

Before, the local return type was `{ id; type: NodeType['type']; data: NonNullable<NodeType['data']> }` — over a union, `type` and `data` became *independent* unions, so a `.type` check couldn't narrow `.data`.

## How

vue-flow's `useNodesData` stays Vue-specific (`MaybeRefOrGetter` params, `ComputedRef` returns, the extra `guard` overload). The only change is the internal `NodeData<NodeType>` return type:

```ts
type NodeData<NodeType extends Node = InternalNode> = DistributivePick<NodeType, 'id' | 'type' | 'data'>;
```

`DistributivePick` ships in our installed `@xyflow/system` (`0.0.77`). For a single (non-union) node type, `DistributivePick<T, K>` ≡ `Pick<T, K>`, so existing usage is unchanged — hence `patch`.

## Verification

- `vue-tsc` + lint clean; core builds.
- Type-checked the narrowing with a throwaway `@ts-expect-error` fixture: after `node.value?.type === 'text'`, `data.text` resolves and `data.value` (the other member's field) errors — confirming the discriminated-union narrowing.
- `useNodesData.cy.ts` (3 tests) green — runtime unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)