### PR TITLE
feat(core): honor NodeResizer autoScale + center handle via translate

### DIFF
--- a/.changeset/node-resizer-auto-scale.md
+++ b/.changeset/node-resizer-auto-scale.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Add an `autoScale` prop to `NodeResizer` / `NodeResizeControl` (mirrors xyflow/react #5326). Handle controls already scale up by `Math.max(1 / zoom, 1)` so they don't shrink below their base size when zooming out; `autoScale` (default `true`) now lets you opt out — previously the prop existed but had no effect. The handle is also centered via the `translate` CSS property instead of `transform`, so the centering composes with the zoom `scale` and the handle stays pinned to the node corner at any zoom (aligns with `@xyflow/system`).

--- a/packages/core/src/components/NodeResizer/ResizeControl.vue
+++ b/packages/core/src/components/NodeResizer/ResizeControl.vue
@@ -173,7 +173,8 @@ export default {
     :class="[...positionClassNames, variant, noDragClassName]"
     :style="{
       ...controlStyle,
-      scale: variant === ResizeControlVariant.Handle ? `${Math.max(1 / viewport.zoom, 1)}` : undefined,
+      // keep handle controls from shrinking below their base size when zooming out; `autoScale` opts out
+      scale: variant === ResizeControlVariant.Handle && autoScale ? `${Math.max(1 / viewport.zoom, 1)}` : undefined,
     }"
   >
     <slot />

--- a/packages/core/src/styles/_necessary.css
+++ b/packages/core/src/styles/_necessary.css
@@ -391,7 +391,8 @@
   border: 1px solid #fff;
   border-radius: 1px;
   background-color: var(--xy-resize-background-color, var(--xy-resize-background-color-default));
-  transform: translate(-50%, -50%);
+  /* the `translate` property (not `transform`) so the centering composes with the inline zoom `scale` */
+  translate: -50% -50%;
 }
 
 .vue-flow__resize-control.handle.left {

--- a/tests/cypress/component/2-vue-flow/nodeResizerAutoScale.cy.ts
+++ b/tests/cypress/component/2-vue-flow/nodeResizerAutoScale.cy.ts
@@ -1,0 +1,66 @@
+import type { VueFlowStore } from '@vue-flow/core';
+import { NodeResizer } from '@vue-flow/core';
+import { h } from 'vue';
+import { getStore } from '../../support/component';
+
+// xyflow/react #5326: NodeResizer handle controls scale up by `Math.max(1 / zoom, 1)` when zooming out, so
+// they never render smaller than their base size. The new `autoScale` prop (default true) opts out. The
+// handle is centered with the `translate` CSS property (not `transform`) so the centering composes with the
+// inline `scale` and the handle stays pinned to the node corner at any zoom.
+describe('NodeResizer handle autoScale (#5326)', () => {
+  let store: VueFlowStore;
+
+  function mount(autoScale?: boolean) {
+    cy.vueFlow(
+      {
+        fitView: false,
+        nodes: [{ id: '1', type: 'custom', position: { x: 100, y: 100 }, width: 80, height: 60, data: {} }],
+      },
+      undefined,
+      {
+        'node-custom': () => h('div', { style: { width: '80px', height: '60px' } }, [
+          h(NodeResizer, autoScale === undefined ? {} : { autoScale }),
+        ]),
+      },
+    );
+    cy.then(() => {
+      store = getStore();
+      store.setViewport({ x: 0, y: 0, zoom: 0.5 });
+    });
+  }
+
+  it('scales the handle up when zoomed out (autoScale default)', () => {
+    mount();
+
+    cy.tryAssertion(() => {
+      const handle = Cypress.$('.vue-flow__resize-control.handle.bottom.right')[0];
+      // zoom 0.5 → Math.max(1 / 0.5, 1) = 2
+      expect(getComputedStyle(handle).scale, 'handle scales by 1/zoom').to.eq('2');
+    });
+  });
+
+  it('does not scale the handle when autoScale is false', () => {
+    mount(false);
+
+    cy.tryAssertion(() => {
+      const handle = Cypress.$('.vue-flow__resize-control.handle.bottom.right')[0];
+      expect(getComputedStyle(handle).scale, 'no scale applied').to.eq('none');
+    });
+  });
+
+  it('keeps the scaled handle centered on the node corner', () => {
+    mount();
+
+    cy.tryAssertion(() => {
+      const node = Cypress.$('.vue-flow__node')[0].getBoundingClientRect();
+      const handle = Cypress.$('.vue-flow__resize-control.handle.bottom.right')[0].getBoundingClientRect();
+
+      const handleCenterX = handle.left + handle.width / 2;
+      const handleCenterY = handle.top + handle.height / 2;
+
+      // the bottom-right handle's center sits on the node's bottom-right corner, even with scale active
+      expect(Math.abs(handleCenterX - node.right), 'handle x centered on corner').to.be.lessThan(1.5);
+      expect(Math.abs(handleCenterY - node.bottom), 'handle y centered on corner').to.be.lessThan(1.5);
+    });
+  });
+});


### PR DESCRIPTION
Ports [xyflow/react #5326](https://github.com/xyflow/xyflow/pull/5326) — *"Prevent NodeResizer controls from becoming too small when zooming out."*

## Background

Handle controls already scale up by `Math.max(1 / zoom, 1)` so they never render smaller than their base size when zooming out — vue-flow had this. #5326 adds an `autoScale` opt-out prop and tweaks the handle CSS.

## What was actually missing

The `autoScale` prop was **already declared + threaded** (types, both `NodeResizer.vue`/`ResizeControl.vue` defaults, `:auto-scale` wiring) — but the inline scale style never checked it:

```ts
scale: variant === ResizeControlVariant.Handle ? `${Math.max(1 / viewport.zoom, 1)}` : undefined,
```

So `autoScale={false}` had **no effect** — the handle still scaled. This gates it:

```ts
scale: variant === ResizeControlVariant.Handle && autoScale ? `${Math.max(1 / viewport.zoom, 1)}` : undefined,
```

Plus the CSS: the handle was centered with `transform: translate(-50%, -50%)`, but the zoom compensation is applied via the inline `scale` property. Centering it with the standalone **`translate`** property (matching `@xyflow/system`'s `node-resizer.css`) keeps both as independent transform properties so they compose and the handle stays pinned to the corner. (The 4px→5px size bump from #5326 was already present.)

## Verification

New `nodeResizerAutoScale.cy.ts` (Chrome, 3/3), mounting a `NodeResizer` in a custom node at `zoom: 0.5`:
- `autoScale` default → handle computed `scale` is `2` (`1 / 0.5`)
- `autoScale: false` → `scale` is `none` (**fails under the old inert gate** — the regression this fixes)
- the scaled bottom-right handle's center stays within 1.5px of the node's bottom-right corner (validates the `translate` + `scale` composition)

`vue-tsc --noEmit`, lint, `vite build` + `pnpm theme` clean; `parentExtentResize` / `expand-parent` resize-behavior specs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)