### PR TITLE
fix(core): hide reconnecting edge only once the drag starts

### DIFF
--- a/.changeset/reconnect-hide-edge-on-drag-start.md
+++ b/.changeset/reconnect-hide-edge-on-drag-start.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Fix reconnectable edges vanishing when you press an edge's reconnect handle without dragging. The edge was hidden eagerly on pointerdown, but `@xyflow/system`'s `XYHandle` only fires its connect/reconnect-end callbacks once the drag threshold (`connectionDragThreshold`, default `1`) is crossed — so a plain click hid the edge and never restored it (it reappeared only on mouse-move, and was gone entirely on mouse-up). The original edge is now hidden — and `reconnectStart` emitted — only once the reconnect drag actually starts (the connection's `onConnectStart`), matching `@xyflow/react` and `@xyflow/svelte`.

--- a/packages/core/src/components/Edges/EdgeWrapper.ts
+++ b/packages/core/src/components/Edges/EdgeWrapper.ts
@@ -127,6 +127,13 @@ const EdgeWrapper = defineComponent({
       type: reconnectHandleType,
       isValidConnection,
       reconnectHandleType,
+      // xyflow/react + svelte hide the original edge AND emit `reconnectStart` from the system's
+      // `onConnectStart` — i.e. once the reconnect drag actually starts (after the drag threshold), not
+      // eagerly on pointerdown. A plain click on the anchor then leaves the edge in place and emits nothing.
+      onReconnectStart: (event) => {
+        updating.value = true;
+        emit.reconnectStart({ event, edge: storedEdge.value, handleType: reconnectHandleType.value });
+      },
       onReconnect,
       onReconnectEnd,
     });
@@ -326,14 +333,10 @@ const EdgeWrapper = defineComponent({
         return;
       }
 
-      updating.value = true;
-
       nodeId.value = isSourceHandle ? edge.value.target : edge.value.source;
       handleId.value = (isSourceHandle ? edge.value.targetHandle : edge.value.sourceHandle) ?? null;
 
       reconnectHandleType.value = isSourceHandle ? 'target' : 'source';
-
-      emit.reconnectStart({ event, edge: storedEdge.value, handleType: reconnectHandleType.value });
 
       handlePointerDown(event);
     }

--- a/packages/core/src/composables/useHandle.ts
+++ b/packages/core/src/composables/useHandle.ts
@@ -14,6 +14,7 @@ export interface UseHandleProps {
   type: MaybeRefOrGetter<HandleType>;
   isValidConnection?: MaybeRefOrGetter<ValidConnectionFunc | null>;
   reconnectHandleType?: MaybeRefOrGetter<HandleType>;
+  onReconnectStart?: (event: MouseTouchEvent) => void;
   onReconnect?: (event: MouseTouchEvent, connection: Connection) => void;
   onReconnectEnd?: (event: MouseTouchEvent, connectionState: FinalConnectionState<InternalNode>) => void;
 }
@@ -38,6 +39,7 @@ export function useHandle({
   type,
   isValidConnection,
   reconnectHandleType,
+  onReconnectStart,
   onReconnect,
   onReconnectEnd,
 }: UseHandleProps) {
@@ -177,6 +179,13 @@ export function useHandle({
           handleId: params.handleId,
           handleType: params.handleType ?? undefined,
         });
+        // For a reconnect this fires only once the drag actually begins (after `connectionDragThreshold`,
+        // or immediately when it's 0) — the cue to hide the original edge. Hiding it eagerly on pointerdown
+        // would strand a plain click (no drag) with a permanently hidden edge, because the system fires
+        // onConnectEnd/onReconnectEnd only after the drag has started.
+        if (reconnectHandleType) {
+          onReconnectStart?.(evt as MouseTouchEvent);
+        }
       },
       onConnect: (connection) => {
         if (onReconnect) {


### PR DESCRIPTION
## Problem

Grabbing a reconnectable edge's reconnect handle made the **edge disappear**: it vanished on pointer-down even without moving, reappeared only while dragging, and was gone entirely on mouse-up without a drag.

## Root cause

`EdgeWrapper` set `updating = true` (which renders the edge path as `null`) **eagerly** in `handleReconnect`, on pointer-down. But `@xyflow/system`'s `XYHandle` only fires `onConnectEnd` / `onReconnectEnd` once the drag threshold (`connectionDragThreshold`, default `1`) is crossed — both calls live inside an `if (connectionStarted)` block. So a plain click (no drag) hid the edge and the restore callback (`updating = false`) never fired → the edge stayed hidden.

## Fix (matches RF/SF)

Both `@xyflow/react` (`EdgeUpdateAnchors.tsx`) and `@xyflow/svelte` (`EdgeReconnectAnchor.svelte`) hide the edge **and** emit `reconnectStart` from the connection's `onConnectStart` — i.e. once the reconnect drag actually starts (after the threshold, or immediately when it's `0`), never on pointer-down:

```js
// xyflow/react + xyflow/svelte
const _onConnectStart = (evt, params) => {
  setReconnecting(true);          // hide the edge
  onReconnectStart?.(event, ...); // public event
};
XYHandle.onPointerDown(event, { onConnectStart: _onConnectStart, /* ... */ });
```

This PR brings vue-flow in line: a new `onReconnectStart` callback in `useHandle` is invoked from the system's `onConnectStart`, and `EdgeWrapper` uses it to set `updating = true` and emit `reconnectStart` there instead of eagerly in `handleReconnect`. A plain click on the anchor now leaves the edge in place and emits nothing.

## Verification

- **Chrome (examples/vite `updateable-edge`)** — click-no-move: edge stays visible throughout and after release. Real drag: edge hides during the drag (connection line takes over) and is restored on release.
- **Cypress (real Chrome)** — `updateEdge.cy.ts` (end-to-end reconnect) + `eventPayloads.cy.ts` pass.
- Lint clean; build green (`attw` + `vue-tsc` dts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)