### PR TITLE
fix(core): honor width/initialWidth in node visibility + inline size

### DIFF
--- a/.changeset/node-initial-dimensions.md
+++ b/.changeset/node-initial-dimensions.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Honor `width`/`height` and `initialWidth`/`initialHeight` in the node visibility gate and inline size (mirrors xyflow/react & xyflow/svelte). The node wrapper previously gated visibility on `measured` alone, so a node sized via `width`/`initialWidth` stayed `visibility: hidden` until the `ResizeObserver` measured it — and in SSR (no `ResizeObserver`) it never became visible. Visibility now uses `@xyflow/system`'s `nodeHasDimensions` (`measured ?? width ?? initialWidth`), and the wrapper's inline size falls back through `initialWidth`/`initialHeight` before the node is measured (`initialWidth`/`initialHeight` are the SSR dimensions, since DOM can't be measured server-side).

--- a/packages/core/src/components/Nodes/NodeWrapper.ts
+++ b/packages/core/src/components/Nodes/NodeWrapper.ts
@@ -1,5 +1,5 @@
 import type { BuiltInNode, MouseTouchEvent, NodeComponent } from '../../types';
-import { getNodesInside } from '@xyflow/system';
+import { getNodesInside, nodeHasDimensions } from '@xyflow/system';
 import {
   computed,
   defineComponent,
@@ -115,7 +115,10 @@ const NodeWrapper = defineComponent({
         || hooks.value.nodeMouseLeave.hasListeners(),
     );
 
-    const isInit = toRef(() => !!nodeRef.value?.measured?.width && !!nodeRef.value?.measured?.height);
+    // a node "has dimensions" once it's measured OR carries explicit `width`/`height` OR `initialWidth`/
+    // `initialHeight` (the SSR fallback, where there's no ResizeObserver to measure) — mirrors xyflow/react
+    // & xyflow/svelte's visibility gate so sized/SSR nodes render immediately instead of staying hidden.
+    const isInit = toRef(() => (nodeRef.value ? nodeHasDimensions(nodeRef.value) : false));
 
     // computed (not toRef): the value-equality gate keeps this node's render effect from re-running on
     // every `parentLookup` entry replacement — an uncached getter read in render tracks the raw map key
@@ -183,14 +186,18 @@ const NodeWrapper = defineComponent({
       // reactive AND would cache stale width/height onto the user object across renders)
       const styles = { ...node?.style };
 
-      const width = node?.width;
-      const height = node?.height;
+      // mirror xyflow/react's `getNodeInlineStyleDimensions`: before the node is measured (no handle bounds
+      // yet — e.g. first paint / SSR) fall back through `initialWidth`/`initialHeight`; once measured, only
+      // an explicit `width`/`height` overrides the natural measured size.
+      const isMeasured = !!node?.internals.handleBounds;
+      const width = node?.width ?? (isMeasured ? undefined : node?.initialWidth);
+      const height = node?.height ?? (isMeasured ? undefined : node?.initialHeight);
 
-      if (!styles.width && width) {
+      if (!styles.width && width != null) {
         styles.width = `${width}px`;
       }
 
-      if (!styles.height && height) {
+      if (!styles.height && height != null) {
         styles.height = `${height}px`;
       }
 

--- a/tests/cypress/component/2-vue-flow/nodeInitialDimensions.cy.ts
+++ b/tests/cypress/component/2-vue-flow/nodeInitialDimensions.cy.ts
@@ -1,0 +1,39 @@
+import { defineComponent, h } from 'vue';
+
+// A node type with no intrinsic size: without measured dimensions (and with nothing to measure) the wrapper
+// is gated `visibility: hidden`. So it's only visible if `width`/`initialWidth` feed the visibility gate —
+// which is exactly the `nodeHasDimensions` behavior vue-flow now mirrors from xyflow/react & xyflow/svelte.
+const EmptyNode = defineComponent({ name: 'EmptyNode', setup: () => () => h('div') });
+
+function visibilityOf(id: string) {
+  return cy.get(`[data-id="${id}"]`).should('exist').then($el => getComputedStyle($el[0]).visibility);
+}
+
+describe('node initial dimensions', () => {
+  it('gates a zero-size, unmeasured node hidden (control)', () => {
+    cy.vueFlow(
+      { fitView: false, nodes: [{ id: '1', type: 'empty', position: { x: 0, y: 0 }, data: {} }] },
+      {},
+      { 'node-empty': (props: any) => h(EmptyNode, props) },
+    );
+
+    visibilityOf('1').then((visibility) => {
+      expect(visibility, 'a node with no dimensions stays hidden').to.eq('hidden');
+    });
+  });
+
+  it('renders a node with only initialWidth/initialHeight visible (SSR fallback)', () => {
+    cy.vueFlow(
+      {
+        fitView: false,
+        nodes: [{ id: '1', type: 'empty', position: { x: 0, y: 0 }, data: {}, initialWidth: 100, initialHeight: 40 }],
+      },
+      {},
+      { 'node-empty': (props: any) => h(EmptyNode, props) },
+    );
+
+    visibilityOf('1').then((visibility) => {
+      expect(visibility, 'initialWidth/initialHeight make the node visible without measuring').to.eq('visible');
+    });
+  });
+});


### PR DESCRIPTION
Closes the gap surfaced while reviewing the selection test: vue-flow's node wrapper didn't fully consider `width`/`height` or `initialWidth`/`initialHeight` the way xyflow/react & xyflow/svelte do.

## The gap (vs RF/SF)

| | RF/SF node wrapper | vue-flow (before) |
|---|---|---|
| **visibility gate** | `nodeHasDimensions(node)` → `measured ?? width ?? initialWidth` | `!!measured.width && !!measured.height` (measured only) |
| **inline size, pre-measure** | `width ?? initialWidth ?? style.width` | `width` only |
| **inline size, post-measure** | `width ?? style.width` (drops `initialWidth`) | `width` |

Consequences:
- A node sized via `width`/`initialWidth` but not yet measured was `visibility: hidden` until the `ResizeObserver` fired (a frame of flicker).
- **In SSR there is no `ResizeObserver`**, so an `initialWidth`/`initialHeight` node — whose whole purpose is to provide dimensions server-side — never became visible.

`@xyflow/system` already falls back `measured ?? width ?? initialWidth` in its own utils (`getNodesInside`, `getNodeDimensions`, …), so selection/bounds already worked; the wrapper's visibility + inline-size were the only spots still measured-only.

## The fix (NodeWrapper)

- **Visibility** now uses `@xyflow/system`'s `nodeHasDimensions(node)` instead of a measured-only check.
- **Inline size** mirrors RF's `getNodeInlineStyleDimensions`: before measurement (`internals.handleBounds` undefined) fall back through `initialWidth`/`initialHeight`; once measured, only an explicit `width`/`height` overrides the natural measured size.

## Verification

- `vue-tsc` + lint clean; core builds.
- New `nodeInitialDimensions.cy.ts` (real Chrome), distinguishing pair:
  - a zero-size, unmeasured node stays `visibility: hidden` (control — proves the gate is real)
  - the same node with `initialWidth`/`initialHeight` is `visible` (the fix)
- `customNode`, `drag`, `expand-parent`, `parentExtentResize` specs green — no regression to the common (content-measured) node path.

> Bonus context for the selection PRs: this is also why `node.width`/`height` alone size a node (no `style` needed) — they seed both `measured` (via system adoption) and the inline DOM size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)