### PR TITLE
fix(core): stop UnwrapRef deep-walking Node/Edge (flaky TS2589)

### DIFF
--- a/.changeset/node-edge-unwrapref-ts2589.md
+++ b/.changeset/node-edge-unwrapref-ts2589.md
@@ -1,0 +1,7 @@
+---
+"@vue-flow/core": patch
+---
+
+Fix the flaky `TS2589: Type instantiation is excessively deep and possibly infinite` that could appear on the most common state-update pattern — `nodes.value = nodes.value.map((n) => ({ ...n, position }))` and the edge equivalent — typically surfacing intermittently in long-running editor type-checkers (clears on a TS-server restart, then returns).
+
+`ref<Node[]>` makes `.value` an `UnwrapRef<Node[]>`, and Vue's `UnwrapRef` recursively walks the entire `Node` type — including `style`'s `CSSProperties` (hundreds of large string-literal unions). A single spread-map therefore cost ~426k type instantiations, sitting right on TypeScript's instantiation-depth limit. Nodes and edges contain no refs, so unwrapping them is pure overhead: `@vue-flow/core` now opts them out via Vue's `RefUnwrapBailTypes` (the same hook Vue uses to bail DOM `Node`/`Window`), dropping the same operation to ~1k instantiations. Type-only — no runtime change.

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -7,5 +7,6 @@ export * from './handle';
 export * from './hooks';
 export * from './node';
 export * from './panel';
+export * from './reactivity-augmentation';
 export * from './store';
 export * from './zoom';

--- a/packages/core/src/types/reactivity-augmentation.ts
+++ b/packages/core/src/types/reactivity-augmentation.ts
@@ -1,0 +1,16 @@
+import type { Edge } from './edge';
+import type { Node } from './node';
+
+// `ref<Node[]>` / `ref<Edge[]>` is the canonical way to hold flow state, but Vue's `UnwrapRef` recursively
+// walks the entire (large) `Node`/`Edge` type — including `style`'s `CSSProperties` — so a single
+// `nodes.value = nodes.value.map((n) => ({ ...n }))` balloons to ~400k type instantiations and flakily
+// trips TS's instantiation-depth limit (`TS2589`) in long-running editor type-checkers. Nodes/edges hold
+// no refs, so unwrapping is pure overhead: bail out of it via `RefUnwrapBailTypes` (the same hook Vue itself
+// uses to bail DOM `Node`/`Window`). The minimal `Pick` shapes match every node/edge — including custom
+// `data` generics — while sidestepping the `label` self-reference that listing the full `Edge` type triggers.
+declare module '@vue/reactivity' {
+  interface RefUnwrapBailTypes {
+    vueFlowNode: Pick<Node, 'id' | 'position'>;
+    vueFlowEdge: Pick<Edge, 'id' | 'source' | 'target'>;
+  }
+}


### PR DESCRIPTION
## Symptom

The most common state-update pattern —

```ts
const nodes = ref<Node[]>([...])
nodes.value = nodes.value.map((n) => ({ ...n, position: { x, y } }))
```

— could throw `TS2589: Type instantiation is excessively deep and possibly infinite`. It's **flaky**: it clears on a TS-server restart and reappears once the editor's long-running checker warms up. (It is *not* about `position` vs `class`, `isNode`, `ClassValue`, or `domAttributes` — those were red herrings; whichever spread the warm checker evaluates nearest the limit is simply the one that tips over.)

## Root cause (measured)

`ref<Node[]>` makes `.value` a `UnwrapRef<Node[]>`, and Vue's `UnwrapRef` recursively walks the **entire** `Node` type to unwrap any nested refs — including `style: Styles`, which contains `CSSProperties` (hundreds of properties, each a large string-literal union). Because `n` is then `UnwrapRefSimple<Node>`, `n.style` is `UnwrapRefSimple<Styles>` — a *different* type instance than `Styles`, so when the spread result is assigned back to `Node[]`, TS can't short-circuit by identity and structurally compares all of `CSSProperties`.

`tsc --generateTrace` on a single spread-map:

| | Instantiations | Check time |
|---|---|---|
| `ref<Node[]>` (before) | **426,329** | 0.28s |
| `shallowRef<Node[]>` (no `UnwrapRef`) | 815 | 0.03s |
| `ref<Node[]>` + this fix | **~1,156** | 0.05s |

The hot events are `structuredTypeRelatedTo` against `Styles` / `CSSProperties`.

## Fix

Nodes and edges contain no refs, so unwrapping them is pure overhead *and* the cause. Opt them out of `UnwrapRef` via Vue's documented `RefUnwrapBailTypes` hook (the same mechanism Vue itself uses to bail DOM `Node`/`Window`):

```ts
declare module '@vue/reactivity' {
  interface RefUnwrapBailTypes {
    vueFlowNode: Pick<Node, 'id' | 'position'>
    vueFlowEdge: Pick<Edge, 'id' | 'source' | 'target'>
  }
}
```

- Minimal `Pick` shapes so **every** node/edge matches — including custom `data` generics — while sidestepping the `label` self-reference (`TS2615`) that listing the full `Edge` type triggers.
- Shipped in `dist/index.d.ts` + `.d.mts`, so any consumer importing `@vue-flow/core` gets it automatically — no per-project augmentation.
- Type-only; no runtime change (`ref<Node[]>` is still deeply reactive at runtime — `Node` simply has no refs to unwrap, so the resulting type is identical, just cheap to compute).

## Verification

- Trace numbers above (426k → ~1k).
- Full `examples/vite` `vue-tsc` clean (no new errors; node/edge/custom-data spreads + property access all typecheck).
- Augmentation confirmed present in both emitted `.d.ts` and `.d.mts`.

> Note for reviewers: after pulling, restart the TS server once so the editor picks up the rebuilt `@vue-flow/core` declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)