### PR TITLE
fix(core): only start a pane selection past the click threshold

### DIFF
--- a/.changeset/selection-click-vs-drag.md
+++ b/.changeset/selection-click-vs-drag.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+A plain click on the pane no longer opens a selection box or fires `selectionStart`/`selectionEnd`. The selection (clearing the current selection + `selectionStart`) now begins only once the pointer moves past the click threshold (`paneClickDistance`, or immediately while the selection key is held), and `nodesSelectionActive` / `selectionEnd` only update when a real selection drag happened — instead of resetting on every pointer-down and activating on every pointer-up. Mirrors xyflow/react #5593.

--- a/packages/core/src/container/Pane/Pane.vue
+++ b/packages/core/src/container/Pane/Pane.vue
@@ -29,6 +29,7 @@ const {
   defaultEdgeOptions,
   connectionStartHandle,
   panOnDrag,
+  paneClickDistance,
   autoPanOnSelection,
   autoPanSpeed,
 } = storeToRefs(useStore());
@@ -138,8 +139,9 @@ function onPointerDown(event: PointerEvent) {
   selectionInProgress = false;
   autoPanStarted = false;
 
-  removeSelectedNodes();
-  removeSelectedEdges();
+  // the selection (resetting the current selection + `selectionStart`) only begins once the pointer moves
+  // past the click threshold — see `onPointerMove`. Resetting here would clear the selection on a plain
+  // click and open a selection box for it (xyflow/react #5593).
 
   // store the origin in flow coordinates so it stays anchored to the canvas while auto-panning
   const flowStart = pointToRendererPoint({ x, y }, transform.value);
@@ -152,8 +154,6 @@ function onPointerDown(event: PointerEvent) {
     x,
     y,
   };
-
-  emits.selectionStart(event);
 }
 
 // Recompute the selection rect (and the selected nodes/edges) from the current pointer position. Called
@@ -247,10 +247,28 @@ function onPointerMove(event: PointerEvent) {
     return;
   }
 
-  selectionInProgress = true;
-
   const { x: mouseX, y: mouseY } = getEventPosition(event, containerBounds.value);
   lastPointerPosition = { x: mouseX, y: mouseY };
+
+  // begin the selection only once the pointer has moved past the click threshold — so a plain click
+  // neither resets the current selection nor opens a selection box (xyflow/react #5593). Holding the
+  // selection key starts immediately (`requiredDistance` 0). `startX`/`startY` are flow coords, so compare
+  // against the start in screen space.
+  if (!selectionInProgress) {
+    const screenStart = rendererPointToPoint({ x: userSelectionRect.value.startX, y: userSelectionRect.value.startY }, transform.value);
+    const requiredDistance = selectionKeyPressed ? 0 : paneClickDistance.value;
+    const distance = Math.hypot(mouseX - screenStart.x, mouseY - screenStart.y);
+
+    if (distance <= requiredDistance) {
+      return;
+    }
+
+    removeSelectedNodes();
+    removeSelectedEdges();
+    emits.selectionStart(event);
+  }
+
+  selectionInProgress = true;
 
   if (!autoPanStarted) {
     autoPan();
@@ -275,9 +293,13 @@ function onPointerUp(event: PointerEvent) {
 
   userSelectionActive.value = false;
   userSelectionRect.value = null;
-  nodesSelectionActive.value = selectedNodeIds.value.size > 0;
 
-  emits.selectionEnd(event);
+  // only a real selection drag (not a plain click) updates the selection box / emits `selectionEnd`
+  // (xyflow/react #5593)
+  if (selectionInProgress) {
+    nodesSelectionActive.value = selectedNodeIds.value.size > 0;
+    emits.selectionEnd(event);
+  }
 
   // If the user kept holding the selectionKey during the selection,
   // we need to reset the selectionInProgress, so the next click event is not prevented

--- a/tests/cypress/component/2-vue-flow/selectionClickVsDrag.cy.ts
+++ b/tests/cypress/component/2-vue-flow/selectionClickVsDrag.cy.ts
@@ -1,0 +1,82 @@
+import type { VueFlowStore } from '@vue-flow/core';
+import { getStore } from '../../support/component';
+
+// xyflow/react #5593: a plain pane click must not open a selection box (nor emit selectionStart/End) —
+// only a real drag past the click threshold begins a selection.
+describe('pane selection: click vs drag', () => {
+  let store: VueFlowStore;
+
+  // Pane calls `setPointerCapture` on pointerdown, which throws on synthetic pointer events — neutralize it.
+  beforeEach(() => {
+    cy.window().then((win) => {
+      win.Element.prototype.setPointerCapture = () => {};
+      win.Element.prototype.releasePointerCapture = () => {};
+    });
+  });
+
+  // `selectionKeyCode: true` + `panOnDrag: false` puts the pane in selection mode without a held key.
+  function mountSelecting() {
+    cy.vueFlow({
+      fitView: false,
+      panOnDrag: false,
+      selectionKeyCode: true,
+      nodes: [{ id: '1', position: { x: 60, y: 60 }, data: {} }],
+    });
+    cy.then(() => {
+      store = getStore();
+    });
+  }
+
+  it('a plain click neither opens a selection box nor emits selectionStart/End', () => {
+    mountSelecting();
+
+    let starts = 0;
+    let ends = 0;
+    cy.then(() => {
+      store.onSelectionStart(() => starts++);
+      store.onSelectionEnd(() => ends++);
+    });
+
+    cy.window().then((win) => {
+      cy.get('.vue-flow__pane')
+        .should('exist')
+        // pointer down + up at the same spot — no movement
+        .trigger('pointerdown', { button: 0, clientX: 200, clientY: 200, force: true, view: win })
+        .trigger('pointerup', { button: 0, clientX: 200, clientY: 200, force: true, view: win });
+    });
+
+    cy.then(() => {
+      expect(starts, 'selectionStart not emitted on a click').to.eq(0);
+      expect(ends, 'selectionEnd not emitted on a click').to.eq(0);
+      expect(store.nodesSelectionActive.value, 'no selection box opened').to.eq(false);
+      expect(store.getSelectedNodes.value, 'nothing selected').to.have.length(0);
+    });
+  });
+
+  it('a drag opens a selection box, selects covered nodes and emits selectionStart/End', () => {
+    mountSelecting();
+
+    let starts = 0;
+    let ends = 0;
+    cy.then(() => {
+      store.onSelectionStart(() => starts++);
+      store.onSelectionEnd(() => ends++);
+    });
+
+    cy.window().then((win) => {
+      cy.get('.vue-flow__pane')
+        .should('exist')
+        .trigger('pointerdown', { button: 0, clientX: 200, clientY: 200, force: true, view: win })
+        // drag back over node 1 (at flow 60,60; viewport is identity without fitView)
+        .trigger('pointermove', { clientX: 40, clientY: 40, force: true, view: win })
+        .trigger('pointerup', { button: 0, clientX: 40, clientY: 40, force: true, view: win });
+    });
+
+    cy.then(() => {
+      expect(starts, 'selectionStart emitted once on a drag').to.eq(1);
+      expect(ends, 'selectionEnd emitted once on a drag').to.eq(1);
+      expect(store.nodesSelectionActive.value, 'selection box opened').to.eq(true);
+      expect(store.getSelectedNodes.value.map(n => n.id), 'node covered by the box is selected').to.deep.eq(['1']);
+    });
+  });
+});

--- a/tests/cypress/component/2-vue-flow/selectionClickVsDrag.cy.ts
+++ b/tests/cypress/component/2-vue-flow/selectionClickVsDrag.cy.ts
@@ -20,7 +20,9 @@ describe('pane selection: click vs drag', () => {
       fitView: false,
       panOnDrag: false,
       selectionKeyCode: true,
-      nodes: [{ id: '1', position: { x: 60, y: 60 }, data: {} }],
+      // small + fully inside the drag rect (40,40)-(200,200) so it's selected regardless of when the node
+      // measures (an unmeasured 0-size node and a measured 20×20 node are both inside → no flake)
+      nodes: [{ id: '1', position: { x: 60, y: 60 }, data: {}, width: 20, height: 20, style: { width: '20px', height: '20px' } }],
     });
     cy.then(() => {
       store = getStore();

--- a/tests/cypress/component/2-vue-flow/selectionClickVsDrag.cy.ts
+++ b/tests/cypress/component/2-vue-flow/selectionClickVsDrag.cy.ts
@@ -20,9 +20,9 @@ describe('pane selection: click vs drag', () => {
       fitView: false,
       panOnDrag: false,
       selectionKeyCode: true,
-      // small + fully inside the drag rect (40,40)-(200,200) so it's selected regardless of when the node
-      // measures (an unmeasured 0-size node and a measured 20×20 node are both inside → no flake)
-      nodes: [{ id: '1', position: { x: 60, y: 60 }, data: {}, width: 20, height: 20, style: { width: '20px', height: '20px' } }],
+      // `width`/`height` make the node a known 20×20 (they seed `measured` + the DOM size) sitting fully
+      // inside the drag rect (40,40)-(200,200), so the drag deterministically selects it — no measurement race
+      nodes: [{ id: '1', position: { x: 60, y: 60 }, data: {}, width: 20, height: 20 }],
     });
     cy.then(() => {
       store = getStore();


### PR DESCRIPTION
Ports [xyflow/xyflow#5593](https://github.com/xyflow/xyflow/pull/5593) ("Fix/selection pointerup").

## The problem

vue-flow's `Pane` reset the selection (`removeSelectedNodes`/`removeSelectedEdges`) **and** emitted `selectionStart` on every pointer-**down**, then set `nodesSelectionActive` on every pointer-**up** — with no `paneClickDistance` gate. So a plain click on the pane behaved like the start/end of a selection: it cleared the current selection and could flip the selection-box state, even though the user never dragged.

## The fix

Mirror RF #5593 — move the selection start into `onPointerMove`, gated by distance:

- **pointer-down**: only sets up `userSelectionRect` + captures the pointer. No reset, no `selectionStart`.
- **pointer-move**: once the pointer travels past `requiredDistance` (`selectionKeyPressed ? 0 : paneClickDistance`), it resets the current selection, emits `selectionStart`, and marks the selection in progress. A click that never moves does neither.
- **pointer-up**: `nodesSelectionActive` and `selectionEnd` only update when a selection drag actually happened (`selectionInProgress`); a plain click still deselects via the existing pane-click path.

vue-flow previously ignored `paneClickDistance` in the selection path entirely — it's now respected (the distance is measured in screen space against the flow-coord `startX/startY` the auto-pan anchoring stores). Composes cleanly with `autoPanOnSelection` (#2117): auto-pan only kicks in once the selection actually starts.

## Verification

- `vue-tsc` + lint clean; core builds.
- New `selectionClickVsDrag.cy.ts` (real Chrome): a plain click emits **no** `selectionStart`/`selectionEnd`, opens no box, selects nothing; a drag emits both once, opens the box, and selects the covered node.
- `selectionKeyCode`, `autoPanOnSelection`, `selectionSync`, `addSelectedElements`, `connect` specs all green — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)