### PR TITLE
fix(core): align handle connectionindicator with xyflow model

### DIFF
--- a/.changeset/handle-connection-indicator.md
+++ b/.changeset/handle-connection-indicator.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Align the handle `connectionindicator` class with xyflow/react's model (fixes the click-connection case from xyflow/react #5042). It now keys off the global connection state — `isConnectableEnd` for possible end handles while a connection is in progress (drag **or** click), `isConnectableStart` otherwise — instead of a per-handle "is this the connection's start/end handle" check. Previously a handle with `connectableStart: false, connectableEnd: true` never showed the indicator as a connection target.

--- a/packages/core/src/components/Handle/Handle.vue
+++ b/packages/core/src/components/Handle/Handle.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import type { HandleProps } from '../../types';
-import { getDimensions, isMouseEvent, Position } from '@xyflow/system';
+import { ConnectionMode, getDimensions, isMouseEvent, Position } from '@xyflow/system';
 import { computed, onMounted, shallowRef, toRef } from 'vue';
 import { storeToRefs, useHandle, useNode, useStore, useVueFlow } from '../../composables';
 import { isDef } from '../../utils';
@@ -23,7 +23,7 @@ const { id: flowId } = useVueFlow();
 const {
   connectionStartHandle,
   connectionClickStartHandle,
-  connectionEndHandle,
+  connectionMode,
   vueFlowRef,
   nodesConnectable,
   noDragClassName,
@@ -48,15 +48,19 @@ const isConnectableStart = toRef(() => (typeof connectableStart !== 'undefined' 
 
 const isConnectableEnd = toRef(() => (typeof connectableEnd !== 'undefined' ? connectableEnd : true));
 
-const isConnecting = toRef(
-  () =>
-    (connectionStartHandle.value?.nodeId === nodeId
-      && connectionStartHandle.value?.id === handleId
-      && connectionStartHandle.value?.type === type.value)
-    || (connectionEndHandle.value?.nodeId === nodeId
-      && connectionEndHandle.value?.id === handleId
-      && connectionEndHandle.value?.type === type.value),
-);
+// Connection-indicator flags, mirroring xyflow/react's `connectingSelector`. A connection is "in process"
+// globally while dragging (`connectionStartHandle`) or click-connecting (`connectionClickStartHandle`);
+// `isPossibleEndHandle` is whether this handle can be the END of the in-progress (drag) connection.
+const connectionInProcess = toRef(() => connectionStartHandle.value !== null);
+
+const clickConnectionInProcess = toRef(() => connectionClickStartHandle.value !== null);
+
+const isPossibleEndHandle = toRef(() => {
+  const fromHandle = connectionStartHandle.value;
+  return connectionMode.value === ConnectionMode.Strict
+    ? fromHandle?.type !== type.value
+    : nodeId !== fromHandle?.nodeId || handleId !== fromHandle?.id;
+});
 
 const isClickConnecting = toRef(
   () =>
@@ -204,7 +208,10 @@ export default {
         connecting: isClickConnecting,
         connectablestart: isConnectableStart,
         connectableend: isConnectableEnd,
-        connectionindicator: isHandleConnectable && ((isConnectableStart && !isConnecting) || (isConnectableEnd && isConnecting)),
+        connectionindicator:
+          isHandleConnectable
+          && (!connectionInProcess || isPossibleEndHandle)
+          && ((connectionInProcess || clickConnectionInProcess) ? isConnectableEnd : isConnectableStart),
       },
     ]"
     @mousedown="onPointerDown"

--- a/tests/cypress/component/2-vue-flow/handleConnectionIndicator.cy.ts
+++ b/tests/cypress/component/2-vue-flow/handleConnectionIndicator.cy.ts
@@ -1,0 +1,71 @@
+import type { ConnectingHandle, VueFlowStore } from '@vue-flow/core';
+import { Handle, Position } from '@vue-flow/core';
+import { defineComponent, h } from 'vue';
+import { getStore } from '../../support/component';
+
+// xyflow/react #5042 + full model alignment: the `connectionindicator` class must reflect `isConnectableEnd`
+// for possible end handles while a connection is in progress (drag OR click) — previously vue-flow keyed it
+// on a per-handle "is this the start/end handle" check, so an end-only handle never lit up as a target.
+const EndOnlyNode = defineComponent({
+  name: 'EndOnlyNode',
+  setup: () => () => h(Handle, { type: 'target', position: Position.Left, connectableStart: false, connectableEnd: true }),
+});
+
+describe('Handle connectionindicator', () => {
+  let store: VueFlowStore;
+
+  beforeEach(() => {
+    cy.vueFlow(
+      {
+        fitView: false,
+        nodes: [
+          { id: '1', type: 'input', position: { x: 0, y: 0 }, data: { label: 'start' } },
+          { id: '2', type: 'endonly', position: { x: 200, y: 0 }, data: {} },
+        ],
+      },
+      {},
+      { 'node-endonly': (props: any) => h(EndOnlyNode, props) },
+    );
+    cy.then(() => {
+      store = getStore();
+    });
+  });
+
+  function endOnlyHandle() {
+    return cy.get('[data-nodeid="2"].vue-flow__handle');
+  }
+
+  it('does not mark an end-only handle as an indicator while idle', () => {
+    endOnlyHandle().should('exist').and('not.have.class', 'connectionindicator');
+  });
+
+  it('marks the end-only handle as an indicator during a drag connection', () => {
+    cy.then(() => {
+      store.connectionStartHandle.value = {
+        nodeId: '1',
+        id: null,
+        type: 'source',
+        position: Position.Right,
+        x: 0,
+        y: 0,
+      } satisfies ConnectingHandle;
+    });
+
+    endOnlyHandle().should('have.class', 'connectionindicator');
+  });
+
+  it('marks the end-only handle as an indicator during a click connection', () => {
+    cy.then(() => {
+      store.connectionClickStartHandle.value = {
+        nodeId: '1',
+        id: null,
+        type: 'source',
+        position: Position.Right,
+        x: 0,
+        y: 0,
+      } satisfies ConnectingHandle;
+    });
+
+    endOnlyHandle().should('have.class', 'connectionindicator');
+  });
+});


### PR DESCRIPTION
Ports [xyflow/xyflow#5042](https://github.com/xyflow/xyflow/pull/5042) ("handle isConnectableStart correctly for click-connections"). Per discussion, taking the **full RF-model alignment** rather than a targeted click-only patch.

## The divergence

vue-flow keyed the handle `connectionindicator` class off a **per-handle** check (`isConnecting` = is *this* handle the connection's start/end):

```ts
connectionindicator: isHandleConnectable && ((isConnectableStart && !isConnecting) || (isConnectableEnd && isConnecting))
```

So during a connection only the start + currently-hovered handle reflected end-connectability; every other possible-end handle was treated as idle (`isConnectableStart`). A `connectableStart: false, connectableEnd: true` handle therefore **never** showed the indicator as a target — and for click-connections (where `connectionStartHandle` is unset, only `connectionClickStartHandle`) nothing lit up at all (the #5042 bug).

## The change

Mirror xyflow/react's `connectingSelector` — derive from the **global** connection state:

```ts
const connectionInProcess = connectionStartHandle !== null          // a drag connection is active
const clickConnectionInProcess = connectionClickStartHandle !== null // a click connection is active
const isPossibleEndHandle = connectionMode === Strict
  ? fromHandle?.type !== type                                        // opposite-type handle
  : nodeId !== fromHandle?.nodeId || handleId !== fromHandle?.id      // any handle but the source

connectionindicator:
  isHandleConnectable
  && (!connectionInProcess || isPossibleEndHandle)
  && ((connectionInProcess || clickConnectionInProcess) ? isConnectableEnd : isConnectableStart)
```

Identical structure to RF. The old per-handle `isConnecting` (and its now-unused `connectionEndHandle` read) are removed; existing class names are untouched (CSS unaffected).

## Verification

- `vue-tsc` + lint clean; core builds.
- New `handleConnectionIndicator.cy.ts` (real Chrome) with a `connectableStart:false, connectableEnd:true` handle: **no** indicator while idle (control), indicator **during a drag** connection, indicator **during a click** connection (the #5042 case). The idle control makes it distinguishing — that handle never carried the indicator before.
- `connect`, `isValidConnection`, `strictConnectionMode` specs green — no functional regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)