### PR TITLE
fix(docs): migrate connection-radius example to from*/to* connection-line slot props

### DIFF
--- a/.changeset/connection-radius-example-slot-props.md
+++ b/.changeset/connection-radius-example-slot-props.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Migrate the connection-radius example to the current connection-line slot props. The custom `#connection-line` slot exposes its coordinates as `fromX`/`fromY`/`fromPosition` and `toX`/`toY`/`toPosition` (matching `@xyflow/react` and `@xyflow/svelte`), not the old `source*`/`target*` — the example used the old names, so it rendered against `undefined` coordinates. Note the edge path helpers (`getBezierPath` etc.) keep their `source*`/`target*` parameter names, so map the slot's `from*`/`to*` onto them.

--- a/docs/examples/connection-radius/App.vue
+++ b/docs/examples/connection-radius/App.vue
@@ -24,14 +24,14 @@ const nodes = ref([
 
 <template>
   <VueFlow :nodes="nodes" :connection-radius="30" auto-connect fit-view>
-    <template #connection-line="{ sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition }">
+    <template #connection-line="{ fromX, fromY, toX, toY, fromPosition, toPosition }">
       <ConnectionLine
-        :source-x="sourceX"
-        :source-y="sourceY"
-        :target-x="targetX"
-        :target-y="targetY"
-        :source-position="sourcePosition"
-        :target-position="targetPosition"
+        :from-x="fromX"
+        :from-y="fromY"
+        :to-x="toX"
+        :to-y="toY"
+        :from-position="fromPosition"
+        :to-position="toPosition"
       />
     </template>
   </VueFlow>

--- a/docs/examples/connection-radius/SnappableConnectionLine.vue
+++ b/docs/examples/connection-radius/SnappableConnectionLine.vue
@@ -3,35 +3,35 @@ import { connectionExists, getBezierPath, storeToRefs, useStore, useVueFlow } fr
 import { computed, reactive, ref, watch } from 'vue';
 
 const props = defineProps({
-  sourceX: {
+  fromX: {
     type: Number,
     required: true,
   },
-  sourceY: {
+  fromY: {
     type: Number,
     required: true,
   },
-  targetX: {
+  toX: {
     type: Number,
     required: true,
   },
-  targetY: {
+  toY: {
     type: Number,
     required: true,
   },
-  targetPosition: {
+  fromPosition: {
     type: String,
     required: true,
   },
-  sourcePosition: {
+  toPosition: {
     type: String,
     required: true,
   },
 });
 
-const { getNodes, getInternalNode, onConnectEnd, addEdges } = useVueFlow();
+const { getNodes, getEdges, getInternalNode, onConnectEnd, addEdges } = useVueFlow();
 
-const { connectionStartHandle, edges } = storeToRefs(useStore());
+const { connectionStartHandle } = storeToRefs(useStore());
 
 const closest = reactive({
   node: null,
@@ -49,13 +49,13 @@ const MIN_DISTANCE = 75;
 
 const SNAP_DISTANCE = 30;
 
-watch([() => props.targetY, () => props.targetX], (_, __, onCleanup) => {
+watch([() => props.toY, () => props.toX], (_, __, onCleanup) => {
   const closestNode = getNodes.value.reduce(
     (res, n) => {
       if (n.id !== connectionStartHandle.value?.nodeId) {
         const internalNode = getInternalNode(n.id);
-        const dx = props.targetX - (internalNode.internals.positionAbsolute.x + internalNode.measured.width / 2);
-        const dy = props.targetY - (internalNode.internals.positionAbsolute.y + internalNode.measured.height / 2);
+        const dx = props.toX - (internalNode.internals.positionAbsolute.x + internalNode.measured.width / 2);
+        const dy = props.toY - (internalNode.internals.positionAbsolute.y + internalNode.measured.height / 2);
         const d = Math.sqrt(dx * dx + dy * dy);
 
         if (d < res.distance && d < MIN_DISTANCE) {
@@ -81,8 +81,8 @@ watch([() => props.targetY, () => props.targetX], (_, __, onCleanup) => {
   const type = connectionStartHandle.value.type === 'source' ? 'target' : 'source';
 
   const closestHandle = closestNode.node.internals.handleBounds[type]?.reduce((prev, curr) => {
-    const prevDistance = Math.sqrt((prev.x - props.targetX) ** 2 + (prev.y - props.targetY) ** 2);
-    const currDistance = Math.sqrt((curr.x - props.targetX) ** 2 + (curr.y - props.targetY) ** 2);
+    const prevDistance = Math.sqrt((prev.x - props.toX) ** 2 + (prev.y - props.toY) ** 2);
+    const currDistance = Math.sqrt((curr.x - props.toX) ** 2 + (curr.y - props.toY) ** 2);
 
     return prevDistance < currDistance ? prev : curr;
   });
@@ -95,7 +95,7 @@ watch([() => props.targetY, () => props.targetX], (_, __, onCleanup) => {
         target: closestNode.node.id,
         targetHandle: closestHandle.id,
       },
-      edges.value,
+      getEdges.value,
     )
   ) {
     return;
@@ -117,7 +117,16 @@ watch([() => props.targetY, () => props.targetX], (_, __, onCleanup) => {
   }
 });
 
-const path = computed(() => getBezierPath(props));
+const path = computed(() =>
+  getBezierPath({
+    sourceX: props.fromX,
+    sourceY: props.fromY,
+    sourcePosition: props.fromPosition,
+    targetX: props.toX,
+    targetY: props.toY,
+    targetPosition: props.toPosition,
+  }),
+);
 
 onConnectEnd(() => {
   if (closest.startHandle && closest.handle && closest.node) {
@@ -150,6 +159,6 @@ const strokeColor = computed(() => {
 <template>
   <g>
     <path :d="path[0]" class="vue-flow__connection-path" />
-    <circle :cx="targetX" :cy="targetY" fill="#fff" :stroke="strokeColor" :r="3" :stroke-width="1.5" />
+    <circle :cx="toX" :cy="toY" fill="#fff" :stroke="strokeColor" :r="3" :stroke-width="1.5" />
   </g>
 </template>


### PR DESCRIPTION
## Problem

The connection-radius docs example (`docs/examples/connection-radius`) broke: its custom `#connection-line` slot still destructured `sourceX` / `sourceY` / `targetX` / `targetY` / `sourcePosition` / `targetPosition`, but the slot now exposes `fromX` / `fromY` / `fromPosition` and `toX` / `toY` / `toPosition` (xyflow/react + svelte parity). So the connection line rendered against `undefined` coordinates.

## Fix

- **`App.vue`** — the `#connection-line` slot destructures `{ fromX, fromY, toX, toY, fromPosition, toPosition }` and forwards them as `:from-x` / `:to-x` / etc.
- **`SnappableConnectionLine.vue`** — props renamed to `from*` / `to*`; the proximity `watch` and the highlight circle use `props.toX` / `props.toY`; and since the edge path helpers (`getBezierPath` etc.) keep their `source*` / `target*` parameter names, the slot's `from*` / `to*` are mapped onto them.

Docs-only — no `@vue-flow/core` code change.

## Verification

The example loads cleanly in the docs dev server (no runtime error; remaining console entries are unrelated dev-server noise — a 404 and a manifest-parse warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)