### PR TITLE
feat(core): theme arrowhead markers via --xy-edge-stroke

### DIFF
--- a/.changeset/arrowhead-css-variables.md
+++ b/.changeset/arrowhead-css-variables.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Allow theming arrowhead markers with the `--xy-edge-stroke` CSS variable (mirrors xyflow/react #5419 + #5459). `defaultMarkerColor` now accepts `null` — pass it (or leave a marker's `color` unset) and the arrowhead inherits `--xy-edge-stroke` instead of the hard-coded `#b1b1b7`, so markers can match themed edge colors. The marker polylines carry `.arrow` / `.arrowclosed` classes and only set an inline color when one is provided; the open arrow strokes only, the closed arrow strokes and fills. The default (`#b1b1b7`) is unchanged.

--- a/packages/core/src/container/EdgeRenderer/MarkerSymbols.vue
+++ b/packages/core/src/container/EdgeRenderer/MarkerSymbols.vue
@@ -35,11 +35,8 @@ export default {
   >
     <polyline
       v-if="type === MarkerType.ArrowClosed"
-      :style="{
-        stroke: color,
-        fill: color,
-        strokeWidth,
-      }"
+      class="arrowclosed"
+      :style="color ? { stroke: color, fill: color, strokeWidth } : { strokeWidth }"
       stroke-linecap="round"
       stroke-linejoin="round"
       points="-5,-4 0,0 -5,4 -5,-4"
@@ -47,10 +44,8 @@ export default {
 
     <polyline
       v-if="type === MarkerType.Arrow"
-      :style="{
-        stroke: color,
-        strokeWidth,
-      }"
+      class="arrow"
+      :style="color ? { stroke: color, strokeWidth } : { strokeWidth }"
       stroke-linecap="round"
       stroke-linejoin="round"
       fill="none"

--- a/packages/core/src/styles/_necessary.css
+++ b/packages/core/src/styles/_necessary.css
@@ -122,6 +122,16 @@
   fill: none;
 }
 
+/* arrowhead markers without an explicit color fall back to the edge-stroke variable (the open `.arrow`
+   only strokes; the closed `.arrowclosed` also fills) */
+.vue-flow__arrowhead polyline {
+  stroke: var(--xy-edge-stroke, var(--xy-edge-stroke-default));
+}
+
+.vue-flow__arrowhead polyline.arrowclosed {
+  fill: var(--xy-edge-stroke, var(--xy-edge-stroke-default));
+}
+
 .vue-flow__connection-path {
   stroke: var(--xy-connectionline-stroke, var(--xy-connectionline-stroke-default));
   stroke-width: var(--xy-connectionline-stroke-width, var(--xy-connectionline-stroke-width-default));

--- a/packages/core/src/types/edge.ts
+++ b/packages/core/src/types/edge.ts
@@ -32,7 +32,8 @@ export interface EdgeMarker {
 export interface MarkerProps {
   id: string;
   type: MarkerType | string;
-  color?: string;
+  /** Marker color; `null`/unset lets the `--xy-edge-stroke` CSS variable drive the arrowhead color */
+  color?: string | null;
   width?: number;
   height?: number;
   markerUnits?: string;

--- a/packages/core/src/types/flow.ts
+++ b/packages/core/src/types/flow.ts
@@ -150,7 +150,8 @@ export interface FlowProps<NodeType extends Node = Node, EdgeType extends Edge =
   nodeOrigin?: NodeOrigin;
   /** light/dark/system — applies the resolved `light`/`dark` class to the flow container; `system` follows `prefers-color-scheme` @default 'light' */
   colorMode?: ColorMode;
-  defaultMarkerColor?: string;
+  /** color of edge markers; pass `null` to drive the arrowhead color from the `--xy-edge-stroke` CSS variable @default '#b1b1b7' */
+  defaultMarkerColor?: string | null;
   zoomOnScroll?: boolean;
   zoomOnPinch?: boolean;
   panOnScroll?: boolean;

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -112,7 +112,7 @@ export interface State<NodeType extends Node = Node, EdgeType extends Edge = Edg
 
   snapToGrid: boolean;
   snapGrid: SnapGrid;
-  defaultMarkerColor: string;
+  defaultMarkerColor: string | null;
 
   edgesReconnectable: EdgeReconnectable;
   edgesFocusable: boolean;

--- a/tests/cypress/component/2-vue-flow/arrowheadMarkers.cy.ts
+++ b/tests/cypress/component/2-vue-flow/arrowheadMarkers.cy.ts
@@ -1,0 +1,51 @@
+import { MarkerType } from '@vue-flow/core';
+
+// xyflow/react #5419 + #5459: arrowhead markers can be themed via the `--xy-edge-stroke` CSS variable when
+// no explicit color is given (`defaultMarkerColor: null`); a set color is applied inline. The closed arrow
+// fills, the open arrow only strokes.
+describe('arrowhead markers', () => {
+  function mount(defaultMarkerColor: string | null, type: MarkerType) {
+    cy.vueFlow({
+      fitView: false,
+      defaultMarkerColor,
+      nodes: [
+        { id: '1', position: { x: 0, y: 0 }, data: {} },
+        { id: '2', position: { x: 200, y: 0 }, data: {} },
+      ],
+      edges: [{ id: 'e1-2', source: '1', target: '2', markerEnd: { type } }],
+    });
+  }
+
+  it('applies an explicit defaultMarkerColor inline (closed arrow strokes + fills)', () => {
+    mount('#ff0000', MarkerType.ArrowClosed);
+
+    cy.get('.vue-flow__arrowhead polyline.arrowclosed').should('exist').then(($p) => {
+      expect($p[0].style.stroke, 'inline stroke').to.eq('rgb(255, 0, 0)');
+      expect($p[0].style.fill, 'inline fill').to.eq('rgb(255, 0, 0)');
+    });
+  });
+
+  it('falls back to the --xy-edge-stroke variable when defaultMarkerColor is null', () => {
+    mount(null, MarkerType.ArrowClosed);
+
+    cy.get('.vue-flow__arrowhead polyline.arrowclosed').should('exist').then(($p) => {
+      // no inline color → the CSS variable drives it
+      expect($p[0].style.stroke, 'no inline stroke').to.eq('');
+      expect($p[0].style.fill, 'no inline fill').to.eq('');
+
+      const computed = getComputedStyle($p[0]);
+      expect(computed.stroke, 'stroke resolves to --xy-edge-stroke default').to.eq('rgb(177, 177, 183)');
+      expect(computed.fill, 'closed arrow fills from the variable').to.eq('rgb(177, 177, 183)');
+    });
+  });
+
+  it('does not fill the open arrow (only strokes)', () => {
+    mount(null, MarkerType.Arrow);
+
+    cy.get('.vue-flow__arrowhead polyline.arrow').should('exist').then(($p) => {
+      const computed = getComputedStyle($p[0]);
+      expect(computed.stroke, 'open arrow strokes from the variable').to.eq('rgb(177, 177, 183)');
+      expect(computed.fill, 'open arrow is not filled').to.eq('none');
+    });
+  });
+});


### PR DESCRIPTION
Ports [xyflow/xyflow#5419](https://github.com/xyflow/xyflow/pull/5419) ("Style arrow heads with CSS variables") + [#5459](https://github.com/xyflow/xyflow/pull/5459) ("open arrow marker fill") — they belong together (both reshape arrowhead rendering).

## What vue-flow already had vs needed

- **#5459 (open arrow uses fill color)** — *already correct*: vue-flow's open arrow has `fill="none"`, so it never filled with the edge color.
- **#5419 (CSS-variable arrowheads)** — *gap*: vue-flow always set inline `stroke: color; fill: color` (color defaulting to the hard-coded `#b1b1b7`), so arrowheads couldn't inherit a themed edge color, and there was no arrowhead CSS-var rule.

## The change

- `defaultMarkerColor?: string | null` (was `string`); default still `#b1b1b7`. Passing `null` (or leaving a marker `color` unset) routes a `null` color through to the marker.
- `MarkerSymbols` only sets the inline `stroke`/`fill` **when a color is present** — so a `null` color falls through to CSS. The polylines now carry `.arrow` / `.arrowclosed` classes (matching #5459's split).
- New CSS in `_necessary.css`:
  ```css
  .vue-flow__arrowhead polyline { stroke: var(--xy-edge-stroke, var(--xy-edge-stroke-default)); }
  .vue-flow__arrowhead polyline.arrowclosed { fill: var(--xy-edge-stroke, var(--xy-edge-stroke-default)); }
  ```
  Open arrow strokes only; closed arrow strokes + fills.

## Verification

- `vue-tsc` + lint clean; core builds (+ `pnpm theme` rebuilds the CSS).
- New `arrowheadMarkers.cy.ts` (real Chrome): with `defaultMarkerColor: '#ff0000'` the closed arrow gets inline `rgb(255,0,0)` stroke + fill; with `defaultMarkerColor: null` there's **no** inline color and the computed `stroke`/`fill` resolve to the `--xy-edge-stroke` default (`rgb(177,177,183)`); the open arrow strokes from the variable but `fill` stays `none`.
- `customEdge`, `updateEdge` specs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)