### PR TITLE
test(core): guard marker definitions svg is aria-hidden

### DIFF
--- a/tests/cypress/component/2-vue-flow/arrowheadMarkers.cy.ts
+++ b/tests/cypress/component/2-vue-flow/arrowheadMarkers.cy.ts
@@ -48,4 +48,11 @@ describe('arrowhead markers', () => {
       expect(computed.fill, 'open arrow is not filled').to.eq('none');
     });
   });
+
+  // xyflow/react #5196: markers are decorative, so the marker-definitions <svg> is hidden from screen readers
+  it('hides the marker definitions svg from screen readers (aria-hidden)', () => {
+    mount(null, MarkerType.ArrowClosed);
+
+    cy.get('svg.vue-flow__marker').should('have.attr', 'aria-hidden', 'true');
+  });
 });


### PR DESCRIPTION
Re: [xyflow/react #5196](https://github.com/xyflow/xyflow/pull/5196) (`chore(marker): add aria-hidden true`).

## Already handled — adding a guard

#5196 added `aria-hidden="true"` to the marker-definitions `<svg>` so decorative edge markers are skipped by screen readers. **vue-flow already does this** — `MarkerDefinitions.vue` renders:

```html
<svg class="vue-flow__marker vue-flow__container" aria-hidden="true">
```

The PR's changeset also mentions attribution, but that nets to no change in the merged diff, and vue-flow ships **no attribution badge** (`attribution` exists only as `--xy-attribution-*` CSS variables, never a rendered element), so there's nothing to change there.

Since the only gap was a missing regression guard for an accessibility attribute that can silently disappear in a refactor, this adds one assertion to the existing arrowhead-markers spec.

## Verification

`arrowheadMarkers.cy.ts` in Chrome → 4/4 passing, including the new:

```ts
cy.get('svg.vue-flow__marker').should('have.attr', 'aria-hidden', 'true');
```

No production code change. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)