### PR TITLE
fix(core): keep selection on pane click when elementsSelectable is false

### DIFF
--- a/.changeset/pane-click-keeps-selection.md
+++ b/.changeset/pane-click-keeps-selection.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Keep the current selection on a pane click when `elementsSelectable` is `false` (mirrors xyflow/react #5217). Previously a pane click always cleared the selection; now a selection set before selection was disabled — or set programmatically — survives the click. The interactive reset is centralized in a new gated `resetSelectedElements` action (a no-op while `elementsSelectable` is `false`), distinct from `removeSelectedNodes`/`removeSelectedEdges`, which still clear unconditionally.

--- a/packages/core/src/container/Pane/Pane.vue
+++ b/packages/core/src/container/Pane/Pane.vue
@@ -10,7 +10,7 @@ import { getSelectionChanges } from '../../utils';
 
 const { isSelecting, selectionKeyPressed } = defineProps<{ isSelecting: boolean; selectionKeyPressed: boolean }>();
 
-const { emits, removeSelectedNodes, removeSelectedEdges, getSelectedEdges, getSelectedNodes, deleteElements, panBy } = useVueFlow();
+const { emits, removeSelectedNodes, removeSelectedEdges, resetSelectedElements, getSelectedEdges, getSelectedNodes, deleteElements, panBy } = useVueFlow();
 
 const { edgeLookup, nodeLookup } = useStore();
 
@@ -99,8 +99,8 @@ function onClick(event: MouseEvent) {
 
   emits.paneClick(event);
 
-  removeSelectedNodes();
-  removeSelectedEdges();
+  // clears the selection, but keeps it while `elementsSelectable` is off (xyflow/react #5217)
+  resetSelectedElements();
 
   nodesSelectionActive.value = false;
 }

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -463,6 +463,19 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
     }
   };
 
+  const resetSelectedElements: Actions<NodeType, EdgeType>['resetSelectedElements'] = () => {
+    // the interactive selection reset (used by a pane click): a no-op while selection is disabled, so a
+    // selection made before `elementsSelectable` was turned off — or set programmatically — survives the
+    // click (xyflow/react #5217). For unconditional clearing, call `removeSelectedNodes`/`removeSelectedEdges`
+    // directly (the equivalent of xyflow/react's ungated `unselectNodesAndEdges`).
+    if (!state.elementsSelectable) {
+      return;
+    }
+
+    removeSelectedNodes();
+    removeSelectedEdges();
+  };
+
   const setMinZoom: Actions<NodeType>['setMinZoom'] = (minZoom) => {
     state.panZoom?.setScaleExtent([minZoom, state.maxZoom]);
     state.minZoom = minZoom;
@@ -1038,6 +1051,7 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
     setPaneClickDistance,
     removeSelectedNodes,
     removeSelectedEdges,
+    resetSelectedElements,
     startConnection,
     updateConnection,
     endConnection,

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -314,6 +314,12 @@ export interface Actions<NodeType extends Node = Node, EdgeType extends Edge = E
   removeSelectedEdges: (edges?: EdgeType[]) => void;
   /** manually unselect nodes and remove from state */
   removeSelectedNodes: (nodes?: NodeType[]) => void;
+  /**
+   * Clear the selection the way a pane click does — but only while `elementsSelectable` is `true`; otherwise
+   * it's a no-op, so a selection set before selection was disabled survives. Use `removeSelectedNodes`/
+   * `removeSelectedEdges` to clear unconditionally.
+   */
+  resetSelectedElements: () => void;
   /** apply min zoom value to panzoom */
   setMinZoom: (zoom: number) => void;
   /** apply max zoom value to panzoom */

--- a/tests/cypress/component/2-vue-flow/paneClickKeepsSelection.cy.ts
+++ b/tests/cypress/component/2-vue-flow/paneClickKeepsSelection.cy.ts
@@ -1,0 +1,59 @@
+import type { VueFlowStore } from '@vue-flow/core';
+import { getStore } from '../../support/component';
+
+// xyflow/react #5217: a pane click clears the selection — but NOT while `elementsSelectable` is false, so a
+// selection set before selection was disabled (or set programmatically) survives the click. The reset is
+// centralized in the gated `resetSelectedElements` action, distinct from the unconditional
+// `removeSelectedNodes`/`removeSelectedEdges` (xyflow/react's `unselectNodesAndEdges`).
+describe('pane click keeps selection when elementsSelectable is false (#5217)', () => {
+  let store: VueFlowStore;
+
+  function mount(elementsSelectable: boolean) {
+    cy.vueFlow({
+      fitView: false,
+      elementsSelectable,
+      // positioned away from the pane's top-left so the click target is the pane, not the node
+      nodes: [{ id: '1', position: { x: 200, y: 200 }, data: {}, selected: true }],
+    });
+    cy.then(() => {
+      store = getStore();
+    });
+  }
+
+  it('keeps the selection on a pane click while selection is disabled', () => {
+    mount(false);
+    cy.then(() => expect(store.getSelectedNodes.value.map(n => n.id)).to.deep.eq(['1']));
+
+    cy.get('.vue-flow__pane').trigger('click');
+
+    cy.tryAssertion(() => {
+      expect(store.getSelectedNodes.value.map(n => n.id), 'selection survives the pane click').to.deep.eq(['1']);
+    });
+  });
+
+  it('clears the selection on a pane click when selection is enabled', () => {
+    mount(true);
+    cy.then(() => expect(store.getSelectedNodes.value.map(n => n.id)).to.deep.eq(['1']));
+
+    cy.get('.vue-flow__pane').trigger('click');
+
+    cy.tryAssertion(() => {
+      expect(store.getSelectedNodes.value, 'selection cleared by the pane click').to.have.length(0);
+    });
+  });
+
+  it('resetSelectedElements is a no-op while disabled, but removeSelectedNodes still clears', () => {
+    mount(false);
+
+    cy.then(() => store.resetSelectedElements());
+    cy.tryAssertion(() => {
+      expect(store.getSelectedNodes.value.map(n => n.id), 'resetSelectedElements no-op when not selectable').to.deep.eq(['1']);
+    });
+
+    // the unconditional path still works regardless of selectability
+    cy.then(() => store.removeSelectedNodes());
+    cy.tryAssertion(() => {
+      expect(store.getSelectedNodes.value, 'removeSelectedNodes clears regardless of selectability').to.have.length(0);
+    });
+  });
+});


### PR DESCRIPTION
Ports [xyflow/react #5217](https://github.com/xyflow/xyflow/pull/5217) — *"Keep node selection on pane click if `elementsSelectable=false`"*.

## Problem

`Pane.vue`'s click handler unconditionally called `removeSelectedNodes()` / `removeSelectedEdges()`, so a selection set **before** `elementsSelectable` was turned off — or set programmatically — was wiped on the next pane click. With selection disabled, the user can't re-select, so the selection was effectively lost.

## Change

RF has two distinct deselect actions: `unselectNodesAndEdges` (unconditional, programmatic) and `resetSelectedElements` (the interactive pane-click reset, where the PR added the `!elementsSelectable` early-return). vue-flow collapsed both into the public `removeSelectedNodes`/`removeSelectedEdges`, so gating *those* would wrongly no-op programmatic deselection.

Instead of a band-aid gate in the component, this adds the missing store action to match RF's architecture:

- **New `resetSelectedElements` action** — no-ops while `elementsSelectable` is `false`, otherwise clears nodes + edges. The pane click now calls it.
- `removeSelectedNodes`/`removeSelectedEdges` stay public and **unconditional** (RF's `unselectNodesAndEdges`) for programmatic clearing.
- The box-select clear path was already implicitly gated — `onPointerDown` returns early when `!elementsSelectable`, so a selection drag can't even start.

The PR's other change (SelectionListener reporting `node.selected` without the `elementsSelectable`/`selectable` filter) is **already** vue-flow's behavior: `getSelectedNodes`/`getSelectedEdges` filter purely on `.selected`. No listener change needed.

## Verification

New `paneClickKeepsSelection.cy.ts` (Chrome, 3/3):
- `elementsSelectable: false` + pane click → selection **survives** (the regression; fails under the old unconditional clear)
- `elementsSelectable: true` + pane click → selection cleared
- `resetSelectedElements()` no-ops while disabled, but `removeSelectedNodes()` still clears regardless

`vue-tsc --noEmit`, lint, `vite build` clean; `selectionClickVsDrag` / `nodesSelectionActive` / `autoPanOnSelection` regression specs all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)