### PR TITLE
fix(core): preserve measured dimensions when re-committing nodes

### DIFF
--- a/.changeset/preserve-measured-on-recommit.md
+++ b/.changeset/preserve-measured-on-recommit.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Fix nodes turning invisible after a re-commit that doesn't change their size. Re-committing fresh node objects — a one-way `:nodes` reassignment, a layout pass, `nodes.value.map((n) => ({ ...n }))` — dropped each node's measured dimensions: the node-rep split keeps `measured` off the user `Node`s, and the system's `adoptUserNodes` only sources `measured` from the incoming user node. The node then failed the `nodeHasDimensions` gate and rendered with `visibility: hidden`, and because its DOM size hadn't actually changed the `ResizeObserver` never re-fired to restore it. `adoptNodes` now carries the previously measured dimensions forward for re-committed nodes that don't supply their own (mirroring how the system already reuses `handleBounds`); a genuine resize still re-measures via the `ResizeObserver`.

--- a/packages/core/src/utils/store.ts
+++ b/packages/core/src/utils/store.ts
@@ -143,11 +143,37 @@ export function adoptNodes<NodeType extends Node = Node>(
     validNodes.push(markRaw(toRaw(node)));
   }
 
+  // vue-flow's node-rep split keeps `measured` off the user `Node`s — it lives only on the `InternalNode`.
+  // The system's `adoptUserNodes` sources `measured` solely from `userNode.measured`, so re-committing fresh
+  // user objects (a one-way `:nodes` reassignment, a layout pass, `nodes.value.map(...)`) would reset
+  // `measured` to `undefined` → the node fails `nodeHasDimensions`, renders `visibility:hidden`, and — since
+  // its DOM size didn't change — the ResizeObserver never re-fires to restore it. Snapshot the dimensions
+  // before adoption clears the lookup and carry them forward below, the way the system already reuses
+  // `handleBounds`.
+  const priorMeasured = new Map<string, { width?: number; height?: number }>();
+  for (const [id, internal] of nodeLookup) {
+    const { width, height } = internal.measured ?? {};
+    if (width !== undefined && height !== undefined) {
+      priorMeasured.set(id, { width, height });
+    }
+  }
+
   const { hasSelectedNodes } = adoptUserNodes(validNodes, nodeLookup, parentLookup, { ...options, checkEquality: true });
 
   for (const node of validNodes) {
     if (node.parentId && !nodeLookup.has(node.parentId)) {
       triggerError(new VueFlowError(ErrorCode.NODE_MISSING_PARENT, node.id, node.parentId));
+    }
+
+    // re-adoption only kept `measured` if the user object carried it; restore the prior measured dimensions
+    // for re-committed nodes that didn't, so a content-agnostic update (class/position/layout) stays visible
+    // instead of collapsing to a hidden, never-re-measured node (see the snapshot above)
+    const prior = priorMeasured.get(node.id);
+    if (prior) {
+      const internal = nodeLookup.get(node.id);
+      if (internal && (internal.measured?.width === undefined || internal.measured?.height === undefined)) {
+        internal.measured = prior;
+      }
     }
   }
 


### PR DESCRIPTION
## Problem

Updating nodes after the initial render could make them **disappear** — they aren't removed, they flip to `visibility: hidden`:

- **One-way `:nodes`** (e.g. the basic / multi-flow examples): clicking *toggle class* or *update positions* (`nodes.value = nodes.value.map((n) => ({ ...n, ... }))`) hid every node.
- **`v-model` + `@nodes-initialized` + a layout pass** (the layouting example): `layout()` re-derives nodes via `{ ...node, position }` and they vanished.

## Root cause

NodeWrapper hides a node until it "has dimensions" (`isInit = nodeHasDimensions(node)`). The node-rep split keeps `measured` **off** the user `Node`s — it lives only on the `InternalNode`. The system's `adoptUserNodes` rebuilds `measured` solely from `userNode.measured`, so a re-commit of fresh user objects (which never carried `measured`) resets it to `undefined`. The node then fails the gate and renders `visibility: hidden` — and since its DOM size didn't actually change, the `ResizeObserver` never re-fires to restore it, so it stays hidden.

`measured` *is* written into `state.nodes` on measurement, but with one-way `:nodes` it never round-trips to the user's source ref; and with `v-model` an `@nodes-initialized` handler can re-derive before that round-trip settles. Both paths end at the same failure: a re-committed node with no `measured`.

## Fix

`adoptNodes` snapshots each node's `measured` before `adoptUserNodes` clears the lookup, then restores it onto any re-committed node whose incoming user object didn't supply dimensions — mirroring how the system already reuses `handleBounds`. It writes to the `InternalNode`, never the user node (stays within the node-rep split). A genuine resize still re-measures via the `ResizeObserver`; only the "no actual size change" re-commits (class / position / layout) are protected.

## Verification

- **Chrome (examples/vite)** — basic example, one-way `:nodes`: toggle → updatePos → toggle keeps all 4 nodes visible (was hiding all). Layouting example, `v-model` + `@nodes-initialized`: init layout + TB + LR re-layouts keep all 11 nodes visible and correctly laid out.
- **Cypress (real Chrome)** — `drag`, `nodeInitialDimensions`, `nodeResizerAutoScale` (resize → measured genuinely changes), `parentExtentResize`, `nodesSelectionActive`, `fitViewQueue` all pass.
- Lint clean; build green (`attw` + `vue-tsc` dts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)