### PR TITLE
chore(core): drop unused d3-interpolate dependency

### DIFF
--- a/.changeset/trim-d3-interpolate.md
+++ b/.changeset/trim-d3-interpolate.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Drop the unused `d3-interpolate` runtime dependency. The d3 zoom/transition/interpolate logic now lives inside `@xyflow/system`, and `@vue-flow/core` no longer imports `d3-interpolate` (or the `@types/d3-*` packages) directly.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -73,15 +73,11 @@
   },
   "dependencies": {
     "@vueuse/core": "^14.3.0",
-    "@xyflow/system": "^0.0.77",
-    "d3-interpolate": "^3.0.1"
+    "@xyflow/system": "^0.0.77"
   },
   "devDependencies": {
     "@arethetypeswrong/core": "^0.18.3",
     "@tooling/eslint-config": "workspace:*",
-    "@types/d3-interpolate": "^3.0.4",
-    "@types/d3-transition": "^3.0.9",
-    "@types/d3-zoom": "^3.0.8",
     "autoprefixer": "^10.5.0",
     "postcss": "^8.5.15",
     "postcss-cli": "^11.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,9 +189,6 @@ importers:
       '@xyflow/system':
         specifier: ^0.0.77
         version: 0.0.77
-      d3-interpolate:
-        specifier: ^3.0.1
-        version: 3.0.1
     devDependencies:
       '@arethetypeswrong/core':
         specifier: ^0.18.3
@@ -199,15 +196,6 @@ importers:
       '@tooling/eslint-config':
         specifier: workspace:*
         version: link:../../tooling/eslint-config
-      '@types/d3-interpolate':
-        specifier: ^3.0.4
-        version: 3.0.4
-      '@types/d3-transition':
-        specifier: ^3.0.9
-        version: 3.0.9
-      '@types/d3-zoom':
-        specifier: ^3.0.8
-        version: 3.0.8
       autoprefixer:
         specifier: ^10.5.0
         version: 10.5.0(postcss@8.5.15)


### PR DESCRIPTION
## What

`@vue-flow/core`'s source imports no d3 package directly — the d3 zoom / transition / interpolate logic all lives inside `@xyflow/system` now. This removes the dead deps:

- `dependencies`: `d3-interpolate`
- `devDependencies`: `@types/d3-interpolate`, `@types/d3-transition`, `@types/d3-zoom`

## Why it's safe

- `grep` of `packages/core/src` finds no d3 import (only a comment in `ZoomPane.vue` describing what `@xyflow/system`'s panzoom does internally).
- The own postcss pipeline (`postcss-import` / `postcss-nested` / `autoprefixer`) is **untouched** — those are still `require()`d by `postcss.config.js`.
- `pnpm --filter @vue-flow/core build` is green: CSS still resolves `@import`s (116 `vue-flow__` rules), tsdown emits `.d.ts` with no missing types, `attw` passes.

Patch changeset included (removing a published runtime dep). The same trim landed on the fork's `@xyflow/vue` (`feat/vue`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)