### PR TITLE
feat(core): add stepPosition option to smooth-step/step edges

### DIFF
--- a/.changeset/smoothstep-edge-step-position.md
+++ b/.changeset/smoothstep-edge-step-position.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Add a `stepPosition` option to smooth-step / step edges (mirrors xyflow/react #5376). Set `pathOptions.stepPosition` (0 = bend at source, 1 = at target, 0.5 = midpoint, the default) to control where the edge bends along its path. The path math comes from `@xyflow/system`'s `getSmoothStepPath`; the `SmoothStepEdge` component now forwards the option to it.

--- a/packages/core/src/components/Edges/SmoothStepEdge.ts
+++ b/packages/core/src/components/Edges/SmoothStepEdge.ts
@@ -26,6 +26,7 @@ const SmoothStepEdge = defineComponent<SmoothStepEdgeProps>({
     'markerStart',
     'interactionWidth',
     'offset',
+    'stepPosition',
   ],
   compatConfig: { MODE: 3 },
   setup(props, { attrs }) {

--- a/packages/core/src/types/edge.ts
+++ b/packages/core/src/types/edge.ts
@@ -105,6 +105,8 @@ export interface DefaultEdge<Data extends Record<string, unknown> = Record<strin
 export interface SmoothStepPathOptions {
   offset?: number;
   borderRadius?: number;
+  /** where the bend sits along the path: 0 = at source, 1 = at target, 0.5 = midpoint @default 0.5 */
+  stepPosition?: number;
 }
 
 export type SmoothStepEdgeType<Data extends Record<string, unknown> = Record<string, unknown>> = DefaultEdge<Data> & {

--- a/tests/cypress/component/2-vue-flow/smoothStepEdgeStepPosition.cy.ts
+++ b/tests/cypress/component/2-vue-flow/smoothStepEdgeStepPosition.cy.ts
@@ -1,0 +1,55 @@
+import type { VueFlowStore } from '@vue-flow/core';
+import { Position } from '@vue-flow/core';
+import { getStore } from '../../support/component';
+
+// xyflow/react #5376: smoothstep/step edges accept a `pathOptions.stepPosition` (0 = bend at source,
+// 1 = at target, 0.5 = midpoint, the default). The engine lives in `@xyflow/system`'s `getSmoothStepPath`;
+// this guards that vue-flow forwards `pathOptions.stepPosition` through to it.
+describe('smoothstep edge stepPosition (#5376)', () => {
+  let store: VueFlowStore;
+
+  const PATH = '.vue-flow__edge[data-id="e1-2"] .vue-flow__edge-path';
+
+  beforeEach(() => {
+    cy.vueFlow({
+      fitView: false,
+      // opposite horizontal handles (source → right, target → left) so the bend's X tracks stepPosition
+      nodes: [
+        { id: '1', position: { x: 0, y: 0 }, width: 40, height: 40, data: {}, sourcePosition: Position.Right, targetPosition: Position.Left },
+        { id: '2', position: { x: 300, y: 150 }, width: 40, height: 40, data: {}, sourcePosition: Position.Right, targetPosition: Position.Left },
+      ],
+      edges: [{ id: 'e1-2', source: '1', target: '2', type: 'smoothstep', pathOptions: { stepPosition: 0.2 } }],
+    });
+    cy.then(() => {
+      store = getStore();
+    });
+  });
+
+  it('moves the bend when stepPosition changes', () => {
+    let near: string | undefined;
+    cy.get(PATH).invoke('attr', 'd').then((d) => {
+      near = d as string;
+    });
+
+    cy.then(() => store.updateEdge('e1-2', { pathOptions: { stepPosition: 0.8 } }));
+
+    cy.get(PATH).should(($p) => {
+      expect($p.attr('d'), 'stepPosition 0.8 produces a different path than 0.2').to.not.eq(near);
+    });
+  });
+
+  it('treats an unset stepPosition as the 0.5 default', () => {
+    cy.then(() => store.updateEdge('e1-2', { pathOptions: {} }));
+
+    let unset: string | undefined;
+    cy.get(PATH).invoke('attr', 'd').then((d) => {
+      unset = d as string;
+    });
+
+    cy.then(() => store.updateEdge('e1-2', { pathOptions: { stepPosition: 0.5 } }));
+
+    cy.get(PATH).should(($p) => {
+      expect($p.attr('d'), 'explicit 0.5 matches the unset default').to.eq(unset);
+    });
+  });
+});


### PR DESCRIPTION
Ports [xyflow/react #5376](https://github.com/xyflow/xyflow/pull/5376) — *"Add stepPosition param to step edge."*

## Change

`@xyflow/system`'s `getSmoothStepPath` already accepts a `stepPosition` param (`0` = bend at source, `1` = at target, `0.5` = midpoint, the default) — vue-flow just never surfaced it. Two small edits:

- `SmoothStepPathOptions` gains `stepPosition?: number`
- `SmoothStepEdge` declares `stepPosition` as a prop

`EdgeWrapper` already spreads an edge's `pathOptions` into the edge component as flat props, and `SmoothStepEdge` spreads `...props` into `getSmoothStepPath`, so `pathOptions: { stepPosition }` now flows straight through. `StepEdge` (which renders `SmoothStepEdge` with `borderRadius: 0`) forwards it via `...attrs`.

## Verification

New `smoothStepEdgeStepPosition.cy.ts` (Chrome, 2/2), with opposite horizontal handles so the bend's X tracks `stepPosition`:
- changing `stepPosition` (0.2 → 0.8) produces a different rendered path `d` (proves it's plumbed through — a no-op wiring would leave both at the 0.5 path)
- an unset `stepPosition` matches an explicit `0.5`

`vue-tsc --noEmit`, lint, `vite build` clean; `customEdge` / `updateEdge` regression specs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)