### PR TITLE
fix(core): count area-in-node containment in isNodeIntersecting

### DIFF
--- a/.changeset/is-node-intersecting-containment.md
+++ b/.changeset/is-node-intersecting-containment.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Fix `isNodeIntersecting` when the area is fully contained in the node. With `partially: false` it only counted a node as intersecting when the node was fully inside the area — so a large node *containing* a smaller query area reported no intersection. Full containment now counts either way (node-in-area or area-in-node), matching `getIntersectingNodes` and xyflow/react #5482.

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -904,7 +904,13 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
     const overlappingArea = getOverlappingArea(nodeRect, area);
     const partiallyVisible = partially && overlappingArea > 0;
 
-    return partiallyVisible || overlappingArea >= Number(nodeRect.width) * Number(nodeRect.height);
+    // "intersecting" when partially overlapping (if `partially`) OR fully contained either way — the node
+    // inside the area, or the area inside the node (the latter was missing; xyflow/react #5482)
+    return (
+      partiallyVisible
+      || overlappingArea >= area.width * area.height
+      || overlappingArea >= Number(nodeRect.width) * Number(nodeRect.height)
+    );
   };
 
   const panBy: Actions<NodeType>['panBy'] = (delta) => {

--- a/tests/cypress/component/2-vue-flow/isNodeIntersecting.cy.ts
+++ b/tests/cypress/component/2-vue-flow/isNodeIntersecting.cy.ts
@@ -1,0 +1,46 @@
+import type { VueFlowStore } from '@vue-flow/core';
+import { getStore } from '../../support/component';
+
+// xyflow/react #5482: with `partially=false`, full containment counts as intersecting *either way* — the
+// node inside the area, or the area inside the node (the latter was previously missed).
+describe('isNodeIntersecting', () => {
+  let store: VueFlowStore;
+
+  beforeEach(() => {
+    cy.vueFlow({ fitView: false, nodes: [], edges: [] });
+    cy.then(() => {
+      store = getStore();
+    });
+  });
+
+  it('treats an area fully contained in the node as intersecting (partially = false)', () => {
+    cy.then(() => {
+      // 200×200 node fully contains the 50×50 area
+      expect(store.isNodeIntersecting({ x: 0, y: 0, width: 200, height: 200 }, { x: 50, y: 50, width: 50, height: 50 }, false)).to.eq(true);
+    });
+  });
+
+  it('treats the node fully contained in the area as intersecting (partially = false)', () => {
+    cy.then(() => {
+      expect(store.isNodeIntersecting({ x: 50, y: 50, width: 50, height: 50 }, { x: 0, y: 0, width: 200, height: 200 }, false)).to.eq(true);
+    });
+  });
+
+  it('returns false for a partial overlap when partially = false', () => {
+    cy.then(() => {
+      expect(store.isNodeIntersecting({ x: 0, y: 0, width: 100, height: 100 }, { x: 50, y: 50, width: 100, height: 100 }, false)).to.eq(false);
+    });
+  });
+
+  it('returns true for a partial overlap when partially = true', () => {
+    cy.then(() => {
+      expect(store.isNodeIntersecting({ x: 0, y: 0, width: 100, height: 100 }, { x: 50, y: 50, width: 100, height: 100 }, true)).to.eq(true);
+    });
+  });
+
+  it('returns false when there is no overlap', () => {
+    cy.then(() => {
+      expect(store.isNodeIntersecting({ x: 0, y: 0, width: 50, height: 50 }, { x: 100, y: 100, width: 50, height: 50 }, false)).to.eq(false);
+    });
+  });
+});


### PR DESCRIPTION
Ports [xyflow/xyflow#5482](https://github.com/xyflow/xyflow/pull/5482) ("Fix is intersecting", fixes xyflow#5479).

## The bug

`isNodeIntersecting(node, area, partially)` with `partially: false` returned:

```ts
partiallyVisible || overlappingArea >= nodeRect.width * nodeRect.height
```

i.e. "intersecting only if the **node** is fully inside the area." So a large node that **contains** a smaller query area had `overlappingArea` = the area's area (< the node's area) → reported **not intersecting**, even though the area sits entirely within the node.

## The fix

Full containment now counts **either way** — node-in-area *or* area-in-node:

```ts
partiallyVisible
  || overlappingArea >= area.width * area.height
  || overlappingArea >= nodeRect.width * nodeRect.height
```

This matches both the sibling `getIntersectingNodes` (which already had both conditions) and the upstream fix.

## Verification

- `vue-tsc` + lint clean; core builds.
- New `isNodeIntersecting.cy.ts` (5 cases): area-fully-inside-node and node-fully-inside-area both intersect with `partially: false` (the first is the regression); partial overlap is intersecting only when `partially: true`; no overlap never intersects. The area-in-node case is the distinguishing one — it returned `false` before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)