### PR TITLE
feat(core)!: add selectionOnDrag prop, drop selectionKeyCode={true}

### DIFF
--- a/.changeset/selection-on-drag.md
+++ b/.changeset/selection-on-drag.md
@@ -1,0 +1,16 @@
+---
+"@vue-flow/core": major
+---
+
+Add an explicit `selectionOnDrag` prop and drop the `selectionKeyCode={true}` overload (aligns with xyflow/react & xyflow/svelte).
+
+Drawing a selection box on a plain pane drag (no key held) used to be expressed by setting `selectionKeyCode` to `true`, which overloaded the key-code prop. It's now its own boolean prop:
+
+```vue
+<!-- before -->
+<VueFlow :selection-key-code="true" :pan-on-drag="false" />
+<!-- after -->
+<VueFlow :selection-on-drag="true" :pan-on-drag="false" />
+```
+
+`selectionKeyCode` is once again just the key you hold to select (default `'Shift'`). As part of this, `selectionOnDrag` is threaded to the pan/zoom instance so `paneClick` fires while selecting on drag (it was previously swallowed by d3-zoom's click handling — xyflow/react #5572).

--- a/docs/src/guide/migration.md
+++ b/docs/src/guide/migration.md
@@ -336,6 +336,20 @@ The old aggregate `--vf-node-color` (which drove border + box-shadow + handle at
 
 **Uniform node accents.** The built-in `input`/`output` node types no longer have blue/pink accent borders — every default node type uses the same neutral `#1a192b` border (matching `@xyflow/react`). Re-add per-type colors with your own CSS if you want them.
 
+## 15. `selectionKeyCode={true}` → `selectionOnDrag`
+
+Drawing a selection box on a plain drag (no key held) used to be expressed by setting `selectionKeyCode` to `true`. That overloaded the key-code prop and was easy to misread. It's now an explicit boolean prop, `selectionOnDrag`, matching `@xyflow/react`:
+
+```vue
+<!-- before -->
+<VueFlow :selection-key-code="true" :pan-on-drag="false" />
+
+<!-- after -->
+<VueFlow :selection-on-drag="true" :pan-on-drag="false" />
+```
+
+`selectionKeyCode` goes back to being just the key you hold to select (default `'Shift'`). Pair `selectionOnDrag` with `:pan-on-drag="false"` or a non-left button (e.g. `:pan-on-drag="[1, 2]"`) so a left-drag selects instead of panning. As a bonus, `paneClick` now fires correctly in this mode (it was previously swallowed by the pan/zoom click handling).
+
 ## Cheat sheet
 
 ```ts
@@ -379,6 +393,7 @@ node.x = …             → updateNode(id, { x: … }) / immutable reassignment
 removeNodes(id)        → also removes connected edges (pass `false` to keep them)
 connectionMode         → defaults to 'strict'
 applyDefault           → autoApplyChanges  (:apply-default → :auto-apply-changes)
+:selection-key-code="true"  → :selection-on-drag="true"   // select-on-drag is its own prop now
 node event payload     → user Node (was InternalNode); getInternalNode(id) for internals
 
 // styles

--- a/docs/src/guide/vue-flow/config.md
+++ b/docs/src/guide/vue-flow/config.md
@@ -550,6 +550,18 @@ const edges = ref([
 
   Define a key which can be used to activate the selection rect.
 
+### selection-on-drag (optional)
+
+- Type: `boolean`
+
+- Default: `false`
+
+- Details:
+
+  Draw a selection rect on a plain pane drag, without holding [`selection-key-code`](#selection-key-code).
+
+  Pair it with `:pan-on-drag="false"` (or a non-left button, e.g. `:pan-on-drag="[1, 2]"`) so a left-drag selects instead of panning.
+
 ### multi-selection-key-code (optional)
 
 - Type: `KeyCode`

--- a/packages/core/src/container/VueFlow/VueFlow.vue
+++ b/packages/core/src/container/VueFlow/VueFlow.vue
@@ -50,6 +50,7 @@ const props = withDefaults(defineProps<FlowProps<NodeType, EdgeType>>(), {
   onBeforeDelete: undefined,
   deleteKeyCode: undefined,
   selectionKeyCode: undefined,
+  selectionOnDrag: undefined,
   multiSelectionKeyCode: undefined,
   panActivationKeyCode: undefined,
   zoomActivationKeyCode: undefined,

--- a/packages/core/src/container/ZoomPane/ZoomPane.vue
+++ b/packages/core/src/container/ZoomPane/ZoomPane.vue
@@ -34,6 +34,7 @@ const {
   noWheelClassName,
   panActivationKeyCode,
   selectionKeyCode,
+  selectionOnDrag,
   paneClickDistance,
   connectionStartHandle,
 } = storeToRefs(useStore());
@@ -48,7 +49,10 @@ const shouldPanOnDrag = toRef(() => !selectionKeyPressed.value && (panKeyPressed
 
 const shouldPanOnScroll = toRef(() => panKeyPressed.value || panOnScroll.value);
 
-const isSelecting = toRef(() => selectionKeyPressed.value || (selectionKeyCode.value === true && shouldPanOnDrag.value !== true));
+// selection-on-drag is active when the user opted in AND a left-drag wouldn't pan (so it selects instead)
+const selectionOnDragActive = toRef(() => selectionOnDrag.value === true && shouldPanOnDrag.value !== true);
+
+const isSelecting = toRef(() => selectionKeyPressed.value || selectionOnDragActive.value);
 
 useResizeHandler(zoomPane);
 
@@ -100,6 +104,7 @@ onMounted(() => {
         userSelectionActive,
         noWheelClassName,
         paneClickDistance,
+        selectionOnDragActive,
         connectionStartHandle,
       ],
       () => {
@@ -117,6 +122,9 @@ onMounted(() => {
           userSelectionActive: userSelectionActive.value,
           noWheelClassName: noWheelClassName.value,
           paneClickDistance: paneClickDistance.value,
+          // when selecting on drag, d3-zoom's click distance is set to Infinity so it never swallows the
+          // gesture as a click — letting `paneClick` fire (xyflow/react #5572)
+          selectionOnDrag: selectionOnDragActive.value,
           onTransformChange: (nextTransform) => {
             emits.viewportChange({ x: nextTransform[0], y: nextTransform[1], zoom: nextTransform[2] });
             transform.value = nextTransform;

--- a/packages/core/src/store/state.ts
+++ b/packages/core/src/store/state.ts
@@ -91,6 +91,7 @@ export function useState<NodeType extends Node = Node, EdgeType extends Edge = E
     selectNodesOnDrag: true,
     multiSelectionActive: false,
     selectionKeyCode: 'Shift',
+    selectionOnDrag: false,
     multiSelectionKeyCode: isMacOs() ? 'Meta' : 'Control',
     zoomActivationKeyCode: isMacOs() ? 'Meta' : 'Control',
     deleteKeyCode: 'Backspace',

--- a/packages/core/src/types/flow.ts
+++ b/packages/core/src/types/flow.ts
@@ -116,7 +116,14 @@ export interface FlowProps<NodeType extends Node = Node, EdgeType extends Edge =
   /** consulted before delete-key/`deleteElements` removals — cancel, confirm, or filter the set */
   onBeforeDelete?: OnBeforeDelete<NodeType, EdgeType> | null;
   deleteKeyCode?: KeyFilter | null;
+  /** hold this key (default `'Shift'`) and drag to draw a selection box. For dragging without a key, see `selectionOnDrag` */
   selectionKeyCode?: KeyFilter | null;
+  /**
+   * Draw a selection box on a plain pane drag (no key held). Pair it with `panOnDrag` set to a non-left
+   * button (e.g. `[1, 2]`) or `false` so a left-drag selects instead of panning. Mirrors xyflow/react.
+   * @default false
+   */
+  selectionOnDrag?: boolean;
   multiSelectionKeyCode?: KeyFilter | null;
   zoomActivationKeyCode?: KeyFilter | null;
   panActivationKeyCode?: KeyFilter | null;

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -89,6 +89,7 @@ export interface State<NodeType extends Node = Node, EdgeType extends Edge = Edg
 
   deleteKeyCode: KeyFilter | null;
   selectionKeyCode: KeyFilter | null;
+  selectionOnDrag: boolean;
   multiSelectionKeyCode: KeyFilter | null;
   zoomActivationKeyCode: KeyFilter | null;
   panActivationKeyCode: KeyFilter | null;

--- a/tests/cypress/component/1-store/viewpane/selectionKeyCode.cy.ts
+++ b/tests/cypress/component/1-store/viewpane/selectionKeyCode.cy.ts
@@ -71,15 +71,15 @@ describe('Store State: `selectionKeyCode`', () => {
     });
   });
 
-  it('allows `true` as keycode', () => {
-    // `selectionKeyCode === true` only enters selection mode while NOT panning on drag (see
-    // `isSelecting` in ZoomPane.vue), and `panOnDrag` feeds the d3 pan filter configured at mount —
-    // so both must be set as initial props rather than toggled after mount.
+  it('selects on a plain drag with `selectionOnDrag`', () => {
+    // `selectionOnDrag` enters selection mode while NOT panning on drag (see `isSelecting` in
+    // ZoomPane.vue), and `panOnDrag` feeds the d3 pan filter configured at mount — so both must be set
+    // as initial props rather than toggled after mount.
     cy.vueFlow({
       nodes,
       edges,
       panOnDrag: false,
-      selectionKeyCode: true,
+      selectionOnDrag: true,
     });
 
     cy.window().then((win) => {

--- a/tests/cypress/component/2-vue-flow/autoPanOnSelection.cy.ts
+++ b/tests/cypress/component/2-vue-flow/autoPanOnSelection.cy.ts
@@ -17,7 +17,7 @@ describe('autoPanOnSelection', () => {
     });
   });
 
-  // `selectionKeyCode: true` + `panOnDrag: false` puts the pane in selection mode without holding a key
+  // `selectionOnDrag` + `panOnDrag: false` puts the pane in selection mode without holding a key
   // (see the `isSelecting` derivation in ZoomPane), so a plain pointer drag draws a selection box.
   function mountSelecting(autoPanOnSelection: boolean) {
     cy.vueFlow({
@@ -25,7 +25,7 @@ describe('autoPanOnSelection', () => {
       edges,
       fitView: false,
       panOnDrag: false,
-      selectionKeyCode: true,
+      selectionOnDrag: true,
       autoPanOnSelection,
     });
   }


### PR DESCRIPTION
Implements the cross-framework part of [xyflow/xyflow#5572](https://github.com/xyflow/xyflow/pull/5572) ("Fix onPaneClick suppressed when selectionOnDrag=true"), and takes the opportunity to drop vue-flow's confusing `selectionKeyCode={true}` overload in favor of an explicit `selectionOnDrag` prop (xyflow/react & xyflow/svelte parity).

## The problem

vue-flow had no `selectionOnDrag` prop. To draw a selection box on a plain drag you set `selectionKeyCode={true}` — which overloaded the key-code prop (`KeyFilter` includes `true`, and `useKeyPress(true)` just pins "pressed" on). It read as "what key is the selection key? true." Confusing, and divergent from the rest of the ecosystem. It also meant we couldn't cleanly thread `selectionOnDrag` to the pan/zoom instance, so `paneClick` was swallowed by d3-zoom's click handling while selecting on drag (the #5572 bug).

## The change

- **New `selectionOnDrag?: boolean`** (default `false`). `selectionKeyCode` is once again just the key you hold to select (default `'Shift'`).
- `ZoomPane`'s `isSelecting` now derives from `selectionKeyPressed || (selectionOnDrag && shouldPanOnDrag !== true)` instead of the `selectionKeyCode === true` special-case.
- `selectionOnDrag` is passed to the system pan/zoom `update()`, which (in our installed `@xyflow/system`) sets d3-zoom's `clickDistance` to `Infinity` while selecting on drag — so the gesture isn't swallowed as a click and `paneClick` fires (#5572).
- Migration guide (§15 + cheat-sheet) and the config-options doc updated.

```vue
<!-- before -->
<VueFlow :selection-key-code="true" :pan-on-drag="false" />
<!-- after -->
<VueFlow :selection-on-drag="true" :pan-on-drag="false" />
```

## Breaking change

`:selection-key-code="true"` → `:selection-on-drag="true"`. Documented in the migration guide.

## Verification

- `vue-tsc` + lint clean; core builds.
- `selectionKeyCode.cy.ts` (the "select on a plain drag" case migrated to `selectionOnDrag`) + `autoPanOnSelection.cy.ts` (migrated) — all green: a plain drag with `selectionOnDrag` enters selection mode and selects/auto-pans.

> Note: stacks with #2123 (selection click-vs-drag) — its `selectionClickVsDrag.cy.ts` uses `selectionKeyCode: true`; whichever lands second needs that one-line swap to `selectionOnDrag: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)