### PR TITLE
test(core): guard panel pointer-events disabled during selection drag

### DIFF
--- a/tests/cypress/component/2-vue-flow/panelPointerEventsSelection.cy.ts
+++ b/tests/cypress/component/2-vue-flow/panelPointerEventsSelection.cy.ts
@@ -1,0 +1,37 @@
+import type { VueFlowStore } from '@vue-flow/core';
+import { Panel } from '@vue-flow/core';
+import { h } from 'vue';
+import { getStore } from '../../support/component';
+
+// While a box-selection is being dragged, a Panel must not intercept pointer events — otherwise dragging the
+// selection over a panel would interrupt it. vue-flow does this in `Panel.vue` via the reactive
+// `userSelectionActive` inline style (xyflow/react #5362 moved this to a `.pane.selection .panel` CSS rule,
+// which doesn't map to vue-flow since panels render outside `.vue-flow__pane`). This guards the behavior.
+describe('panel pointer-events during selection', () => {
+  let store: VueFlowStore;
+
+  function mount() {
+    cy.vueFlow({ fitView: false, nodes: [] }, undefined, {
+      default: () => h(Panel, { position: 'top-left' }, () => 'panel'),
+    });
+    cy.then(() => {
+      store = getStore();
+    });
+  }
+
+  it('disables panel pointer-events while a selection is active, restores them after', () => {
+    mount();
+
+    cy.get('.vue-flow__panel').should('have.css', 'pointer-events', 'all');
+
+    cy.then(() => {
+      store.userSelectionActive.value = true;
+    });
+    cy.get('.vue-flow__panel').should('have.css', 'pointer-events', 'none');
+
+    cy.then(() => {
+      store.userSelectionActive.value = false;
+    });
+    cy.get('.vue-flow__panel').should('have.css', 'pointer-events', 'all');
+  });
+});


### PR DESCRIPTION
Re: [xyflow/react #5362](https://github.com/xyflow/xyflow/pull/5362) — *"Remove pointer events from Panel via CSS while a selection gets dragged."*

## Already handled — adding a guard (no production change)

#5362 is a refactor: it drops the Panel's JS store-subscription (`userSelectionActive → pointerEvents`) and disables panel pointer-events purely in CSS with a descendant selector:

```css
.xy-flow__pane.selection .xy-flow__panel { pointer-events: none; }
```

This works in RF/Svelte because their `Panel` renders **inside** `.react-flow__pane` (`Pane` renders `{children}` within the pane div).

**It doesn't translate to vue-flow:** panels render through `VueFlow.vue`'s default slot, which is a **sibling** of `.vue-flow__viewport` — *not* a descendant of `.vue-flow__pane` (only the `#zoom-pane` named slot lands inside the pane). The `.selection` class is on `.vue-flow__pane`, *below* the panel's level, so the descendant selector would match nothing. Porting it verbatim would remove the working JS guard and let panels block selection drags — a regression.

vue-flow already prevents this via the existing reactive inline style in `Panel.vue`:

```vue
:style="{ pointerEvents: userSelectionActive ? 'none' : 'all' }"
```

So no production change — this just adds a regression guard for the behavior.

## Verification

New `panelPointerEventsSelection.cy.ts` (Chrome, 1/1): a `<Panel>` has `pointer-events: all` normally, `none` once `userSelectionActive` is set, and `all` again after it clears. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)