### PR TITLE
feat(core): expose raw pointer position on connection

### DIFF
--- a/.changeset/connection-pointer.md
+++ b/.changeset/connection-pointer.md
@@ -1,0 +1,8 @@
+---
+"@vue-flow/core": minor
+---
+
+Expose the raw pointer position during a connection (mirrors xyflow/react & xyflow/svelte, "pass current pointer position to connection"):
+
+- Custom connection-line components (`#connection-line`) now receive a `pointer` prop — the unsnapped pointer position in flow coordinates, distinct from `toX`/`toY` (which snap to the hovered handle).
+- `useConnection().pointer` is now the raw pointer position. Previously it tracked the snapped end (it was aliased to the connection's `to`); the snapped end is still available via `to` / `toHandle`.

--- a/packages/core/src/components/ConnectionLine/index.ts
+++ b/packages/core/src/components/ConnectionLine/index.ts
@@ -26,7 +26,9 @@ const ConnectionLine = defineComponent({
 
     const toNode = computed(() => getInternalNode(connectionEndHandle.value?.nodeId) ?? null);
 
-    const toXY = computed(() => {
+    // `connectionPosition` holds the raw pointer (screen space); convert to flow space for the line + the
+    // custom connection-line component. The line END snaps to the hovered handle (below) when there is one.
+    const pointer = computed(() => {
       return {
         x: (connectionPosition.value.x - viewport.value.x) / viewport.value.zoom,
         y: (connectionPosition.value.y - viewport.value.y) / viewport.value.zoom,
@@ -87,6 +89,10 @@ const ConnectionLine = defineComponent({
         return null;
       }
 
+      // snap the line end to the hovered handle when there is one; otherwise follow the raw pointer
+      const { x: toX, y: toY }
+        = toHandle && toNode.value ? getHandlePosition(toNode.value, toHandle, toPosition) : pointer.value;
+
       const type = connectionLineOptions.value.type ?? ConnectionLineType.Bezier;
 
       let dAttr = '';
@@ -95,8 +101,8 @@ const ConnectionLine = defineComponent({
         sourceX: fromX,
         sourceY: fromY,
         sourcePosition: fromPosition,
-        targetX: toXY.value.x,
-        targetY: toXY.value.y,
+        targetX: toX,
+        targetY: toY,
         targetPosition: toPosition,
       };
 
@@ -116,7 +122,7 @@ const ConnectionLine = defineComponent({
         ;[dAttr] = getSimpleBezierPath(pathParams);
       }
       else {
-        dAttr = `M${fromX},${fromY} ${toXY.value.x},${toXY.value.y}`;
+        dAttr = `M${fromX},${fromY} ${toX},${toY}`;
       }
 
       return h(
@@ -130,8 +136,8 @@ const ConnectionLine = defineComponent({
                 fromX,
                 fromY,
                 fromPosition,
-                toX: toXY.value.x,
-                toY: toXY.value.y,
+                toX,
+                toY,
                 toPosition,
                 fromNode: fromNode.value,
                 fromHandle,
@@ -140,6 +146,7 @@ const ConnectionLine = defineComponent({
                 markerEnd: markerEnd.value,
                 markerStart: markerStart.value,
                 connectionStatus: connectionStatus.value,
+                pointer: pointer.value,
               })
             : h('path', {
                 'd': dAttr,

--- a/packages/core/src/composables/useHandle.ts
+++ b/packages/core/src/composables/useHandle.ts
@@ -148,8 +148,11 @@ export function useHandle({
               y: state.to.y,
             });
           }
+          // `connectionPosition` tracks the raw pointer (not the snapped `to`): `useConnection` derives the
+          // snapped end from `connectionEndHandle`, and the connection line snaps via the same handle, so
+          // storing the raw pointer here surfaces it as `pointer` (xyflow/react #5594/#5578).
           updateConnection(
-            state.to,
+            state.pointer,
             state.toHandle
               ? ({
                   nodeId: state.toHandle.nodeId,

--- a/packages/core/src/types/connection.ts
+++ b/packages/core/src/types/connection.ts
@@ -104,6 +104,8 @@ export interface ConnectionLineProps {
   markerEnd?: string;
   /** status of the connection (valid, invalid) */
   connectionStatus: ConnectionStatus | null;
+  /** the raw pointer position in flow coordinates (unsnapped, unlike `toX`/`toY`) */
+  pointer: XYPosition;
 }
 
 export type ConnectionLookup = Map<string, Map<string, NodeConnection>>;

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -98,6 +98,7 @@ export interface State<NodeType extends Node = Node, EdgeType extends Edge = Edg
   connectionStartHandle: ConnectingHandle | null;
   connectionEndHandle: ConnectingHandle | null;
   connectionClickStartHandle: ConnectingHandle | null;
+  /** the raw pointer position during a connection drag (screen coords); the snapped end is `connectionEndHandle` */
   connectionPosition: XYPosition;
   connectionRadius: number;
   connectionDragThreshold: number;

--- a/tests/cypress/component/2-vue-flow/customConnectionLine.cy.ts
+++ b/tests/cypress/component/2-vue-flow/customConnectionLine.cy.ts
@@ -7,7 +7,7 @@ const connectionLineId = 'test-custom-connection-line';
 describe('Custom Connection Line', () => {
   it('renders a custom connection line component', () => {
     const CustomConnectionLine = defineComponent<ConnectionLineProps>({
-      props: ['fromNode', 'fromHandle', 'toNode', 'toHandle', 'fromX', 'fromY', 'toX', 'toY'] as any,
+      props: ['fromNode', 'fromHandle', 'toNode', 'toHandle', 'fromX', 'fromY', 'toX', 'toY', 'pointer'] as any,
       emits: ['change'],
       setup(props, { emit }) {
         watch(
@@ -18,6 +18,9 @@ describe('Custom Connection Line', () => {
               sourceHandleId: currProps.fromHandle?.id ?? null,
               targetNodeId: currProps.toNode?.id,
               targetHandleId: currProps.toHandle?.id ?? null,
+              // the raw pointer + the (snapped) line end must be finite flow-space coordinates
+              pointerIsFinite: Number.isFinite(currProps.pointer?.x) && Number.isFinite(currProps.pointer?.y),
+              toIsFinite: Number.isFinite(currProps.toX) && Number.isFinite(currProps.toY),
             });
           },
           { immediate: true, deep: true },
@@ -94,6 +97,8 @@ describe('Custom Connection Line', () => {
       sourceHandleId: null,
       targetNodeId: '2',
       targetHandleId: null,
+      pointerIsFinite: true,
+      toIsFinite: true,
     });
 
     // finish the drag (mouseup over the target) → line removed, edge committed


### PR DESCRIPTION
Ports [xyflow/xyflow#5594](https://github.com/xyflow/xyflow/pull/5594) / [#5578](https://github.com/xyflow/xyflow/pull/5578) (same change, "pass current pointer position to connection").

## What

The raw, **unsnapped** pointer position during a connection drag is now exposed:

- Custom connection-line components (`<template #connection-line>`) receive a new `pointer` prop — the pointer in flow coordinates, distinct from `toX`/`toY` (which snap to the hovered handle).
- `useConnection().pointer` is now the raw pointer too.

## Why this isn't a one-liner

The **system** parts already shipped in our installed `@xyflow/system` (`0.0.77`): `pointer` on the connection state, and the removal of the "skip update when snapped to the same handle" early-return (so the pointer keeps flowing while snapped).

But vue-flow's `useConnection().pointer` already *existed* — and was wrong: the `useHandle` adapter fed `connectionPosition` the connection's snapped `to`, and `pointer` aliased it. So while snapped, `pointer` returned the handle position, not the cursor.

The fix makes `connectionPosition` the **raw pointer** and lets the connection line snap its end via the hovered `connectionEndHandle` — using the same `getHandlePosition` the `from` end already uses — instead of relying on a pre-snapped position. That:
- auto-corrects `useConnection().pointer` (and leaves `to` / `toHandle` unchanged: `to` already derives the snapped end from `connectionEndHandle`),
- keeps the rendered line snapping to handles (the snapped end is now computed from handle bounds in flow space, equivalent to the previous screen round-trip),
- and surfaces `pointer` to the custom component.

## Verification

- `vue-tsc` + lint clean; core builds.
- `customConnectionLine.cy.ts` extended: during a real drag onto node 2 it asserts the line renders, the custom component resolves `targetNodeId: '2'` (snap detection intact), and **both** `pointer` and the snapped `toX/toY` arrive as finite flow-space coordinates.
- `connect.cy.ts` (default connection line, drag-to-connect) green — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)