### PR TITLE
fix(core): toggle connectingfrom/connectingto/valid handle classes during a connection

### DIFF
--- a/.changeset/handle-connection-validation-classes.md
+++ b/.changeset/handle-connection-validation-classes.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Restore the per-handle connection-state classes used for connection-validation styling. During a connection drag `<Handle>` again toggles `connectingfrom` (on the handle the drag started from), `connectingto` (on the handle currently hovered), and `valid` (when that hovered handle is a valid target) — matching `@xyflow/react` and `@xyflow/svelte`. Core only toggles the classes; coloring is left to your CSS. Note the class names now mirror xyflow: target `.vue-flow__handle.connectingto` / `.connectingfrom` / `.valid` instead of the old `vue-flow__handle-connecting` / `vue-flow__handle-valid`.

--- a/docs/examples/validation/style.css
+++ b/docs/examples/validation/style.css
@@ -22,10 +22,14 @@
 
 }
 
-.validationflow .vue-flow__handle-connecting {
+.validationflow .vue-flow__handle.connectingto {
   background: #ff6060;
 }
 
-.validationflow .vue-flow__handle-valid {
+.validationflow .vue-flow__handle.connectingfrom {
+  background: #55dd99;
+}
+
+.validationflow .vue-flow__handle.valid {
   background: #55dd99;
 }

--- a/examples/vite/src/Validation/validation.css
+++ b/examples/vite/src/Validation/validation.css
@@ -22,10 +22,14 @@
 
 }
 
-.validationflow .vue-flow__handle-connecting {
+.validationflow .vue-flow__handle.connectingto {
   background: #ff6060;
 }
 
-.validationflow .vue-flow__handle-valid {
+.validationflow .vue-flow__handle.connectingfrom {
+  background: #55dd99;
+}
+
+.validationflow .vue-flow__handle.valid {
   background: #55dd99;
 }

--- a/packages/core/src/components/Handle/Handle.vue
+++ b/packages/core/src/components/Handle/Handle.vue
@@ -22,7 +22,9 @@ const { id: flowId } = useVueFlow();
 
 const {
   connectionStartHandle,
+  connectionEndHandle,
   connectionClickStartHandle,
+  connectionStatus,
   connectionMode,
   vueFlowRef,
   nodesConnectable,
@@ -69,6 +71,25 @@ const isClickConnecting = toRef(
     && connectionClickStartHandle.value?.id === handleId
     && connectionClickStartHandle.value?.type === type.value,
 );
+
+// xyflow/react + svelte toggle these per handle during a connection: `connectingfrom` on the handle the
+// drag started from, `connectingto` on the handle currently hovered, and `valid` when that hovered handle
+// is a valid target. Core only toggles the classes — coloring is left to user CSS.
+const connectingFrom = toRef(
+  () =>
+    connectionStartHandle.value?.nodeId === nodeId
+    && connectionStartHandle.value?.id === handleId
+    && connectionStartHandle.value?.type === type.value,
+);
+
+const connectingTo = toRef(
+  () =>
+    connectionEndHandle.value?.nodeId === nodeId
+    && connectionEndHandle.value?.id === handleId
+    && connectionEndHandle.value?.type === type.value,
+);
+
+const valid = toRef(() => connectingTo.value && connectionStatus.value === 'valid');
 
 const { handlePointerDown, handleClick } = useHandle({
   nodeId,
@@ -210,6 +231,9 @@ export default {
         connecting: isClickConnecting,
         connectablestart: isConnectableStart,
         connectableend: isConnectableEnd,
+        connectingfrom: connectingFrom,
+        connectingto: connectingTo,
+        valid,
         connectionindicator:
           isHandleConnectable
           && (!connectionInProcess || isPossibleEndHandle)


### PR DESCRIPTION
## Problem

Connection-validation styling stopped working (e.g. the validation example's red/green target handles). `<Handle>` was no longer emitting the per-handle connection-state classes, so there was nothing for user CSS to hook onto.

## Fix (RF/SF parity)

During a connection drag, `<Handle>` again toggles the classes `@xyflow/react` and `@xyflow/svelte` use:

- **`connectingfrom`** — the handle the drag started from
- **`connectingto`** — the handle currently hovered as a target
- **`valid`** — that hovered handle is a valid target (`connectingTo && connectionStatus === 'valid'`)

derived from the store's `connectionStartHandle` / `connectionEndHandle` / `connectionStatus`. Core only toggles the classes; coloring is left to user CSS — same as RF/SF.

The class names now mirror xyflow (`.vue-flow__handle.connectingto` / `.connectingfrom` / `.valid`) instead of the old `vue-flow__handle-connecting` / `vue-flow__handle-valid`, so the validation examples (`examples/vite` + docs) are updated to the new selectors (`connectingto` → red, `connectingfrom` / `valid` → green), matching RF's and SF's own validation examples.

## Verification

In Chrome (examples/vite `validation`), dragging a connection:
- source handle → `connectingfrom`, renders green (`rgb(85,221,153)`)
- hovering an invalid target → `connectingto`, renders red (`rgb(255,96,96)`)
- hovering a valid target → `connectingto` + `valid`, renders green

Lint clean; build green (`attw` + `vue-tsc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)