### PR TITLE
fix(core): preserve handle bounds across node re-commits

### DIFF
--- a/.changeset/preserve-handle-bounds-on-recommit.md
+++ b/.changeset/preserve-handle-bounds-on-recommit.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Fix edges snapping back to a node's default handle positions after a re-commit (e.g. a dagre layout flipping `sourcePosition`/`targetPosition`, or any `nodes.value.map(...)`). `@xyflow/system`'s `parseHandles` resets `handleBounds` to `undefined` whenever a re-committed user node carries no `measured`, and vue-flow's node-rep split deliberately keeps `measured` (and `handleBounds`) off the user `Node` — so every re-commit wiped the handle bounds and edges fell back to the node's default sides instead of its actual handles. `adoptNodes` now carries the prior `handleBounds` forward alongside `measured` (extending the same adapter that already preserves `measured`); a genuine re-measure (`updateNodeDimensions`, e.g. NodeWrapper's `sourcePosition` watcher) still overwrites them, and that fresh result is preserved by the next re-commit.

--- a/packages/core/src/utils/store.ts
+++ b/packages/core/src/utils/store.ts
@@ -13,6 +13,7 @@ import type {
   Edge,
   InternalNode,
   Node,
+  NodeHandleBounds,
   NodeOrigin,
   State,
   ValidConnectionFunc,
@@ -143,19 +144,27 @@ export function adoptNodes<NodeType extends Node = Node>(
     validNodes.push(markRaw(toRaw(node)));
   }
 
-  // vue-flow's node-rep split keeps `measured` off the user `Node`s — it lives only on the `InternalNode`.
-  // The system's `adoptUserNodes` sources `measured` solely from `userNode.measured`, so re-committing fresh
-  // user objects (a one-way `:nodes` reassignment, a layout pass, `nodes.value.map(...)`) would reset
-  // `measured` to `undefined` → the node fails `nodeHasDimensions`, renders `visibility:hidden`, and — since
-  // its DOM size didn't change — the ResizeObserver never re-fires to restore it. Snapshot the dimensions
-  // before adoption clears the lookup and carry them forward below, the way the system already reuses
-  // `handleBounds`.
-  const priorMeasured = new Map<string, { width?: number; height?: number }>();
+  // vue-flow's node-rep split keeps `measured` AND `handleBounds` off the user `Node`s — they live only on
+  // the `InternalNode`. The system's `adoptUserNodes` sources both from the user node (`parseHandles` even
+  // resets `handleBounds` to `undefined` when the node carries no `measured`), so re-committing fresh user
+  // objects (a one-way `:nodes` reassignment, a layout pass, `nodes.value.map(...)`) resets:
+  //   - `measured` → `undefined`: the node fails `nodeHasDimensions`, renders `visibility:hidden`, and — since
+  //     its DOM size didn't change — the ResizeObserver never re-fires to restore it.
+  //   - `handleBounds` → `undefined`: edges fall back to the node's default handle positions, ignoring its
+  //     `sourcePosition`/`targetPosition` (e.g. a dagre layout's edges no longer meet the handles).
+  // Snapshot both before adoption clears the lookup and carry them forward below. A genuine re-measure
+  // (`updateNodeDimensions`, e.g. NodeWrapper's `sourcePosition` watcher) still overwrites them, and that
+  // fresh result is in turn preserved by the next re-commit.
+  const priorInternals = new Map<
+    string,
+    { measured?: { width?: number; height?: number }; handleBounds: NodeHandleBounds | undefined }
+  >();
   for (const [id, internal] of nodeLookup) {
     const { width, height } = internal.measured ?? {};
-    if (width !== undefined && height !== undefined) {
-      priorMeasured.set(id, { width, height });
-    }
+    priorInternals.set(id, {
+      measured: width !== undefined && height !== undefined ? { width, height } : undefined,
+      handleBounds: internal.internals.handleBounds,
+    });
   }
 
   const { hasSelectedNodes } = adoptUserNodes(validNodes, nodeLookup, parentLookup, { ...options, checkEquality: true });
@@ -165,14 +174,19 @@ export function adoptNodes<NodeType extends Node = Node>(
       triggerError(new VueFlowError(ErrorCode.NODE_MISSING_PARENT, node.id, node.parentId));
     }
 
-    // re-adoption only kept `measured` if the user object carried it; restore the prior measured dimensions
-    // for re-committed nodes that didn't, so a content-agnostic update (class/position/layout) stays visible
-    // instead of collapsing to a hidden, never-re-measured node (see the snapshot above)
-    const prior = priorMeasured.get(node.id);
+    // re-adoption only kept `measured`/`handleBounds` if the user object carried them; restore the prior
+    // values for re-committed nodes that didn't, so a content-agnostic update (class/position/layout) keeps
+    // the node visible and its edges anchored to the right handles (see the snapshot above)
+    const prior = priorInternals.get(node.id);
     if (prior) {
       const internal = nodeLookup.get(node.id);
-      if (internal && (internal.measured?.width === undefined || internal.measured?.height === undefined)) {
-        internal.measured = prior;
+      if (internal) {
+        if (prior.measured && (internal.measured?.width === undefined || internal.measured?.height === undefined)) {
+          internal.measured = prior.measured;
+        }
+        if (prior.handleBounds && !internal.internals.handleBounds) {
+          internal.internals.handleBounds = prior.handleBounds;
+        }
       }
     }
   }

--- a/tests/cypress/component/2-vue-flow/handleBoundsRecommit.cy.ts
+++ b/tests/cypress/component/2-vue-flow/handleBoundsRecommit.cy.ts
@@ -1,0 +1,64 @@
+import { Position } from '@vue-flow/core';
+import { getStore } from '../../support/component';
+
+// `@xyflow/system`'s `parseHandles` resets `handleBounds` to `undefined` whenever a re-committed user node
+// carries no `measured` — and vue-flow's node-rep split always keeps `measured` off the user node. So a plain
+// re-commit (a layout pass, `nodes.value.map(...)`, `updateNode`) would wipe the handle bounds and leave
+// edges anchored to the node's default handle positions. `adoptNodes` carries the prior `measured`/
+// `handleBounds` forward to prevent that.
+describe('handle bounds survive re-commits', () => {
+  const nodes = [
+    { id: '1', position: { x: 0, y: 0 }, data: { label: 'a' } },
+    { id: '2', position: { x: 300, y: 0 }, data: { label: 'b' } },
+  ];
+  const edges = [{ id: 'e1-2', source: '1', target: '2' }];
+
+  let store: ReturnType<typeof getStore>;
+  const bounds = (id: string) => store.getInternalNode(id)?.internals.handleBounds;
+
+  it('keeps handle bounds when a node is re-committed without resizing', () => {
+    cy.vueFlow({ nodes, edges, fitView: false });
+    cy.then(() => {
+      store = getStore();
+    });
+
+    // wait for the initial measure to populate handle bounds
+    cy.tryAssertion(() => {
+      expect(bounds('1')?.source, 'initial source bounds').to.have.length(1);
+    });
+
+    cy.then(() => {
+      // a fresh node object with no size change (mirrors a class/position update or a layout pass)
+      store.updateNode('1', { position: { x: 10, y: 10 } });
+    });
+
+    cy.tryAssertion(() => {
+      const b = bounds('1');
+      expect(b, 'handleBounds object survives the re-commit').to.not.be.undefined;
+      expect(b?.source, 'source bounds survive the re-commit').to.have.length(1);
+      expect(b?.target, 'target bounds survive the re-commit').to.have.length(1);
+    });
+  });
+
+  it('repopulates handle bounds to the new side when sourcePosition/targetPosition change', () => {
+    cy.vueFlow({ nodes, edges, fitView: false });
+    cy.then(() => {
+      store = getStore();
+    });
+
+    cy.tryAssertion(() => {
+      expect(bounds('1')?.source?.[0]?.position, 'default source handle is bottom').to.eq(Position.Bottom);
+      expect(bounds('1')?.target?.[0]?.position, 'default target handle is top').to.eq(Position.Top);
+    });
+
+    cy.then(() => {
+      // mirror a horizontal (LR) dagre layout flipping the handles to the sides
+      store.updateNode('1', { sourcePosition: Position.Right, targetPosition: Position.Left });
+    });
+
+    cy.tryAssertion(() => {
+      expect(bounds('1')?.source?.[0]?.position, 'source handle moved to the right').to.eq(Position.Right);
+      expect(bounds('1')?.target?.[0]?.position, 'target handle moved to the left').to.eq(Position.Left);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

In the simple dagre layout example, edges didn't meet the nodes' handles and the layout looked off. Root cause: a node's `internals.handleBounds` came back **`undefined`** after the layout re-committed the nodes — so edges fell back to the node's *default* handle sides (bottom/top) instead of the laid-out `sourcePosition`/`targetPosition` (right/left).

## Root cause

`@xyflow/system`'s `parseHandles` (shared by react/svelte/vue) resets `handleBounds` to `undefined` whenever a re-committed user node carries no `measured`:

```ts
// system store.ts
if (!userNode.handles) {
  return !userNode.measured ? undefined : internalNode?.internals.handleBounds;
}
```

React/Svelte keep `measured` *on* the public node, so the gate passes and handleBounds is reused. vue-flow's **node-rep split** (#40) deliberately keeps `measured` (and `handleBounds`) off the user node — they live only on the `InternalNode` — so the gate always fails on a re-commit and handleBounds is wiped. `NodeWrapper`'s `sourcePosition` watcher re-measures, but the *next* re-commit (the `dimensions` change it emits) wiped it again, and the watcher wouldn't re-fire (`sourcePosition` unchanged).

This is the **same mechanism as #2143**, which preserved `measured` but not `handleBounds`.

## Fix

`adoptNodes` now snapshots the prior `handleBounds` alongside `measured` and carries it forward for re-committed nodes that didn't supply their own — extending the existing measured-preservation adapter. A genuine re-measure (`updateNodeDimensions`, e.g. the `sourcePosition` watcher) still overwrites them, and that fresh result is in turn preserved by the next re-commit. Binding-agnostic (covers both `v-model` and one-way `:nodes`).

## Verification

- **New Cypress regression test** (`handleBoundsRecommit.cy.ts`, real Chrome): handle bounds survive a no-op re-commit, and repopulate to the new side when `sourcePosition`/`targetPosition` change.
- **Chrome (docs `layout/simple`)**: edge `e1-2` now starts at node 1's right-center `(228,165)` ≈ `(225,165)` and ends at node 2's left-center `(272,251)` ≈ `(275,251)` — was bottom→top before.
- Adopt-path specs pass: `drag`, `nodeInitialDimensions`, `nodeResizerAutoScale`, `parentExtentResize`, `updateEdge`, `fitViewQueue`. Build green (`attw` + `vue-tsc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)