### PR TITLE
perf(core): skip unselected nodes/edges in removeSelected*

### DIFF
--- a/.changeset/skip-unselected-on-remove.md
+++ b/.changeset/skip-unselected-on-remove.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+`removeSelectedNodes` / `removeSelectedEdges` now only emit changes for nodes/edges that are actually selected, instead of one deselect change per element. This avoids re-committing and re-rendering every node/edge on an unselect — most noticeably on drag start with `selectNodesOnDrag: false`. Mirrors xyflow/react #5682.

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -440,19 +440,25 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
   const removeSelectedNodes: Actions<NodeType>['removeSelectedNodes'] = (nodes) => {
     const nodesToUnselect = nodes || state.nodes;
 
-    // emit select=false changes only — `applyNodeChanges` applies them immutably + re-adopts. (No in-place
-    // `n.selected = false`: it would keep the node's reference, so the re-adopt would reuse the stale entry.)
-    const nodeChanges = nodesToUnselect.map(n => createSelectionChange(n.id, false));
+    // Emit select=false changes only for nodes that ARE selected — skipping the rest avoids re-committing
+    // (and re-rendering) every node on an unselect, e.g. on drag start with `selectNodesOnDrag: false`
+    // (xyflow/react #5682). `applyNodeChanges` applies them immutably + re-adopts (no in-place
+    // `n.selected = false`: it would keep the node's reference, so the re-adopt would reuse the stale entry).
+    const nodeChanges = nodesToUnselect.filter(n => n.selected).map(n => createSelectionChange(n.id, false));
 
-    state.hooks.nodesChange.trigger(nodeChanges);
+    if (nodeChanges.length) {
+      state.hooks.nodesChange.trigger(nodeChanges);
+    }
   };
 
   const removeSelectedEdges: Actions<NodeType, EdgeType>['removeSelectedEdges'] = (edges) => {
     const edgesToUnselect = edges || state.edges;
 
-    const edgeChanges = edgesToUnselect.map(e => createSelectionChange(e.id, false));
+    const edgeChanges = edgesToUnselect.filter(e => e.selected).map(e => createSelectionChange(e.id, false));
 
-    state.hooks.edgesChange.trigger(edgeChanges);
+    if (edgeChanges.length) {
+      state.hooks.edgesChange.trigger(edgeChanges);
+    }
   };
 
   const setMinZoom: Actions<NodeType>['setMinZoom'] = (minZoom) => {

--- a/tests/cypress/component/1-store/nodes/removeSelectedNodes.cy.ts
+++ b/tests/cypress/component/1-store/nodes/removeSelectedNodes.cy.ts
@@ -52,3 +52,45 @@ describe('Store Action: `removeSelectedNodes`', () => {
     }, 1);
   });
 });
+
+// xyflow/react #5682: unselecting must only touch nodes that are actually selected, so an unselect
+// (e.g. drag start with `selectNodesOnDrag: false`) doesn't re-commit/re-render every node.
+describe('Store Action: `removeSelectedNodes` skips unselected nodes', () => {
+  let store: VueFlowStore;
+
+  beforeEach(() => {
+    cy.vueFlow({ nodes, edges });
+    cy.then(() => {
+      store = getStore();
+    });
+  });
+
+  it('fires no node changes when nothing is selected', () => {
+    cy.then(() => {
+      let changeCalls = 0;
+      store.onNodesChange(() => changeCalls++);
+
+      store.removeSelectedNodes();
+
+      expect(changeCalls, 'no nodesChange fired when nothing is selected').to.eq(0);
+    });
+  });
+
+  it('emits a deselect change only for the selected node', () => {
+    cy.then(() => {
+      store.addSelectedNodes([store.nodes.value[0]]);
+
+      // register the spy after selecting, so it only captures the `removeSelectedNodes` emission
+      let captured: { id: string; selected?: boolean }[] = [];
+      store.onNodesChange((changes) => {
+        captured = changes as typeof captured;
+      });
+
+      store.removeSelectedNodes();
+
+      expect(captured, 'one deselect change for the selected node only').to.have.length(1);
+      expect(captured[0].id).to.eq(store.nodes.value[0].id);
+      expect(captured[0].selected).to.eq(false);
+    });
+  });
+});


### PR DESCRIPTION
Ports [xyflow/xyflow#5682](https://github.com/xyflow/xyflow/pull/5682) — avoid re-rendering everything on an unselect.

## The problem

`removeSelectedNodes` / `removeSelectedEdges` mapped over **every** node/edge and emitted a `select=false` change for each — even the ones already unselected:

```ts
const nodeChanges = nodesToUnselect.map(n => createSelectionChange(n.id, false));
state.hooks.nodesChange.trigger(nodeChanges);
```

Since these run on drag start (`Pane` calls `removeSelectedNodes()` / `removeSelectedEdges()` before a selection drag), this re-committed and re-rendered the whole graph on every drag start when `selectNodesOnDrag: false` — the perf issue in xyflow#1876.

## The fix

Filter to the elements that are **actually selected**, and skip the trigger entirely when there's nothing to change:

```ts
const nodeChanges = nodesToUnselect.filter(n => n.selected).map(n => createSelectionChange(n.id, false));
if (nodeChanges.length) {
  state.hooks.nodesChange.trigger(nodeChanges);
}
```

The length guard matters more here than upstream: in vue-flow an empty `nodesChange` still flows through `applyNodeChanges` → `commitNodes` (re-adopt + sync), so emitting nothing is what actually avoids the work. (vue-flow keeps its immutable approach — no in-place `selected = false`, which would let the re-adopt reuse the stale node by reference.)

## Verification

- `vue-tsc` + lint clean; core builds.
- `removeSelectedNodes.cy.ts` extended (now 4): existing correctness intact + two new — `removeSelectedNodes()` with nothing selected fires **no** `nodesChange`, and with one selected node emits exactly **one** deselect change for it.
- `removeSelectedEdges`, `selectionSync`, `addSelectedElements`, `selectionKeyCode` specs all green — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)