### PR TITLE
test(core): guard unknown node/edge type falls back to custom default

### DIFF
--- a/tests/cypress/component/2-vue-flow/unknownTypeDefaultOverride.cy.ts
+++ b/tests/cypress/component/2-vue-flow/unknownTypeDefaultOverride.cy.ts
@@ -1,0 +1,45 @@
+import { defineComponent, h, markRaw } from 'vue';
+
+// xyflow/react #5384: when a node/edge has an unknown `type`, it falls back to the `'default'` type — and
+// that fallback must honor a user's CUSTOM `default` registered via `nodeTypes`/`edgeTypes`, not the
+// built-in. vue-flow resolves the fallback through the merged `getNodeTypes`/`getEdgeTypes`
+// (`{ ...builtin, ...userTypes }`), so a custom default already wins. This guards that behavior.
+describe('unknown type falls back to the custom default override (#5384)', () => {
+  const CustomDefaultNode = markRaw(
+    defineComponent({
+      name: 'CustomDefaultNode',
+      setup: () => () => h('div', { class: 'custom-default-node' }, 'custom default node'),
+    }),
+  );
+
+  const CustomDefaultEdge = markRaw(
+    defineComponent({
+      name: 'CustomDefaultEdge',
+      setup: () => () => h('path', { 'class': 'custom-default-edge', 'd': 'M0,0 L10,10', 'data-testid': 'custom-edge' }),
+    }),
+  );
+
+  it('renders an unknown node type with the custom default node', () => {
+    cy.vueFlow({
+      fitView: false,
+      nodeTypes: { default: CustomDefaultNode },
+      nodes: [{ id: '1', type: 'unregistered', position: { x: 0, y: 0 }, data: {} }],
+    });
+
+    cy.get('.vue-flow__node[data-id="1"] .custom-default-node').should('exist');
+  });
+
+  it('renders an unknown edge type with the custom default edge', () => {
+    cy.vueFlow({
+      fitView: false,
+      edgeTypes: { default: CustomDefaultEdge },
+      nodes: [
+        { id: '1', type: 'default', position: { x: 0, y: 0 }, data: {} },
+        { id: '2', type: 'default', position: { x: 200, y: 0 }, data: {} },
+      ],
+      edges: [{ id: 'e1-2', source: '1', target: '2', type: 'unregistered' }],
+    });
+
+    cy.get('.vue-flow__edge[data-id="e1-2"] .custom-default-edge').should('exist');
+  });
+});


### PR DESCRIPTION
Re: [xyflow/react #5384](https://github.com/xyflow/xyflow/pull/5384) — *"Fix node/edge fallback to respect custom default type when an unknown type is encountered."*

## Already handled — adding a guard (no production change)

In RF, when a node/edge has an **unknown `type`**, it falls back to `'default'` — but the fallback used `builtinNodeTypes.default` / `builtinEdgeTypes.default`, ignoring a user's custom override of the `default` type. #5384 changes it to `nodeTypes?.['default'] || builtinNodeTypes.default`.

**vue-flow already does the right thing.** `NodeWrapper`/`EdgeWrapper` resolve the unknown-type fallback through the merged getters:

```ts
// getters.ts
const nodeTypes = { ...defaultNodeTypes, ...state.nodeTypes };  // user types override built-ins
// NodeWrapper render (unknown type → nodeCmp === false):
h(nodeCmp.value === false ? getNodeTypes.value.default : nodeCmp.value, { ... })
```

Since `getNodeTypes.value.default` (and `getEdgeTypes.value.default`) is the user's custom `default` when registered, the fallback already honors it — no built-in-only path to fix.

## Verification

New `unknownTypeDefaultOverride.cy.ts` (Chrome, 2/2):
- a node with `type: 'unregistered'` + `nodeTypes: { default: CustomDefaultNode }` → renders the custom default node
- an edge with `type: 'unregistered'` + `edgeTypes: { default: CustomDefaultEdge }` → renders the custom default edge

Test-only (no changeset); lint clean.

> Note: this covers the `nodeTypes`/`edgeTypes` **prop** path, which is what #5384 addresses (RF has no slots). vue-flow's slot-based `#node-default`/`#edge-default` override is not consulted for the unknown-type fallback — a possible separate follow-up, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)