### PR TITLE
test(core): guard fitView-on-init fires without node changes

### DIFF
--- a/tests/cypress/component/2-vue-flow/fitViewOnInitNoChanges.cy.ts
+++ b/tests/cypress/component/2-vue-flow/fitViewOnInitNoChanges.cy.ts
@@ -1,0 +1,46 @@
+import type { VueFlowStore } from '@vue-flow/core';
+import { getStore } from '../../support/component';
+
+// xyflow/react #5127 + #5132: in RF the initial `fitView` is queued (`fitViewQueued`) and resolved by the
+// BatchProvider when the node queue flushes — which broke when the controlled flow's `onNodesChange` produced
+// no changes (#5127) or wasn't defined at all (#5132). vue-flow has no batch queue: `useFitViewOnInit`
+// reactively watches `nodesInitialized` (read straight from the measured node lookup) and fits once nodes are
+// measured — independent of any change handler. These tests pin that down: the initial fit fires even with
+// `autoApplyChanges: false` (no auto-applied changes) and with no change listener attached.
+describe('fitView on init without node changes (#5127 / #5132 are N/A)', () => {
+  let store: VueFlowStore;
+
+  const IDENTITY = { x: 0, y: 0, zoom: 1 };
+
+  function mount(extra: Record<string, unknown>) {
+    cy.vueFlow({
+      fitView: true,
+      // nodes placed far from the origin so a successful fit must move the viewport off the identity transform
+      nodes: [
+        { id: '1', position: { x: 400, y: 400 }, width: 40, height: 40, data: {} },
+        { id: '2', position: { x: 700, y: 600 }, width: 40, height: 40, data: {} },
+      ],
+      ...extra,
+    });
+    cy.then(() => {
+      store = getStore();
+    });
+  }
+
+  it('fits on init with autoApplyChanges disabled (no changes auto-applied)', () => {
+    mount({ autoApplyChanges: false });
+
+    cy.tryAssertion(() => {
+      expect(store.viewport.value, 'viewport moved off identity → fit ran').to.not.deep.eq(IDENTITY);
+    });
+  });
+
+  it('fits on init with no change listener attached', () => {
+    mount({});
+    // deliberately register no onNodesChange / onEdgesChange handler
+
+    cy.tryAssertion(() => {
+      expect(store.viewport.value, 'viewport moved off identity → fit ran').to.not.deep.eq(IDENTITY);
+    });
+  });
+});


### PR DESCRIPTION
Re: [xyflow/react #5127](https://github.com/xyflow/xyflow/pull/5127) (*fitView not working when returning early in `onNodesChange`*) + [#5132](https://github.com/xyflow/xyflow/pull/5132) (*fitView not working when `onNodesChange` is not defined*).

## Already handled — adding a guard (no production change)

Both RF bugs are rooted in its **`BatchProvider` queue**: the initial `fitView` is deferred via a `fitViewQueued` store flag and only resolved when the batched node queue flushes through `onNodesChange`. That breaks when the controlled flow's `onNodesChange` produces no changes (#5127) or isn't defined (#5132) — the queued fit never resolves; the fixes force a `setNodes` re-render in those cases.

**vue-flow has no batch queue.** The "fitView queue" concept is instead a reactive watcher — `useFitViewOnInit` watches `nodesInitialized` (computed straight from the measured node lookup) plus panZoom/dimensions, and calls `fitView` once nodes are measured. It never routes the initial fit through a change handler, so neither "no changes" nor "no `onNodesChange`" can stop it. No port needed.

## Verification

New `fitViewOnInitNoChanges.cy.ts` (Chrome, 2/2), nodes placed far from the origin so a successful fit must move the viewport off the identity transform:
- `:fit-view` with `autoApplyChanges: false` (no auto-applied changes) → viewport fits
- `:fit-view` with no change listener attached → viewport fits

(Measurement updates the lookup in-place regardless of `autoApplyChanges`, so `nodesInitialized` flips and the reactive fit fires — the same reason the `nodesInitialized` computed is kept rather than cached.) Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)