### PR TITLE
fix(types): export ResizeControlVariant as a value, not type-only

### DIFF
--- a/.changeset/resize-control-variant-value-export.md
+++ b/.changeset/resize-control-variant-value-export.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Export `ResizeControlVariant` as a value, not type-only (mirrors xyflow/react #4947). It is a runtime enum, but the bundled type declarations re-exported it through the NodeResizer barrel as `export type`, so `ResizeControlVariant.Line` / `.Handle` could not be used as a value in TypeScript consumers. It is now re-exported directly from the package root as a value.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -108,6 +108,9 @@ export {
   PanOnScrollMode,
   Position,
   type Rect,
+  // value export (it's a runtime enum) — keeps `ResizeControlVariant.Line/.Handle` usable as a value, not
+  // type-only, at the package root (mirrors xyflow/react #4947; `export *` via NodeResizer downgraded it)
+  ResizeControlVariant,
   SelectionMode,
   type SelectionRect,
   type SnapGrid,


### PR DESCRIPTION
Ports [xyflow/react #4947](https://github.com/xyflow/xyflow/pull/4947) (closes their #4946).

## Problem

`ResizeControlVariant` is a runtime **enum** in `@xyflow/system`, but vue-flow's bundled declarations re-exported it **type-only**. The runtime bundle (`vue-flow-core.mjs`) always exported the value correctly, but `dist/index.d.ts` had:

```ts
export { ..., type ResizeControlVariant, ... }
```

So TypeScript consumers using it as a value hit:

> `ResizeControlVariant` cannot be used as a value because it was exported using `export type`.

Root cause: it reached the package root only via `export * from './components/NodeResizer'` → `NodeResizer/types.ts`, which also does `import type { ResizeControlVariant }` for its own annotations. The dts bundler conflated the two and downgraded the public re-export to `type`.

## Fix

Re-export `ResizeControlVariant` explicitly as a **value** from the package root, in the same `from '@xyflow/system'` block as the other enums (`ConnectionMode`, `Position`, `SelectionMode`, …). An explicit named export is authoritative over `export *`, so the bundled `dist/index.d.ts` now emits a value export. One-line source change; no runtime change (the runtime export was already correct).

## Verification

Regenerated declarations (`pnpm types`) and type-checked a consumer against the **built** `dist/index.d.ts`:

```ts
import { ResizeControlVariant } from '@vue-flow/core';
const v = ResizeControlVariant.Line;             // value usage — was the TS error
const t: ResizeControlVariant = ResizeControlVariant.Handle; // type usage still works
```

`tsc --noEmit --strict` → exit 0 (errored before the fix). Source `eslint` clean. The bundled `export { … }` block now lists `ResizeControlVariant` with no `type` prefix, and there is no duplicate export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)