### PR TITLE
fix(core): de-recurse ClassValue to avoid TS2589 on node spreads

### DIFF
--- a/.changeset/classvalue-recursion-ts2589.md
+++ b/.changeset/classvalue-recursion-ts2589.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Fix `TS2589: Type instantiation is excessively deep and possibly infinite` when spreading or mapping nodes — e.g. the extremely common `nodes.value = nodes.value.map((n) => ({ ...n, position }))`. The internal `ClassValue` type (used by `Node['class']`) was self-referential (`string | Record<string, boolean> | ClassValue[]`), so `UnwrapRef<Node[]>` and node spreads pushed TypeScript past its recursion-depth ceiling. `ClassValue` is now one level deep (`string | Record<string, boolean> | Array<string | Record<string, boolean>>`), which still matches Vue's `class` binding — it's type-only, no runtime change.

--- a/packages/core/src/types/flow.ts
+++ b/packages/core/src/types/flow.ts
@@ -80,8 +80,11 @@ export type CSSVars
 export type ThemeVars = { [key in CSSVars]?: CSSProperties['color'] };
 export type Styles = CSSProperties & ThemeVars & CustomThemeVars;
 
-// Vue does not publicly export ClassValue, so we define it here to match its class binding type
-export type ClassValue = string | Record<string, boolean> | ClassValue[];
+// Vue does not publicly export ClassValue, so we define it here to match its class binding type. Kept
+// NON-recursive (one level of array, not `ClassValue[]`) — a self-referential `ClassValue[]` makes
+// `UnwrapRef<Node[]>` / node spreads trip `TS2589: Type instantiation is excessively deep` (e.g. on
+// `nodes.value.map((n) => ({ ...n }))`).
+export type ClassValue = string | Record<string, boolean> | Array<string | Record<string, boolean>>;
 
 export interface FlowExportObject {
   /** exported nodes */


### PR DESCRIPTION
## Problem

A bare `nodes.value = nodes.value.map((n) => ({ ...n, position }))` — one of the most common things a consumer writes — could fail to typecheck with:

```
TS2589: Type instantiation is excessively deep and possibly infinite.
```

It's **budget-sensitive** (depends on cumulative type work in the file), so it surfaces intermittently — which is exactly the kind of thing that generates confused bug reports.

## Cause

`ClassValue` (the type of `Node['class']`) was **self-referential**:

```ts
export type ClassValue = string | Record<string, boolean> | ClassValue[];
```

`ref<Node[]>` makes `.value` an `UnwrapRef<Node[]>`, which recursively walks every property of `Node` — including `class: ClassValue`. The `ClassValue[]` self-reference has no fixed depth, so spreading/unwrapping a `Node` pushes TypeScript past its instantiation-depth ceiling. (Same family as the `accessor-readonly-depth` fix — there it was `DeepReadonly` descending into `Edge.label`'s `VNode`/`Component`.) It is *not* `domAttributes`/`HTMLAttributes` — typing that `Record` doesn't help; de-recursing `ClassValue` does.

## Fix

```ts
export type ClassValue = string | Record<string, boolean> | Array<string | Record<string, boolean>>;
```

One level deep — still matches Vue's `class` binding (`string | object | array of those`). Type-only; no runtime behavior changes.

## Verification

The previously-failing `examples/vite/src/Basic/Basic.vue` `updatePos()` (`nodes.value.map((n) => ({ ...n, position }))`) now typechecks; `vue-tsc` on the examples no longer reports TS2589 anywhere. Core build green (`attw` + `vue-tsc` dts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)