### PR TITLE
feat(core): defer imperative fitView until nodes are measured

### DIFF
--- a/.changeset/fitview-queue.md
+++ b/.changeset/fitview-queue.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Defer an imperative `fitView()` until the nodes are measured (ports xyflow/react's `fitView` queue). A `fitView()` call made before the nodes settle — e.g. right after `addNodes()` — used to frame only the already-measured nodes (`getFitViewNodes` skips unmeasured ones) and ignore the new ones. It now waits for `nodesInitialized` before fitting, so the fit always frames the current nodes. An empty flow resolves immediately (nothing to wait for). The `useNodesInitialized` check is now a shared `areNodesInitialized` helper used by both the composable and the fitView queue.

--- a/packages/core/src/composables/useNodesInitialized.ts
+++ b/packages/core/src/composables/useNodesInitialized.ts
@@ -1,7 +1,6 @@
 import { computed } from 'vue';
-import { storeToRefs } from './storeToRefs';
+import { areNodesInitialized } from '../utils';
 import { useStore } from './useStore';
-import { useVueFlow } from './useVueFlow';
 
 export interface UseNodesInitializedOptions {
   includeHiddenNodes?: boolean;
@@ -19,30 +18,7 @@ export interface UseNodesInitializedOptions {
  * @returns boolean indicating whether all nodes are initialized
  */
 export function useNodesInitialized(options: UseNodesInitializedOptions = { includeHiddenNodes: false }) {
-  const { getInternalNode } = useVueFlow();
-  const { nodes } = storeToRefs(useStore());
+  const { nodeLookup } = useStore();
 
-  return computed(() => {
-    if (nodes.value.length === 0) {
-      return false;
-    }
-
-    for (const node of nodes.value) {
-      if (options.includeHiddenNodes || !node.hidden) {
-        // `nodes` are user `Node`s; the measured/handleBounds live on the InternalNode. A node is
-        // initialized once it has been measured (handleBounds set + non-zero/defined dimensions).
-        const internalNode = getInternalNode(node.id);
-        if (
-          !internalNode
-          || internalNode.internals.handleBounds === undefined
-          || !internalNode.measured?.width
-          || !internalNode.measured?.height
-        ) {
-          return false;
-        }
-      }
-    }
-
-    return true;
-  });
+  return computed(() => areNodesInitialized(nodeLookup, options.includeHiddenNodes));
 }

--- a/packages/core/src/composables/useViewportHelper.ts
+++ b/packages/core/src/composables/useViewportHelper.ts
@@ -1,8 +1,9 @@
 import type { Project } from '@xyflow/system';
 import type { Edge, Node, NodeLookup, State, ViewportFunctions } from '../types';
+import { until } from '@vueuse/core';
 import { fitViewport, getViewportForBounds, pointToRendererPoint, rendererPointToPoint } from '@xyflow/system';
 import { computed } from 'vue';
-import { warn } from '../utils';
+import { areNodesInitialized, warn } from '../utils';
 
 export interface ViewportHelper<NodeType extends Node = Node> extends ViewportFunctions<NodeType> {
   viewportInitialized: boolean;
@@ -42,6 +43,10 @@ export function useViewportHelper<NodeType extends Node = Node, EdgeType extends
   state: State<NodeType, EdgeType>,
   nodeLookup: NodeLookup<NodeType>,
 ) {
+  // whether every (non-hidden) node has been measured — `fitView` waits on this so an imperative call right
+  // after `addNodes` doesn't fit around stale (unmeasured) geometry (`getFitViewNodes` skips unmeasured nodes)
+  const nodesInitialized = computed(() => areNodesInitialized(nodeLookup));
+
   return computed<ViewportHelper<NodeType>>(() => {
     const panZoom = state.panZoom;
     const isInitialized = state.panZoom && state.dimensions.width && state.dimensions.height;
@@ -86,6 +91,14 @@ export function useViewportHelper<NodeType extends Node = Node, EdgeType extends
       ) => {
         if (!panZoom) {
           return false;
+        }
+
+        // queue the fit until every node is measured (xyflow/react's `fitViewQueued`): a fit requested
+        // before the nodes settle — e.g. right after `addNodes` — would otherwise frame only the already
+        // measured nodes (`getFitViewNodes` skips unmeasured ones) and ignore the new ones. An empty flow has
+        // nothing to wait for, so don't queue (else the fit would never resolve).
+        if (nodeLookup.size > 0 && !nodesInitialized.value) {
+          await until(nodesInitialized).toBe(true);
         }
 
         return fitViewport(

--- a/packages/core/src/utils/node.ts
+++ b/packages/core/src/utils/node.ts
@@ -1,6 +1,27 @@
 import type { Ref } from 'vue';
-import type { Actions, InternalNode } from '../types';
+import type { Actions, InternalNode, NodeLookup } from '../types';
 import { nextTick } from 'vue';
+
+/**
+ * Whether every node in the lookup has been measured — handle bounds resolved + non-zero dimensions. Hidden
+ * nodes are skipped unless `includeHiddenNodes`. Shared by `useNodesInitialized` and `fitView`'s queue so the
+ * "are nodes ready" check has a single definition.
+ */
+export function areNodesInitialized(nodeLookup: NodeLookup, includeHiddenNodes = false): boolean {
+  if (nodeLookup.size === 0) {
+    return false;
+  }
+
+  for (const node of nodeLookup.values()) {
+    if (includeHiddenNodes || !node.hidden) {
+      if (node.internals.handleBounds === undefined || !node.measured?.width || !node.measured?.height) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
 
 export function handleNodeClick(
   node: InternalNode,

--- a/tests/cypress/component/2-vue-flow/fitViewQueue.cy.ts
+++ b/tests/cypress/component/2-vue-flow/fitViewQueue.cy.ts
@@ -1,0 +1,32 @@
+import type { VueFlowStore } from '@vue-flow/core';
+import { getStore } from '../../support/component';
+
+// Port of xyflow/react's fitView queue (#5127 / #5132 context): an imperative `fitView()` requested before
+// the nodes have settled — e.g. right after `addNodes` — must wait until they're measured before fitting,
+// otherwise `getFitViewNodes` (which skips unmeasured nodes) frames only the old nodes and ignores the new
+// ones. vue-flow now defers the fit on `nodesInitialized`.
+describe('imperative fitView defers until nodes are measured', () => {
+  let store: VueFlowStore;
+
+  it('frames a freshly added node instead of fitting stale geometry', () => {
+    cy.vueFlow({ fitView: false, nodes: [{ id: '1', position: { x: 0, y: 0 }, data: { label: 'a' } }] });
+    cy.then(() => {
+      store = getStore();
+    });
+    // wait for the initial node to be measured so the flow is in a settled state first
+    cy.tryAssertion(() => expect(store.getInternalNode('1')?.measured?.width).to.be.greaterThan(0));
+
+    cy.then(async () => {
+      // add a far-away node, then fit immediately — node 2 is not measured yet at this point
+      store.addNodes([{ id: '2', position: { x: 2000, y: 2000 }, data: { label: 'far' } }]);
+
+      const ok = await store.fitView({ padding: 0.1 });
+
+      expect(ok, 'fitView resolved').to.eq(true);
+      // the deferral guarantee: by the time fitView resolved, node 2 had been measured
+      expect(store.getInternalNode('2')?.measured?.width, 'node 2 was measured before the fit ran').to.be.greaterThan(0);
+      // and the fit framed the far node → zoomed out below 1 (a stale fit of only node 1 would clamp to maxZoom)
+      expect(store.viewport.value.zoom, 'fit zoomed out to include the far node').to.be.lessThan(1);
+    });
+  });
+});


### PR DESCRIPTION
Ports xyflow/react's **`fitView` queue** — the mechanism behind [#5127](https://github.com/xyflow/xyflow/pull/5127) / [#5132](https://github.com/xyflow/xyflow/pull/5132) — to vue-flow's imperative path.

## Problem

`getFitViewNodes` only includes nodes with a measured width/height, so an imperative `fitView()` called *before* the nodes settle — most commonly right after `addNodes()` — framed only the already-measured nodes and **ignored the freshly added ones**. (The `:fit-view` *init* path was already safe: `useFitViewOnInit` waits on `nodesInitialized`. Only the imperative call lacked the guarantee — see #2140.)

## Change

`fitView()` now defers until `nodesInitialized` before fitting — the same ordering guarantee RF's `fitViewQueued` flag provides: the fit resolves only after the pending nodes are applied **and** measured, so it never frames stale geometry. An empty flow resolves immediately (nothing to wait for, so it doesn't hang).

The "are all nodes measured" predicate is extracted into a shared **`areNodesInitialized(nodeLookup, includeHiddenNodes?)`** helper, so `useNodesInitialized` and the fitView queue share **one** definition rather than two parallel checks. (Consistent with keeping `nodesInitialized` a derived check rather than cached state.)

## Verification

- New `fitViewQueue.cy.ts` (Chrome, 1/1): after `addNodes()` of a far node + `await fitView()`, the new node **was measured by the time the fit resolved** and the fit **zoomed out to frame it** (`zoom < 1`) — vs the previous stale fit that excluded it.
- Regression: `fitView.cy.ts` (3/3, incl. the empty-flow case that must not hang), `controlledViewport`, `nodeInitialDimensions` all green.
- `vue-tsc --noEmit`, lint, `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)