### PR TITLE
feat(core): add ariaLabelConfig prop for customizing a11y text

### DIFF
--- a/.changeset/aria-label-config.md
+++ b/.changeset/aria-label-config.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Add an `ariaLabelConfig` prop to customize the accessibility text (ports xyflow/react #5277). Pass a `Partial<AriaLabelConfig>` (merged over the defaults) to override any of the node/edge a11y descriptions, the aria-live "moved node" message, and the Controls / MiniMap / Handle aria labels. Defaults now come from `@xyflow/system`'s `defaultAriaLabelConfig`, aligning the wording with `@xyflow/react`/`@xyflow/svelte`. As part of this, the Controls buttons and Handle — which previously had no `aria-label` — now get accessible labels, the Controls panel gets a `Control Panel` label, and the MiniMap label default moves into the config. `AriaLabelConfig` is re-exported from the package root.

--- a/packages/core/src/components/A11y/A11yDescriptions.vue
+++ b/packages/core/src/components/A11y/A11yDescriptions.vue
@@ -3,7 +3,7 @@ import { storeToRefs, useStore, useVueFlow } from '../../composables';
 import { ARIA_EDGE_DESC_KEY, ARIA_LIVE_MESSAGE, ARIA_NODE_DESC_KEY } from '../../utils/a11y';
 
 const { id } = useVueFlow();
-const { disableKeyboardA11y, ariaLiveMessage } = storeToRefs(useStore());
+const { disableKeyboardA11y, ariaLiveMessage, ariaLabelConfig } = storeToRefs(useStore());
 </script>
 
 <script lang="ts">
@@ -15,16 +15,15 @@ export default {
 
 <template>
   <div :id="`${ARIA_NODE_DESC_KEY}-${id}`" style="display: none">
-    Press enter or space to select a node.
     {{
-      !disableKeyboardA11y
-        ? 'You can then use the arrow keys to move the node around, press delete to remove it and press escape to cancel.'
-        : ''
+      disableKeyboardA11y
+        ? ariaLabelConfig['node.a11yDescription.default']
+        : ariaLabelConfig['node.a11yDescription.keyboardDisabled']
     }}
   </div>
 
   <div :id="`${ARIA_EDGE_DESC_KEY}-${id}`" style="display: none">
-    Press enter or space to select an edge. You can then press delete to remove it or press escape to cancel.
+    {{ ariaLabelConfig['edge.a11yDescription.default'] }}
   </div>
 
   <div

--- a/packages/core/src/components/Controls/ControlButton.vue
+++ b/packages/core/src/components/Controls/ControlButton.vue
@@ -1,6 +1,8 @@
 <script lang="ts" setup>
 defineProps<{
   disabled?: boolean;
+  /** accessible label; applied as both `aria-label` and `title` (mirrors xyflow) */
+  label?: string;
 }>();
 
 defineEmits<{
@@ -16,7 +18,14 @@ export default {
 </script>
 
 <template>
-  <button type="button" class="vue-flow__controls-button" :disabled="disabled" @click="$emit('click', $event)">
+  <button
+    type="button"
+    class="vue-flow__controls-button"
+    :disabled="disabled"
+    :aria-label="label"
+    :title="label"
+    @click="$emit('click', $event)"
+  >
     <slot />
   </button>
 </template>

--- a/packages/core/src/components/Controls/Controls.vue
+++ b/packages/core/src/components/Controls/Controls.vue
@@ -21,7 +21,7 @@ const emit = defineEmits<ControlEmits>();
 
 const { setInteractive, zoomIn, zoomOut, fitView, viewport } = useVueFlow();
 
-const { nodesDraggable, nodesConnectable, elementsSelectable, minZoom, maxZoom } = storeToRefs(useStore());
+const { nodesDraggable, nodesConnectable, elementsSelectable, minZoom, maxZoom, ariaLabelConfig } = storeToRefs(useStore());
 
 const isInteractive = toRef(() => nodesDraggable.value || nodesConnectable.value || elementsSelectable.value);
 
@@ -62,12 +62,17 @@ export default {
 </script>
 
 <template>
-  <Panel class="vue-flow__controls" :position="position">
+  <Panel class="vue-flow__controls" :position="position" :label="ariaLabel ?? ariaLabelConfig['controls.ariaLabel']">
     <slot name="top" />
 
     <template v-if="showZoom">
       <slot name="control-zoom-in">
-        <ControlButton class="vue-flow__controls-zoomin" :disabled="maxZoomReached" @click="onZoomInHandler">
+        <ControlButton
+          class="vue-flow__controls-zoomin"
+          :disabled="maxZoomReached"
+          :label="ariaLabelConfig['controls.zoomIn.ariaLabel']"
+          @click="onZoomInHandler"
+        >
           <slot name="icon-zoom-in">
             <component :is="PlusIcon" />
           </slot>
@@ -75,7 +80,12 @@ export default {
       </slot>
 
       <slot name="control-zoom-out">
-        <ControlButton class="vue-flow__controls-zoomout" :disabled="minZoomReached" @click="onZoomOutHandler">
+        <ControlButton
+          class="vue-flow__controls-zoomout"
+          :disabled="minZoomReached"
+          :label="ariaLabelConfig['controls.zoomOut.ariaLabel']"
+          @click="onZoomOutHandler"
+        >
           <slot name="icon-zoom-out">
             <component :is="MinusIcon" />
           </slot>
@@ -85,7 +95,11 @@ export default {
 
     <template v-if="showFitView">
       <slot name="control-fit-view">
-        <ControlButton class="vue-flow__controls-fitview" @click="onFitViewHandler">
+        <ControlButton
+          class="vue-flow__controls-fitview"
+          :label="ariaLabelConfig['controls.fitView.ariaLabel']"
+          @click="onFitViewHandler"
+        >
           <slot name="icon-fit-view">
             <component :is="FitView" />
           </slot>
@@ -95,7 +109,12 @@ export default {
 
     <template v-if="showInteractive">
       <slot name="control-interactive">
-        <ControlButton v-if="showInteractive" class="vue-flow__controls-interactive" @click="onInteractiveChangeHandler">
+        <ControlButton
+          v-if="showInteractive"
+          class="vue-flow__controls-interactive"
+          :label="ariaLabelConfig['controls.interactive.ariaLabel']"
+          @click="onInteractiveChangeHandler"
+        >
           <slot v-if="isInteractive" name="icon-unlock">
             <component :is="Unlock" />
           </slot>

--- a/packages/core/src/components/Controls/types.ts
+++ b/packages/core/src/components/Controls/types.ts
@@ -32,6 +32,12 @@ export interface ControlProps {
    * @default 'bottom-left'
    */
   position?: PanelPosition;
+  /**
+   * Accessible label for the controls panel; falls back to `ariaLabelConfig['controls.ariaLabel']`.
+   *
+   * @default 'Control Panel'
+   */
+  ariaLabel?: string | null;
 }
 
 export interface ControlEmits {

--- a/packages/core/src/components/Handle/Handle.vue
+++ b/packages/core/src/components/Handle/Handle.vue
@@ -28,6 +28,7 @@ const {
   nodesConnectable,
   noDragClassName,
   noPanClassName,
+  ariaLabelConfig,
 } = storeToRefs(useStore());
 
 const { id: nodeId, node: nodeRef, nodeEl, connectedEdges } = useNode();
@@ -194,6 +195,7 @@ export default {
   <div
     ref="handle"
     v-bind="handleDataIds"
+    :aria-label="ariaLabelConfig['handle.ariaLabel']"
     class="vue-flow__handle"
     :class="[
       `vue-flow__handle-${position}`,

--- a/packages/core/src/components/MiniMap/MiniMap.vue
+++ b/packages/core/src/components/MiniMap/MiniMap.vue
@@ -24,7 +24,7 @@ const {
   maskBorderRadius = 0,
   pannable = false,
   zoomable = false,
-  ariaLabel = 'Vue Flow mini map',
+  ariaLabel,
   inversePan = false,
   zoomStep = 1,
   offsetScale = 5,
@@ -43,7 +43,10 @@ const { id, viewport, emits } = useVueFlow();
 
 const { nodeLookup } = useStore();
 
-const { edges, nodes, transform, translateExtent, dimensions, panZoom } = storeToRefs(useStore());
+const { edges, nodes, transform, translateExtent, dimensions, panZoom, ariaLabelConfig } = storeToRefs(useStore());
+
+// fall back to the configurable default label (`ariaLabelConfig`) when no explicit `ariaLabel` is passed
+const resolvedAriaLabel = computed(() => ariaLabel ?? ariaLabelConfig.value['minimap.ariaLabel']);
 
 const el = shallowRef<SVGElement>();
 
@@ -229,7 +232,7 @@ export default {
       role="img"
       @click="onSvgClick"
     >
-      <title v-if="ariaLabel" :id="`vue-flow__minimap-${id}`">{{ ariaLabel }}</title>
+      <title v-if="resolvedAriaLabel" :id="`vue-flow__minimap-${id}`">{{ resolvedAriaLabel }}</title>
 
       <!-- v-memo on the lookup entry: unchanged nodes keep their InternalNode reference across commits
       (checkEquality reuse), so drag/pan-frame MiniMap re-renders skip every untouched child instead of

--- a/packages/core/src/components/Nodes/NodeWrapper.ts
+++ b/packages/core/src/components/Nodes/NodeWrapper.ts
@@ -55,6 +55,7 @@ const NodeWrapper = defineComponent({
       multiSelectionActive,
       disableKeyboardA11y,
       ariaLiveMessage,
+      ariaLabelConfig,
       nodeDragThreshold,
       nodesDraggable,
       elementsSelectable,
@@ -398,9 +399,11 @@ const NodeWrapper = defineComponent({
         // prevent page scrolling
         event.preventDefault();
 
-        ariaLiveMessage.value = `Moved selected node ${event.key.replace('Arrow', '').toLowerCase()}. New position, x: ${~~node
-          .position
-          .x}, y: ${~~node.position.y}`;
+        ariaLiveMessage.value = ariaLabelConfig.value['node.a11yDescription.ariaLiveMessage']({
+          direction: event.key.replace('Arrow', '').toLowerCase(),
+          x: ~~node.position.x,
+          y: ~~node.position.y,
+        });
 
         updateNodePositions(
           {

--- a/packages/core/src/components/Panel/Panel.vue
+++ b/packages/core/src/components/Panel/Panel.vue
@@ -18,7 +18,12 @@ export default {
 </script>
 
 <template>
-  <div class="vue-flow__panel" :class="positionClasses" :style="{ pointerEvents: userSelectionActive ? 'none' : 'all' }">
+  <div
+    class="vue-flow__panel"
+    :class="positionClasses"
+    :aria-label="label ?? undefined"
+    :style="{ pointerEvents: userSelectionActive ? 'none' : 'all' }"
+  >
     <slot />
   </div>
 </template>

--- a/packages/core/src/composables/useWatchProps.ts
+++ b/packages/core/src/composables/useWatchProps.ts
@@ -1,6 +1,7 @@
 import type { Connection } from '@xyflow/system';
 import type { Ref, ToRefs } from 'vue';
 import type { Edge, FlowProps, Node, VueFlowStoreHandle } from '../types';
+import { mergeAriaLabelConfig } from '@xyflow/system';
 import { effectScope, isRef, toRaw, toRef, watch } from 'vue';
 import { isDef } from '../utils';
 import { storeToRefs } from './storeToRefs';
@@ -99,9 +100,9 @@ export function useWatchProps<NodeType extends Node = Node, EdgeType extends Edg
       scope.run(() => {
         watch(
           () => props.maxZoom,
-          () => {
-            if (props.maxZoom && isDef(props.maxZoom)) {
-              instance.setMaxZoom(props.maxZoom);
+          (maxZoom) => {
+            if (maxZoom && isDef(maxZoom)) {
+              instance.setMaxZoom(maxZoom);
             }
           },
           {
@@ -115,9 +116,9 @@ export function useWatchProps<NodeType extends Node = Node, EdgeType extends Edg
       scope.run(() => {
         watch(
           () => props.minZoom,
-          () => {
-            if (props.minZoom && isDef(props.minZoom)) {
-              instance.setMinZoom(props.minZoom);
+          (minZoom) => {
+            if (minZoom && isDef(minZoom)) {
+              instance.setMinZoom(minZoom);
             }
           },
           { immediate: true },
@@ -129,9 +130,9 @@ export function useWatchProps<NodeType extends Node = Node, EdgeType extends Edg
       scope.run(() => {
         watch(
           () => props.translateExtent,
-          () => {
-            if (props.translateExtent && isDef(props.translateExtent)) {
-              instance.setTranslateExtent(props.translateExtent);
+          (translateExtent) => {
+            if (translateExtent && isDef(translateExtent)) {
+              instance.setTranslateExtent(translateExtent);
             }
           },
           {
@@ -145,9 +146,9 @@ export function useWatchProps<NodeType extends Node = Node, EdgeType extends Edg
       scope.run(() => {
         watch(
           () => props.nodeExtent,
-          () => {
-            if (props.nodeExtent && isDef(props.nodeExtent)) {
-              instance.setNodeExtent(props.nodeExtent);
+          (nodeExtent) => {
+            if (nodeExtent && isDef(nodeExtent)) {
+              instance.setNodeExtent(nodeExtent);
             }
           },
           {
@@ -157,13 +158,27 @@ export function useWatchProps<NodeType extends Node = Node, EdgeType extends Edg
       });
     };
 
+    const watchAriaLabelConfig = () => {
+      scope.run(() => {
+        watch(
+          () => props.ariaLabelConfig,
+          (ariaLabelConfig) => {
+            // merge over the defaults so unspecified keys keep their default text (handled here rather than
+            // in `watchRest`, which would assign the partial verbatim and drop the defaults)
+            state.ariaLabelConfig = mergeAriaLabelConfig(ariaLabelConfig);
+          },
+          { immediate: true },
+        );
+      });
+    };
+
     const watchApplyDefault = () => {
       scope.run(() => {
         watch(
           () => props.autoApplyChanges,
-          () => {
-            if (isDef(props.autoApplyChanges)) {
-              storeRefs.autoApplyChanges.value = props.autoApplyChanges;
+          (autoApplyChanges) => {
+            if (isDef(autoApplyChanges)) {
+              storeRefs.autoApplyChanges.value = autoApplyChanges;
             }
           },
           {
@@ -189,9 +204,9 @@ export function useWatchProps<NodeType extends Node = Node, EdgeType extends Edg
 
         watch(
           () => props.autoConnect,
-          () => {
-            if (isDef(props.autoConnect)) {
-              storeRefs.autoConnect.value = props.autoConnect;
+          (autConnect) => {
+            if (isDef(autConnect)) {
+              storeRefs.autoConnect.value = autConnect;
             }
           },
           { immediate: true },
@@ -229,6 +244,8 @@ export function useWatchProps<NodeType extends Node = Node, EdgeType extends Edg
         'autoConnect',
         // `viewport` isn't a state field (it's a getter on the instance); `useViewportSync` two-way binds it
         'viewport',
+        // merged (not assigned verbatim) by `watchAriaLabelConfig`
+        'ariaLabelConfig',
       ];
 
       for (const key of Object.keys(props)) {
@@ -267,6 +284,7 @@ export function useWatchProps<NodeType extends Node = Node, EdgeType extends Edg
       watchNodeExtent();
       watchApplyDefault();
       watchAutoConnect();
+      watchAriaLabelConfig();
       watchRest();
     };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -86,6 +86,7 @@ export {
 
 export {
   type Align,
+  type AriaLabelConfig,
   type ColorMode,
   type ColorModeClass,
   type Connection,

--- a/packages/core/src/store/state.ts
+++ b/packages/core/src/store/state.ts
@@ -1,5 +1,5 @@
 import type { Edge, FlowProps, Node, State } from '../types';
-import { ConnectionLineType, ConnectionMode, isMacOs, PanOnScrollMode, SelectionMode } from '@xyflow/system';
+import { ConnectionLineType, ConnectionMode, isMacOs, mergeAriaLabelConfig, PanOnScrollMode, SelectionMode } from '@xyflow/system';
 
 import { createHooks } from './hooks';
 
@@ -120,6 +120,7 @@ export function useState<NodeType extends Node = Node, EdgeType extends Edge = E
     autoPanSpeed: 15,
 
     disableKeyboardA11y: false,
+    ariaLabelConfig: mergeAriaLabelConfig(),
     ariaLiveMessage: '',
   };
 }

--- a/packages/core/src/types/flow.ts
+++ b/packages/core/src/types/flow.ts
@@ -1,5 +1,5 @@
 import type { KeyFilter } from '@vueuse/core';
-import type { ColorMode, Connection, ConnectionMode, CoordinateExtent, FitViewOptionsBase, PanOnScrollMode, SelectionMode, SnapGrid, Viewport, ZIndexMode } from '@xyflow/system';
+import type { AriaLabelConfig, ColorMode, Connection, ConnectionMode, CoordinateExtent, FitViewOptionsBase, PanOnScrollMode, SelectionMode, SnapGrid, Viewport, ZIndexMode } from '@xyflow/system';
 import type { CSSProperties } from 'vue';
 import type { VueFlowError } from '../utils';
 import type { EdgeChange, NodeChange } from './changes';
@@ -204,6 +204,8 @@ export interface FlowProps<NodeType extends Node = Node, EdgeType extends Edge =
   zIndexMode?: ZIndexMode;
 
   disableKeyboardA11y?: boolean;
+  /** customize the aria labels / a11y descriptions (node/edge descriptions, the aria-live move message, and the Controls/MiniMap/Handle labels); merged over the defaults */
+  ariaLabelConfig?: Partial<AriaLabelConfig>;
   edgesFocusable?: boolean;
   nodesFocusable?: boolean;
 

--- a/packages/core/src/types/panel.ts
+++ b/packages/core/src/types/panel.ts
@@ -2,4 +2,6 @@ import type { PanelPosition } from '@xyflow/system';
 
 export interface PanelProps {
   position: PanelPosition;
+  /** accessible label for the panel container, applied as `aria-label` (used by `<Controls>`) */
+  label?: string | null;
 }

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -1,5 +1,6 @@
 import type { KeyFilter } from '@vueuse/core';
 import type {
+  AriaLabelConfig,
   ColorMode,
   Connection,
   ConnectionMode,
@@ -168,6 +169,8 @@ export interface State<NodeType extends Node = Node, EdgeType extends Edge = Edg
   autoPanSpeed: number;
 
   disableKeyboardA11y: boolean;
+  /** the merged aria-label / a11y text config (defaults overlaid with the `ariaLabelConfig` prop) */
+  ariaLabelConfig: AriaLabelConfig;
 
   ariaLiveMessage: string;
 }

--- a/tests/cypress/component/2-vue-flow/ariaLabelConfig.cy.ts
+++ b/tests/cypress/component/2-vue-flow/ariaLabelConfig.cy.ts
@@ -1,0 +1,38 @@
+import { Controls, MiniMap } from '@vue-flow/core';
+import { h } from 'vue';
+
+// xyflow/react #5277: `ariaLabelConfig` prop customizes the a11y text (node/edge descriptions, the aria-live
+// move message, and the Controls/MiniMap/Handle labels). The prop is a Partial merged over the defaults.
+describe('ariaLabelConfig (#5277)', () => {
+  beforeEach(() => {
+    cy.vueFlow(
+      {
+        fitView: false,
+        ariaLabelConfig: {
+          'handle.ariaLabel': 'Custom handle',
+          'minimap.ariaLabel': 'Custom minimap',
+          'controls.zoomIn.ariaLabel': 'Custom zoom in',
+          'node.a11yDescription.keyboardDisabled': 'CUSTOM NODE DESC',
+        },
+        nodes: [{ id: '1', position: { x: 0, y: 0 }, data: { label: 'n' } }],
+      },
+      undefined,
+      { default: () => [h(Controls), h(MiniMap)] },
+    );
+  });
+
+  it('applies the overridden labels across handle, minimap, controls, and node description', () => {
+    cy.get('.vue-flow__handle').first().should('have.attr', 'aria-label', 'Custom handle');
+    cy.get('#vue-flow__minimap-test').should('have.text', 'Custom minimap');
+    cy.get('.vue-flow__controls-zoomin').should('have.attr', 'aria-label', 'Custom zoom in');
+    // the zoom-in button also mirrors the label onto `title`
+    cy.get('.vue-flow__controls-zoomin').should('have.attr', 'title', 'Custom zoom in');
+    cy.get('#vue-flow__node-desc-test').should('contain.text', 'CUSTOM NODE DESC');
+  });
+
+  it('keeps the defaults for unspecified keys (merged over defaults)', () => {
+    cy.get('.vue-flow__controls-zoomout').should('have.attr', 'aria-label', 'Zoom Out');
+    cy.get('.vue-flow__controls-fitview').should('have.attr', 'aria-label', 'Fit View');
+    cy.get('.vue-flow__controls').should('have.attr', 'aria-label', 'Control Panel');
+  });
+});


### PR DESCRIPTION
Ports [xyflow/react #5277](https://github.com/xyflow/xyflow/pull/5277) — *"Add `ariaLabelConfig` prop for customizing UI text like aria labels and descriptions."*

## What

A new **`ariaLabelConfig`** prop (`Partial<AriaLabelConfig>`, merged over `@xyflow/system`'s `defaultAriaLabelConfig`) customizes all the a11y text:

- node/edge a11y descriptions (`A11yDescriptions`)
- the aria-live "moved node" message (`NodeWrapper`) — now built from `config['node.a11yDescription.ariaLiveMessage']({ direction, x, y })`
- MiniMap label, Controls panel + button labels, Handle label

Threaded `FlowProps → State` and consumed across the six surfaces. The merge happens in a dedicated `watchAriaLabelConfig` watcher (the generic prop-sync would assign the partial verbatim and drop the unspecified defaults). `AriaLabelConfig` is re-exported from the root.

## Notable

- **Defaults now come from the system config**, aligning wording with react/svelte. This gives the **Controls buttons and Handle accessible labels they previously lacked**, a `Control Panel` label on the Controls container, and moves the MiniMap default label into the config (the `ariaLabel`/`label` props still override per-instance).
- `ControlButton`/`Panel` gained a single-word **`label`** prop that maps to `aria-label` (+ `title` on the button). Camel-case `aria*` prop bindings hit a conflict — `strictTemplates` rejects kebab `:aria-label` on a component while `vue/attribute-hyphenation` rejects camel `:ariaLabel` — so a neutral `label` prop satisfies both.

## Verification

New `ariaLabelConfig.cy.ts` (Chrome, 2/2): a custom config overrides the Handle / MiniMap / Controls-zoom-in / node-description text (and the zoom-in `title` mirrors its label), while unspecified keys keep their defaults (`Zoom Out`, `Fit View`, `Control Panel`) — proving the merge. `vue-tsc --noEmit`, lint, `vite build` clean; `customNode` / `connect` / `handleConnectionIndicator` / `connectionDragThreshold` regressions green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)