### PR TITLE
feat(core): discriminate slot props by type + thread generics through ConnectionLineProps/Actions

### DIFF
--- a/.changeset/discriminated-slot-types.md
+++ b/.changeset/discriminated-slot-types.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": minor
+---
+
+Discriminate the `#node-<type>` / `#edge-<type>` slot props by node/edge type. When `nodes`/`edges` are typed as a discriminated union (e.g. `(MyNodeA | MyNodeB)[]`), each `#node-<type>` / `#edge-<type>` slot now narrows its props to the matching variant's `NodeProps` / `EdgeProps`, so a custom node/edge component can safely type its `data` without a cast. Generic `Node[]` / `Edge[]` flows are unchanged (props stay broad), and arbitrary slot names remain allowed (a broad `node-${string}` / `edge-${string}` fallback). Type-only.

--- a/.changeset/thread-generics.md
+++ b/.changeset/thread-generics.md
@@ -1,0 +1,11 @@
+---
+"@vue-flow/core": minor
+---
+
+Thread the flow's `NodeType`/`EdgeType` through a few more public types so a typed flow gets specific typing instead of the generic default:
+
+- `ConnectionLineProps<NodeType>` — the `#connection-line` slot now types `fromNode`/`toNode` as `InternalNode<NodeType>` (inferred from `:nodes`), so a custom connection-line component gets typed node `data`. It was the only `FlowSlots` slot that didn't carry the flow's `NodeType`.
+- `RemoveNodes<NodeType>` / `RemoveEdges<EdgeType>` — the functional-updater form now receives the flow's node/edge type, matching `SetNodes`/`AddNodes`.
+- `IsNodeIntersecting<NodeType>` — mirrors its sibling `GetIntersectingNodes<NodeType>`.
+
+All generics default to `Node`/`Edge`, so existing code is unaffected. Type-only, no runtime change.

--- a/packages/core/src/types/connection.ts
+++ b/packages/core/src/types/connection.ts
@@ -77,7 +77,7 @@ export interface OnConnectStartParams {
   handleType?: HandleType;
 }
 
-export interface ConnectionLineProps {
+export interface ConnectionLineProps<NodeType extends Node = Node> {
   /** X start position of the connection line */
   fromX: number;
   /** Y start position of the connection line */
@@ -91,11 +91,11 @@ export interface ConnectionLineProps {
   /** the side of the end handle */
   toPosition: Position;
   /** the node the connection started from */
-  fromNode: InternalNode;
+  fromNode: InternalNode<NodeType>;
   /** the handle the connection started from (not the DOM element) */
   fromHandle: HandleElement | null;
   /** the node the connection currently ends on, or `null` */
-  toNode: InternalNode | null;
+  toNode: InternalNode<NodeType> | null;
   /** the handle the connection currently ends on (not the DOM element), or `null` */
   toHandle: HandleElement | null;
   /** marker url */

--- a/packages/core/src/types/flow.ts
+++ b/packages/core/src/types/flow.ts
@@ -290,12 +290,21 @@ export interface FlowEmits<NodeType extends Node = Node, EdgeType extends Edge =
 // rather than a bare `Record`. Beyond correctness, a required index signature makes `<VueFlow>`
 // unassignable to Vue's `Component` (whose `InternalSlots` are optional), which breaks Options-API
 // `components: { VueFlow }` registration.
+// Pick the union member(s) whose `type` matches the slot's type tag. Distributive (not `Extract<…, {type:T}>`)
+// because `type` is OPTIONAL on Node/Edge (`type?:`), so an `Extract` against a required `{ type: T }` is
+// always `never`. For a generic `Node`/`Edge` (`type: string`) every member matches, so the slot stays broad;
+// for a discriminated union it narrows to the matching variant.
+type NodeByType<NodeType extends Node, T extends string> = NodeType extends any ? (T extends NonNullable<NodeType['type']> ? NodeType : never) : never;
+type EdgeByType<EdgeType extends Edge, T extends string> = EdgeType extends any ? (T extends NonNullable<EdgeType['type']> ? EdgeType : never) : never;
+
 export type NodeSlots<NodeType extends Node = Node> = Partial<
-  Record<`node-${NodeType['type'] | string}`, (nodeProps: NodeProps<NodeType>) => any>
+  & { [T in NonNullable<NodeType['type']> as `node-${T}`]: (nodeProps: NodeProps<NodeByType<NodeType, T>>) => any }
+  & Record<`node-${string}`, (nodeProps: NodeProps<NodeType>) => any>
 >;
 
 export type EdgeSlots<EdgeType extends Edge = Edge> = Partial<
-  Record<`edge-${NonNullable<EdgeType['type']> | string}`, (edgeProps: EdgeProps<EdgeType>) => any>
+  & { [T in NonNullable<EdgeType['type']> as `edge-${T}`]: (edgeProps: EdgeProps<EdgeByType<EdgeType, T>>) => any }
+  & Record<`edge-${string}`, (edgeProps: EdgeProps<EdgeType>) => any>
 >;
 
 export type FlowSlots<NodeType extends Node = Node, EdgeType extends Edge = Edge> = NodeSlots<NodeType>

--- a/packages/core/src/types/flow.ts
+++ b/packages/core/src/types/flow.ts
@@ -309,7 +309,7 @@ export type EdgeSlots<EdgeType extends Edge = Edge> = Partial<
 
 export type FlowSlots<NodeType extends Node = Node, EdgeType extends Edge = Edge> = NodeSlots<NodeType>
   & EdgeSlots<EdgeType> & {
-    'connection-line'?: (connectionLineProps: ConnectionLineProps) => any;
+    'connection-line'?: (connectionLineProps: ConnectionLineProps<NodeType>) => any;
     'zoom-pane'?: () => any;
     'default'?: () => any;
   };

--- a/packages/core/src/types/store.ts
+++ b/packages/core/src/types/store.ts
@@ -183,14 +183,14 @@ export type AddNodes<NodeType extends Node = Node> = (
   nodes: NodeType | NodeType[] | ((nodes: NodeType[]) => NodeType | NodeType[]),
 ) => void;
 
-export type RemoveNodes = (
-  nodes: (string | Node) | (Node | string)[] | ((nodes: Node[]) => (string | Node) | (Node | string)[]),
+export type RemoveNodes<NodeType extends Node = Node> = (
+  nodes: (string | NodeType) | (NodeType | string)[] | ((nodes: NodeType[]) => (string | NodeType) | (NodeType | string)[]),
   removeConnectedEdges?: boolean,
   removeChildren?: boolean,
 ) => void;
 
-export type RemoveEdges = (
-  edges: (string | Edge) | (Edge | string)[] | ((edges: Edge[]) => (string | Edge) | (Edge | string)[]),
+export type RemoveEdges<EdgeType extends Edge = Edge> = (
+  edges: (string | EdgeType) | (EdgeType | string)[] | ((edges: EdgeType[]) => (string | EdgeType) | (EdgeType | string)[]),
 ) => void;
 
 /**
@@ -271,7 +271,7 @@ export type UpdateNodeData<NodeType extends Node = Node> = (
   options?: { replace: boolean },
 ) => void;
 
-export type IsNodeIntersecting = (node: (Partial<Node> & { id: Node['id'] }) | Rect, area: Rect, partially?: boolean) => boolean;
+export type IsNodeIntersecting<NodeType extends Node = Node> = (node: (Partial<NodeType> & { id: NodeType['id'] }) | Rect, area: Rect, partially?: boolean) => boolean;
 
 export interface Actions<NodeType extends Node = Node, EdgeType extends Edge = Edge>
   extends Omit<ViewportHelper<NodeType>, 'viewportInitialized'> {
@@ -284,9 +284,9 @@ export interface Actions<NodeType extends Node = Node, EdgeType extends Edge = E
   /** parses edges and adds to state */
   addEdges: AddEdges<EdgeType>;
   /** remove nodes (and possibly connected edges and children) from state */
-  removeNodes: RemoveNodes;
+  removeNodes: RemoveNodes<NodeType>;
   /** remove edges from state */
-  removeEdges: RemoveEdges;
+  removeEdges: RemoveEdges<EdgeType>;
   /** delete nodes/edges (with connected edges + children), gated by `onBeforeDelete`; mirrors xyflow/react */
   deleteElements: DeleteElements<NodeType, EdgeType>;
   /** find a node by id */
@@ -355,8 +355,8 @@ export interface Actions<NodeType extends Node = Node, EdgeType extends Edge = E
   /** returns all node intersections */
   getIntersectingNodes: GetIntersectingNodes<NodeType>;
   /** check if a node is intersecting with a defined area */
-  isNodeIntersecting: IsNodeIntersecting;
-  /** get a node's connected edges */
+  isNodeIntersecting: IsNodeIntersecting<NodeType>;
+  /** get a node's connected edges (accepts any nodes — it matches by id; output is the flow's `EdgeType`) */
   getConnectedEdges: (nodes: Node[]) => EdgeType[];
   /** get all connections of a handle belonging to a node */
   getHandleConnections: ({ id, type, nodeId }: { id?: string | null; type: HandleType; nodeId: string }) => NodeConnection[];


### PR DESCRIPTION
Threads the flow's `NodeType`/`EdgeType` further through the public type surface so custom node/edge/connection-line components get *specific* typing when `nodes`/`edges` are typed as a discriminated union — without affecting generic `Node[]`/`Edge[]` flows.

## 1. Discriminated slot props (`NodeSlots` / `EdgeSlots`)
Previously every `#node-<type>` / `#edge-<type>` slot received the whole `NodeProps<NodeType>` / `EdgeProps<EdgeType>`, so a per-type custom component that narrows `data` couldn't `v-bind` the slot props without a cast. Now each slot key maps to the matching union variant via a distributive conditional (`type` is optional on Node/Edge, so `Extract<…,{type:T}>` would be `never`), with a broad `node-/edge-${string}` fallback that keeps arbitrary slot names + generic flows working.

```ts
const nodes = ref<(CounterNode | GaugeNode)[]>([])
// #node-counter="props"  →  props.data is { count: number }, not the union
```

## 2. Generic threading
- **`ConnectionLineProps<NodeType>`** — the only `FlowSlots` slot that wasn't carrying the flow's `NodeType`; `fromNode`/`toNode` are now `InternalNode<NodeType>`, inferred from `:nodes`.
- **`RemoveNodes<NodeType>` / `RemoveEdges<EdgeType>`** — the functional-updater arg now carries the flow type (matches `SetNodes`/`AddNodes`).
- **`IsNodeIntersecting<NodeType>`** — mirrors its sibling `GetIntersectingNodes<NodeType>`.

Deliberately **not** changed: `getConnectedEdges`' input stays `Node[]` (it's a query matched by id — tightening a contravariant input broke a caller for no benefit; the output is already `EdgeType[]`). And child-component prop types (`MiniMapProps`, `ControlProps`, etc.) were left alone — they have no `:nodes` to infer from, so a generic there would just force consumers to hand-annotate.

## Verification
- **Narrowing is real, not silent-accept**: a positive assertion (`takesCustom2(props)`) passes and the negative (`takesPlus(props)`) errors. Confirmed for nodes, edges, and `ConnectionLineProps`.
- **No regressions**: full `examples/vite` `vue-tsc` shows only 2 unrelated pre-existing errors.
- **IDE (Volar), not just CLI**: a `custom2`-only field access in a slot stays clean in WebStorm.
- **Scales**: a 12-type discriminated union compiles with no TS2589.
- All generics default to `Node`/`Edge` → non-breaking; type-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)