### PR TITLE
test(core): guard MiniMap against all-hidden nodes

### DIFF
--- a/tests/cypress/component/3-additional-components/minimap/minimap.cy.ts
+++ b/tests/cypress/component/3-additional-components/minimap/minimap.cy.ts
@@ -27,3 +27,33 @@ describe('Render MiniMap', () => {
     cy.get('.vue-flow__minimap-node').should('have.length', nodes.length);
   });
 });
+
+// xyflow/react & xyflow/svelte #5546: the minimap must not break when every node is hidden — the bounds
+// must stay finite (no Infinity/NaN viewBox) and hidden nodes must be excluded from the minimap.
+describe('MiniMap with all nodes hidden', () => {
+  beforeEach(() => {
+    cy.mount(App, {
+      props: {
+        nodes: nodes.map(n => ({ ...n, hidden: true })),
+        edges,
+      },
+      attrs: {
+        style: {
+          width: '100vw',
+          height: '100vh',
+        },
+      },
+    });
+  });
+
+  it('renders with a finite viewBox', () => {
+    cy.get('.vue-flow__minimap svg').should('exist').then(($svg) => {
+      const viewBox = $svg.attr('viewBox') ?? '';
+      expect(viewBox, 'viewBox has no NaN/Infinity').to.match(/^-?[\d.]+ -?[\d.]+ -?[\d.]+ -?[\d.]+$/);
+    });
+  });
+
+  it('renders no minimap nodes', () => {
+    cy.get('.vue-flow__minimap-node').should('have.length', 0);
+  });
+});


### PR DESCRIPTION
Checked [xyflow/xyflow#5546](https://github.com/xyflow/xyflow/pull/5546) ("Fix Minimap if all nodes are hidden") — **vue-flow already handles it.** This PR is just the regression guard.

## Why it's already handled

The upstream bug: `getInternalNodesBounds` early-returned `{0,0,0,0}` only when the *lookup was empty*; with all nodes hidden it fell through to `Infinity` bounds → NaN viewBox → broken minimap. The fix made it return `{0,0,0,0}` whenever *no node passes the filter*.

vue-flow's `MiniMap` doesn't hit that path:

- **Bounds** use `getNodesBounds(nodes.filter(n => !n.hidden), { nodeLookup })`. `getNodesBounds` early-returns `{0,0,0,0}` for an empty array — so all-hidden yields `{0,0,0,0}`, never `Infinity`. `getBoundsOfRects({0,0,0,0}, viewBB)` is finite (same fallback the fixed RF/SF minimaps land on).
- **Render** already excludes hidden nodes: `MiniMapNode` is `v-if="!hidden && dimensions.width !== 0 && dimensions.height !== 0"` — equivalent to the `&& !node.hidden` the upstream fix added to its render loop.

(The system-side `getInternalNodesBounds` fix itself ships in our installed `@xyflow/system` 0.0.77, so anything that *does* use it is covered too.)

## The guard

Extends the existing `minimap.cy.ts`: with every node hidden, the minimap renders with a **finite viewBox** (no `NaN`/`Infinity`) and **zero** `.vue-flow__minimap-node` rects. Verified in real Chrome (4/4 in the spec, the 2 existing + these 2).

No source change — purely a regression test for an edge case we already handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)