### PR TITLE
perf(core): read store directly in node/edge/handle wrappers + per-element composables

### DIFF
--- a/.changeset/store-direct-reads.md
+++ b/.changeset/store-direct-reads.md
@@ -2,6 +2,6 @@
 "@vue-flow/core": patch
 ---
 
-Perf: read the reactive store directly in the per-element components (`NodeWrapper`, `EdgeWrapper`, `Handle`) instead of `storeToRefs(useStore())`. `storeToRefs` runs `toRefs` over the whole state — allocating a ref for every state key — on each call, which adds up when it runs once per node, edge, and handle on a large graph. Inside a component's computeds/render, `store.x` already tracks reactively, so no refs are needed.
+Perf: read the reactive store directly in the per-element components (`NodeWrapper`, `EdgeWrapper`, `Handle`) and the per-element composables they call (`useNode`, `useHandle`, `useDrag`, `useUpdateNodePositions`, `useNodeConnections`) instead of `storeToRefs(useStore())`. `storeToRefs` runs `toRefs` over the whole state — allocating a ref for every state key — on each call, which adds up when it runs once per node, edge, and handle on a large graph. Inside a component's computeds/render, `store.x` already tracks reactively, so no refs are needed.
 
 `useStore` and `storeToRefs` are unchanged (`storeToRefs` is still the way to destructure state into refs and carry them around). The guidance for custom nodes/edges: read fields off `useStore()` directly (`const store = useStore(); store.transform`) rather than `storeToRefs` per instance.

--- a/.changeset/store-direct-reads.md
+++ b/.changeset/store-direct-reads.md
@@ -1,0 +1,7 @@
+---
+"@vue-flow/core": patch
+---
+
+Perf: read the reactive store directly in the per-element components (`NodeWrapper`, `EdgeWrapper`, `Handle`) instead of `storeToRefs(useStore())`. `storeToRefs` runs `toRefs` over the whole state — allocating a ref for every state key — on each call, which adds up when it runs once per node, edge, and handle on a large graph. Inside a component's computeds/render, `store.x` already tracks reactively, so no refs are needed.
+
+`useStore` and `storeToRefs` are unchanged (`storeToRefs` is still the way to destructure state into refs and carry them around). The guidance for custom nodes/edges: read fields off `useStore()` directly (`const store = useStore(); store.transform`) rather than `storeToRefs` per instance.

--- a/docs/src/guide/composables.md
+++ b/docs/src/guide/composables.md
@@ -158,7 +158,7 @@ This is how the default handle component is built:
 ```vue
 
 <script lang="ts" setup>
-import { storeToRefs, useHandle, useNodeId, useStore } from '@vue-flow/core'
+import { useHandle, useNodeId, useStore } from '@vue-flow/core'
 import type { HandleProps, Position } from '@vue-flow/core'
 
 const props = withDefaults(defineProps<HandleProps>(), {
@@ -169,8 +169,9 @@ const props = withDefaults(defineProps<HandleProps>(), {
 
 const nodeId = useNodeId()
 
-// `connectionStartHandle` is raw store state — pull it off `useStore` (as a ref) via `storeToRefs`
-const { connectionStartHandle } = storeToRefs(useStore())
+// read raw store state directly — `store.x` is reactive inside computeds/templates, so a per-instance
+// component doesn't need `storeToRefs` (which re-derives a ref for every state key on each call)
+const store = useStore()
 
 const { handlePointerDown, handleClick } = useHandle({
   nodeId,
@@ -204,9 +205,9 @@ export default {
         target: type === 'target',
         connectable: isConnectable,
         connecting:
-          connectionStartHandle?.nodeId === nodeId &&
-          connectionStartHandle?.id === id &&
-          connectionStartHandle?.type === type,
+          store.connectionStartHandle?.nodeId === nodeId &&
+          store.connectionStartHandle?.id === id &&
+          store.connectionStartHandle?.type === type,
       },
     ]"
     @mousedown="onMouseDownHandler"

--- a/docs/src/guide/migration.md
+++ b/docs/src/guide/migration.md
@@ -156,6 +156,12 @@ const { nodes, transform } = storeToRefs(useStore())           // value-type sta
 const { nodeLookup } = useStore()                              // reactive-Map lookups (no .value)
 ```
 
+> **Inside a component (incl. custom nodes/edges), prefer reading the store directly** —
+> `const store = useStore()` then `store.transform`, `store.nodesDraggable`, … . Reads inside a
+> computed/render track reactively without `.value`, and you skip re-projecting the whole state into refs
+> on every instance. Reach for `storeToRefs` only when you need to destructure refs and pass them around
+> outside a reactive scope.
+
 | Before                                                           | After                                                                       |
 |------------------------------------------------------------------|-----------------------------------------------------------------------------|
 | `const { nodes } = useVueFlow()`                                 | `const { nodes } = storeToRefs(useStore())`                                 |

--- a/examples/vite/src/EasyConnect/CustomNode.vue
+++ b/examples/vite/src/EasyConnect/CustomNode.vue
@@ -1,12 +1,14 @@
 <script lang="ts" setup>
-import { Handle, Position, storeToRefs, useStore } from '@vue-flow/core';
+import { Handle, Position, useStore } from '@vue-flow/core';
 import { computed } from 'vue';
 
 const props = defineProps<{ id: string }>();
 
-const { connectionStartHandle } = storeToRefs(useStore());
+// In a custom node, read the reactive store directly — `store.x` tracks reactively inside a computed.
+// (Avoid `storeToRefs(useStore())` here: it re-derives a ref for every state key on each node instance.)
+const store = useStore();
 
-const isTarget = computed(() => connectionStartHandle.value && connectionStartHandle.value.nodeId !== props.id);
+const isTarget = computed(() => store.connectionStartHandle && store.connectionStartHandle.nodeId !== props.id);
 </script>
 
 <template>

--- a/packages/core/src/components/Edges/EdgeWrapper.ts
+++ b/packages/core/src/components/Edges/EdgeWrapper.ts
@@ -2,7 +2,7 @@ import type { Connection, FinalConnectionState, HandleType } from '@xyflow/syste
 import type { Edge, EdgeComponent, InternalNode, MouseTouchEvent } from '../../types';
 import { ConnectionMode, getHandlePosition, getMarkerId, Position } from '@xyflow/system';
 import { computed, defineComponent, getCurrentInstance, h, inject, provide, resolveComponent, shallowRef, toRef } from 'vue';
-import { storeToRefs, useEdgeHooks, useHandle, useStore, useVueFlow } from '../../composables';
+import { useEdgeHooks, useHandle, useStore, useVueFlow } from '../../composables';
 import { EdgeId, EdgeRef, Slots } from '../../context';
 import { ARIA_EDGE_DESC_KEY, elementSelectionKeys, ErrorCode, getEdgeHandle, getEdgeZIndex, VueFlowError } from '../../utils';
 import EdgeAnchor from './EdgeAnchor';
@@ -30,34 +30,24 @@ const EdgeWrapper = defineComponent({
   setup(props: Props) {
     const { id: vueFlowId, addSelectedEdges, emits, getEdgeTypes, removeSelectedEdges, getEdge, getInternalNode } = useVueFlow();
 
-    const {
-      connectionMode,
-      reconnectRadius,
-      nodesSelectionActive,
-      noPanClassName,
-      isValidConnection,
-      multiSelectionActive,
-      disableKeyboardA11y,
-      elementsSelectable,
-      edgesReconnectable,
-      edgesFocusable,
-      elevateEdgesOnSelect,
-      zIndexMode,
-      defaultEdgeOptions,
-      hooks,
-    } = storeToRefs(useStore());
+    // Read the reactive store directly (see NodeWrapper) — `store.x` tracks reactively inside
+    // computeds/handlers, so there's no need to project the whole state into refs per edge.
+    const store = useStore();
+
+    // `isValidConnection` is handed to `useHandle`, which reads it as a ref, so keep it as one.
+    const isValidConnection = toRef(store, 'isValidConnection');
 
     const storedEdge = computed(() => getEdge(props.id) as Edge);
 
     const edge = computed<Edge>(() => {
-      const defaults = defaultEdgeOptions.value;
+      const defaults = store.defaultEdgeOptions;
       return defaults ? ({ ...(defaults as Edge), ...storedEdge.value } as Edge) : storedEdge.value;
     });
 
     // resolved per edge (value-gated computed) so the z-tracking of BOTH endpoint lookup keys lives in
     // this component's scope — resolving it in EdgeRenderer's v-for made the whole renderer re-render
     // (all edge vnodes) whenever ANY node entry was replaced, i.e. every drag frame
-    const zIndex = computed(() => getEdgeZIndex(edge.value, getInternalNode, elevateEdgesOnSelect.value, zIndexMode.value));
+    const zIndex = computed(() => getEdgeZIndex(edge.value, getInternalNode, store.elevateEdgesOnSelect, store.zIndexMode));
 
     const { emit } = useEdgeHooks(emits);
 
@@ -78,14 +68,14 @@ const EdgeWrapper = defineComponent({
     const edgeEl = shallowRef<SVGElement | null>(null);
 
     const isSelectable = toRef(() =>
-      typeof edge.value.selectable === 'undefined' ? elementsSelectable.value : edge.value.selectable,
+      typeof edge.value.selectable === 'undefined' ? store.elementsSelectable : edge.value.selectable,
     );
 
     const isReconnectable = toRef(() =>
-      typeof edge.value.reconnectable === 'undefined' ? edgesReconnectable.value : edge.value.reconnectable,
+      typeof edge.value.reconnectable === 'undefined' ? store.edgesReconnectable : edge.value.reconnectable,
     );
 
-    const isFocusable = toRef(() => (typeof edge.value.focusable === 'undefined' ? edgesFocusable.value : edge.value.focusable));
+    const isFocusable = toRef(() => (typeof edge.value.focusable === 'undefined' ? store.edgesFocusable : edge.value.focusable));
 
     provide(EdgeId, props.id);
     provide(EdgeRef, edgeEl);
@@ -172,7 +162,7 @@ const EdgeWrapper = defineComponent({
       }
 
       // strict mode considers only the matching side's handles; loose mode considers both (matching first)
-      const strict = connectionMode.value === ConnectionMode.Strict;
+      const strict = store.connectionMode === ConnectionMode.Strict;
       const sourceHandle = getEdgeHandle(getNodeHandles(sourceNode, 'source', strict), edge.value.sourceHandle);
       const targetHandle = getEdgeHandle(getNodeHandles(targetNode, 'target', strict), edge.value.targetHandle);
 
@@ -199,13 +189,13 @@ const EdgeWrapper = defineComponent({
             'class': [
               'vue-flow__edge',
               `vue-flow__edge-${edgeCmp.value === false ? 'default' : edge.value.type || 'default'}`,
-              noPanClassName.value,
+              store.noPanClassName,
               edgeClass.value,
               {
                 updating: mouseOver.value,
                 selected: edge.value.selected,
                 animated: edge.value.animated,
-                inactive: !isSelectable.value && !hooks.value.edgeClick.hasListeners(),
+                inactive: !isSelectable.value && !store.hooks.edgeClick.hasListeners(),
               },
             ],
             'tabIndex': isFocusable.value ? 0 : undefined,
@@ -278,7 +268,7 @@ const EdgeWrapper = defineComponent({
                         'position': sourcePosition,
                         'centerX': sourceX,
                         'centerY': sourceY,
-                        'radius': reconnectRadius.value,
+                        'radius': store.reconnectRadius,
                         'type': 'source',
                         'data-type': 'source',
                       }),
@@ -298,7 +288,7 @@ const EdgeWrapper = defineComponent({
                         'position': targetPosition,
                         'centerX': targetX,
                         'centerY': targetY,
-                        'radius': reconnectRadius.value,
+                        'radius': store.reconnectRadius,
                         'type': 'target',
                         'data-type': 'target',
                       }),
@@ -345,9 +335,9 @@ const EdgeWrapper = defineComponent({
       const data = { event, edge: storedEdge.value };
 
       if (isSelectable.value) {
-        nodesSelectionActive.value = false;
+        store.nodesSelectionActive = false;
 
-        if (edge.value.selected && multiSelectionActive.value) {
+        if (edge.value.selected && store.multiSelectionActive) {
           removeSelectedEdges([storedEdge.value]);
 
           edgeEl.value?.blur();
@@ -389,7 +379,7 @@ const EdgeWrapper = defineComponent({
     }
 
     function onKeyDown(event: KeyboardEvent) {
-      if (!disableKeyboardA11y.value && elementSelectionKeys.includes(event.key) && isSelectable.value) {
+      if (!store.disableKeyboardA11y && elementSelectionKeys.includes(event.key) && isSelectable.value) {
         const unselect = event.key === 'Escape';
 
         if (unselect) {

--- a/packages/core/src/components/Handle/Handle.vue
+++ b/packages/core/src/components/Handle/Handle.vue
@@ -2,7 +2,7 @@
 import type { HandleProps } from '../../types';
 import { ConnectionMode, getDimensions, isMouseEvent, nodeHasDimensions, Position } from '@xyflow/system';
 import { computed, onMounted, shallowRef, toRef } from 'vue';
-import { storeToRefs, useHandle, useNode, useStore, useVueFlow } from '../../composables';
+import { useHandle, useNode, useStore, useVueFlow } from '../../composables';
 import { isDef } from '../../utils';
 
 const {
@@ -20,18 +20,9 @@ const isValidConnection = toRef(() => props.isValidConnection ?? null);
 
 const { id: flowId } = useVueFlow();
 
-const {
-  connectionStartHandle,
-  connectionEndHandle,
-  connectionClickStartHandle,
-  connectionStatus,
-  connectionMode,
-  vueFlowRef,
-  nodesConnectable,
-  noDragClassName,
-  noPanClassName,
-  ariaLabelConfig,
-} = storeToRefs(useStore());
+// Read the reactive store directly (see NodeWrapper) instead of projecting it into refs — there are ~2
+// handles per node, so this setup runs a lot; `store.x` already tracks reactively in computeds/template.
+const store = useStore();
 
 const { id: nodeId, node: nodeRef, nodeEl, connectedEdges } = useNode();
 
@@ -54,22 +45,22 @@ const isConnectableEnd = toRef(() => (typeof connectableEnd !== 'undefined' ? co
 // Connection-indicator flags, mirroring xyflow/react's `connectingSelector`. A connection is "in process"
 // globally while dragging (`connectionStartHandle`) or click-connecting (`connectionClickStartHandle`);
 // `isPossibleEndHandle` is whether this handle can be the END of the in-progress (drag) connection.
-const connectionInProcess = toRef(() => connectionStartHandle.value !== null);
+const connectionInProcess = toRef(() => store.connectionStartHandle !== null);
 
-const clickConnectionInProcess = toRef(() => connectionClickStartHandle.value !== null);
+const clickConnectionInProcess = toRef(() => store.connectionClickStartHandle !== null);
 
 const isPossibleEndHandle = toRef(() => {
-  const fromHandle = connectionStartHandle.value;
-  return connectionMode.value === ConnectionMode.Strict
+  const fromHandle = store.connectionStartHandle;
+  return store.connectionMode === ConnectionMode.Strict
     ? fromHandle?.type !== type.value
     : nodeId !== fromHandle?.nodeId || handleId !== fromHandle?.id;
 });
 
 const isClickConnecting = toRef(
   () =>
-    connectionClickStartHandle.value?.nodeId === nodeId
-    && connectionClickStartHandle.value?.id === handleId
-    && connectionClickStartHandle.value?.type === type.value,
+    store.connectionClickStartHandle?.nodeId === nodeId
+    && store.connectionClickStartHandle?.id === handleId
+    && store.connectionClickStartHandle?.type === type.value,
 );
 
 // xyflow/react + svelte toggle these per handle during a connection: `connectingfrom` on the handle the
@@ -77,19 +68,19 @@ const isClickConnecting = toRef(
 // is a valid target. Core only toggles the classes — coloring is left to user CSS.
 const connectingFrom = toRef(
   () =>
-    connectionStartHandle.value?.nodeId === nodeId
-    && connectionStartHandle.value?.id === handleId
-    && connectionStartHandle.value?.type === type.value,
+    store.connectionStartHandle?.nodeId === nodeId
+    && store.connectionStartHandle?.id === handleId
+    && store.connectionStartHandle?.type === type.value,
 );
 
 const connectingTo = toRef(
   () =>
-    connectionEndHandle.value?.nodeId === nodeId
-    && connectionEndHandle.value?.id === handleId
-    && connectionEndHandle.value?.type === type.value,
+    store.connectionEndHandle?.nodeId === nodeId
+    && store.connectionEndHandle?.id === handleId
+    && store.connectionEndHandle?.type === type.value,
 );
 
-const valid = toRef(() => connectingTo.value && connectionStatus.value === 'valid');
+const valid = toRef(() => connectingTo.value && store.connectionStatus === 'valid');
 
 const { handlePointerDown, handleClick } = useHandle({
   nodeId,
@@ -129,7 +120,7 @@ const isHandleConnectable = computed(() => {
     return nodeRef.value ? isConnectable(nodeRef.value, connectedEdges.value) : false;
   }
 
-  return isDef(isConnectable) ? isConnectable : nodesConnectable.value;
+  return isDef(isConnectable) ? isConnectable : store.nodesConnectable;
 });
 
 // todo: remove this and have users handle this themselves using `updateNodeInternals`
@@ -145,11 +136,11 @@ onMounted(() => {
 
   const existingBounds = node.internals.handleBounds?.[type.value]?.find(b => b.id === handleId);
 
-  if (!vueFlowRef.value || existingBounds) {
+  if (!store.vueFlowRef || existingBounds) {
     return;
   }
 
-  const viewportNode = vueFlowRef.value.querySelector('.vue-flow__viewport');
+  const viewportNode = store.vueFlowRef.querySelector('.vue-flow__viewport');
 
   if (!nodeEl.value || !handle.value || !viewportNode || !handleId) {
     return;
@@ -188,7 +179,7 @@ function onPointerDown(event: MouseEvent | TouchEvent) {
 }
 
 function onClick(event: MouseEvent) {
-  if (!nodeId || (!connectionClickStartHandle.value && !isConnectableStart.value)) {
+  if (!nodeId || (!store.connectionClickStartHandle && !isConnectableStart.value)) {
     return;
   }
 
@@ -216,13 +207,13 @@ export default {
   <div
     ref="handle"
     v-bind="handleDataIds"
-    :aria-label="ariaLabelConfig['handle.ariaLabel']"
+    :aria-label="store.ariaLabelConfig['handle.ariaLabel']"
     class="vue-flow__handle"
     :class="[
       `vue-flow__handle-${position}`,
       handleId && `vue-flow__handle-${handleId}`,
-      noDragClassName,
-      noPanClassName,
+      store.noDragClassName,
+      store.noPanClassName,
       type,
       {
         // use the resolved value (falls back to `nodesConnectable`), not the raw prop — XYHandle's DOM

--- a/packages/core/src/components/Nodes/NodeWrapper.ts
+++ b/packages/core/src/components/Nodes/NodeWrapper.ts
@@ -16,7 +16,6 @@ import {
 } from 'vue';
 import {
   isInputDOMNode,
-  storeToRefs,
   useDrag,
   useNode,
   useNodeHooks,
@@ -48,26 +47,15 @@ const NodeWrapper = defineComponent({
       setCenter,
     } = useVueFlow();
 
-    const {
-      noPanClassName,
-      selectNodesOnDrag,
-      nodesSelectionActive,
-      multiSelectionActive,
-      disableKeyboardA11y,
-      ariaLiveMessage,
-      ariaLabelConfig,
-      nodeDragThreshold,
-      nodesDraggable,
-      elementsSelectable,
-      nodesConnectable,
-      nodesFocusable,
-      autoPanOnNodeFocus,
-      transform,
-      dimensions,
-      hooks,
-    } = storeToRefs(useStore());
+    // Read the reactive store directly. Inside computeds/handlers `store.x` already tracks reactively, so
+    // there's no need to project the whole state into refs per node (`storeToRefs` allocates a ref for every
+    // state key on each call — a real cost when it runs once per node/edge/handle).
+    const store = useStore();
+    const { parentLookup } = store;
 
-    const { parentLookup } = useStore();
+    // `nodesSelectionActive` is the one exception: it's handed to `handleNodeClick`, which writes it back,
+    // so it needs a writable ref.
+    const nodesSelectionActive = toRef(store, 'nodesSelectionActive');
 
     const nodeElement = shallowRef<HTMLDivElement | null>(null);
     provide(NodeRef, nodeElement);
@@ -87,33 +75,33 @@ const NodeWrapper = defineComponent({
 
     const isDraggable = toRef(() => {
       const node = nodeRef.value;
-      return !node || typeof node.draggable === 'undefined' ? nodesDraggable.value : node.draggable;
+      return !node || typeof node.draggable === 'undefined' ? store.nodesDraggable : node.draggable;
     });
 
     const isSelectable = toRef(() => {
       const node = nodeRef.value;
-      return !node || typeof node.selectable === 'undefined' ? elementsSelectable.value : node.selectable;
+      return !node || typeof node.selectable === 'undefined' ? store.elementsSelectable : node.selectable;
     });
 
     const isConnectable = toRef(() => {
       const node = nodeRef.value;
-      return !node || typeof node.connectable === 'undefined' ? nodesConnectable.value : node.connectable;
+      return !node || typeof node.connectable === 'undefined' ? store.nodesConnectable : node.connectable;
     });
 
     const isFocusable = toRef(() => {
       const node = nodeRef.value;
-      return !node || typeof node.focusable === 'undefined' ? nodesFocusable.value : node.focusable;
+      return !node || typeof node.focusable === 'undefined' ? store.nodesFocusable : node.focusable;
     });
 
     const hasPointerEvents = computed(
       () =>
         isSelectable.value
         || isDraggable.value
-        || hooks.value.nodeClick.hasListeners()
-        || hooks.value.nodeDoubleClick.hasListeners()
-        || hooks.value.nodeMouseEnter.hasListeners()
-        || hooks.value.nodeMouseMove.hasListeners()
-        || hooks.value.nodeMouseLeave.hasListeners(),
+        || store.hooks.nodeClick.hasListeners()
+        || store.hooks.nodeDoubleClick.hasListeners()
+        || store.hooks.nodeMouseEnter.hasListeners()
+        || store.hooks.nodeMouseMove.hasListeners()
+        || store.hooks.nodeMouseLeave.hasListeners(),
     );
 
     // a node "has dimensions" once it's measured OR carries explicit `width`/`height` OR `initialWidth`/
@@ -246,7 +234,7 @@ const NodeWrapper = defineComponent({
             'vue-flow__node',
             `vue-flow__node-${nodeCmp.value === false ? 'default' : node.type || 'default'}`,
             {
-              [noPanClassName.value]: isDraggable.value,
+              [store.noPanClassName]: isDraggable.value,
               dragging: dragging?.value,
               draggable: isDraggable.value,
               selected: node.selected,
@@ -264,7 +252,7 @@ const NodeWrapper = defineComponent({
           },
           'tabIndex': isFocusable.value ? 0 : undefined,
           'role': isFocusable.value ? 'group' : undefined,
-          'aria-describedby': disableKeyboardA11y.value ? undefined : `${ARIA_NODE_DESC_KEY}-${vueFlowId}`,
+          'aria-describedby': store.disableKeyboardA11y ? undefined : `${ARIA_NODE_DESC_KEY}-${vueFlowId}`,
           'aria-label': node.ariaLabel,
           'aria-roledescription': 'node',
           ...node.domAttributes,
@@ -352,11 +340,11 @@ const NodeWrapper = defineComponent({
         return;
       }
 
-      if (isSelectable.value && (!selectNodesOnDrag.value || !isDraggable.value || nodeDragThreshold.value > 0)) {
+      if (isSelectable.value && (!store.selectNodesOnDrag || !isDraggable.value || store.nodeDragThreshold > 0)) {
         // handleNodeClick needs the enriched InternalNode; the event payload gets the user node
         handleNodeClick(
           node,
-          multiSelectionActive.value,
+          store.multiSelectionActive,
           addSelectedNodes,
           removeSelectedNodes,
           nodesSelectionActive,
@@ -370,7 +358,7 @@ const NodeWrapper = defineComponent({
 
     function onKeyDown(event: KeyboardEvent) {
       const node = nodeRef.value;
-      if (!node || isInputDOMNode(event) || disableKeyboardA11y.value) {
+      if (!node || isInputDOMNode(event) || store.disableKeyboardA11y) {
         return;
       }
 
@@ -379,7 +367,7 @@ const NodeWrapper = defineComponent({
 
         handleNodeClick(
           node,
-          multiSelectionActive.value,
+          store.multiSelectionActive,
           addSelectedNodes,
           removeSelectedNodes,
           nodesSelectionActive,
@@ -391,7 +379,7 @@ const NodeWrapper = defineComponent({
         // prevent page scrolling
         event.preventDefault();
 
-        ariaLiveMessage.value = ariaLabelConfig.value['node.a11yDescription.ariaLiveMessage']({
+        store.ariaLiveMessage = store.ariaLabelConfig['node.a11yDescription.ariaLiveMessage']({
           direction: event.key.replace('Arrow', '').toLowerCase(),
           x: ~~node.position.x,
           y: ~~node.position.y,
@@ -412,15 +400,15 @@ const NodeWrapper = defineComponent({
     // focus (not pointer/programmatic).
     function onFocus() {
       const node = nodeRef.value;
-      if (!node || disableKeyboardA11y.value || !autoPanOnNodeFocus.value || !nodeElement.value?.matches(':focus-visible')) {
+      if (!node || store.disableKeyboardA11y || !store.autoPanOnNodeFocus || !nodeElement.value?.matches(':focus-visible')) {
         return;
       }
 
       const withinViewport
         = getNodesInside(
           new Map([[node.id, node]]),
-          { x: 0, y: 0, width: dimensions.value.width, height: dimensions.value.height },
-          transform.value,
+          { x: 0, y: 0, width: store.dimensions.width, height: store.dimensions.height },
+          store.transform,
           true,
         ).length > 0;
 
@@ -428,7 +416,7 @@ const NodeWrapper = defineComponent({
         setCenter(
           node.internals.positionAbsolute.x + (node.measured.width ?? 0) / 2,
           node.internals.positionAbsolute.y + (node.measured.height ?? 0) / 2,
-          { zoom: transform.value[2] },
+          { zoom: store.transform[2] },
         );
       }
     }

--- a/packages/core/src/composables/useDrag.ts
+++ b/packages/core/src/composables/useDrag.ts
@@ -3,7 +3,7 @@ import type { MaybeRefOrGetter, Ref } from 'vue';
 import type { Node, NodeDragEvent, NodeDragItem } from '../types';
 import { infiniteExtent, isCoordinateExtent, XYDrag } from '@xyflow/system';
 import { shallowRef, toValue, watchEffect } from 'vue';
-import { storeToRefs, useStore, useVueFlow } from '.';
+import { useStore, useVueFlow } from '.';
 
 interface UseDragParams {
   onStart: (event: NodeDragEvent) => void;
@@ -27,24 +27,12 @@ export function useDrag(params: UseDragParams) {
   const { panBy, getInternalNode, removeSelectedNodes, removeSelectedEdges, updateNodePositions, getNodes, getEdges }
     = useVueFlow();
 
-  const { nodeLookup } = useStore();
+  // Read the reactive store directly — these are read inside the XYDrag `getStoreItems`/`update` callbacks
+  // and the `watchEffect`, where `store.x` yields the current value with the same reactivity (no per-node
+  // ref projection).
+  const store = useStore();
 
-  const {
-    vueFlowRef,
-    snapToGrid,
-    snapGrid,
-    noDragClassName,
-    nodeExtent,
-    nodeOrigin,
-    nodeDragThreshold,
-    nodeClickDistance,
-    transform,
-    autoPanOnNodeDrag,
-    autoPanSpeed,
-    nodesDraggable,
-    multiSelectionActive,
-    selectNodesOnDrag,
-  } = storeToRefs(useStore());
+  const { nodeLookup } = store;
 
   const { onStart, onDrag, onStop, onClick, el, disabled, id, selectable, dragHandle } = params;
 
@@ -73,19 +61,19 @@ export function useDrag(params: UseDragParams) {
         get edges() {
           return getEdges.value as EdgeBase[];
         },
-        nodeExtent: (isCoordinateExtent(nodeExtent.value as CoordinateExtent)
-          ? nodeExtent.value
+        nodeExtent: (isCoordinateExtent(store.nodeExtent as CoordinateExtent)
+          ? store.nodeExtent
           : infiniteExtent) as CoordinateExtent,
-        snapGrid: snapGrid.value,
-        snapToGrid: snapToGrid.value,
-        nodeOrigin: nodeOrigin.value,
-        multiSelectionActive: multiSelectionActive.value,
-        domNode: vueFlowRef.value,
-        transform: transform.value,
-        autoPanOnNodeDrag: autoPanOnNodeDrag.value,
-        nodesDraggable: nodesDraggable.value,
-        selectNodesOnDrag: selectNodesOnDrag.value,
-        nodeDragThreshold: nodeDragThreshold.value,
+        snapGrid: store.snapGrid,
+        snapToGrid: store.snapToGrid,
+        nodeOrigin: store.nodeOrigin,
+        multiSelectionActive: store.multiSelectionActive,
+        domNode: store.vueFlowRef,
+        transform: store.transform,
+        autoPanOnNodeDrag: store.autoPanOnNodeDrag,
+        nodesDraggable: store.nodesDraggable,
+        selectNodesOnDrag: store.selectNodesOnDrag,
+        nodeDragThreshold: store.nodeDragThreshold,
         panBy,
         unselectNodesAndEdges: (args?: { nodes?: any[]; edges?: any[] }) => {
           removeSelectedNodes(args?.nodes);
@@ -116,7 +104,7 @@ export function useDrag(params: UseDragParams) {
           }
           updateNodePositions(items, true, isDragging ?? false);
         },
-        autoPanSpeed: autoPanSpeed.value,
+        autoPanSpeed: store.autoPanSpeed,
       }),
       // XYDrag hands user nodes (the InternalNode's `userNode`, spread with the live drag position +
       // `dragging`), which is exactly the event payload — emit them directly, no lookup round-trip
@@ -135,12 +123,12 @@ export function useDrag(params: UseDragParams) {
     });
 
     dragInstance.update({
-      noDragClassName: noDragClassName.value,
+      noDragClassName: store.noDragClassName,
       handleSelector: toValue(dragHandle),
       isSelectable: toValue(selectable),
       nodeId: id,
       domNode: nodeEl,
-      nodeClickDistance: nodeClickDistance.value,
+      nodeClickDistance: store.nodeClickDistance,
     });
 
     // Handle the "moved slightly but within threshold" click case.
@@ -157,7 +145,7 @@ export function useDrag(params: UseDragParams) {
         const dy = e.clientY - pointerDownPos.y;
         const dist = Math.sqrt(dx * dx + dy * dy);
 
-        if (dist > 0 && dist <= nodeDragThreshold.value) {
+        if (dist > 0 && dist <= store.nodeDragThreshold) {
           onClick(e);
         }
       }

--- a/packages/core/src/composables/useHandle.ts
+++ b/packages/core/src/composables/useHandle.ts
@@ -4,7 +4,6 @@ import type { ConnectingHandle, InternalNode, MouseTouchEvent, ValidConnectionFu
 import { getEventPosition, getHostForElement, Position, XYHandle } from '@xyflow/system';
 import { toValue } from 'vue';
 import { isValidHandle } from '../utils';
-import { storeToRefs } from './storeToRefs';
 import { useStore } from './useStore';
 import { useVueFlow } from './useVueFlow';
 
@@ -45,24 +44,12 @@ export function useHandle({
 }: UseHandleProps) {
   const { id: flowId, getNode, getInternalNode, panBy, startConnection, updateConnection, endConnection, emits } = useVueFlow();
 
-  const { nodeLookup } = useStore();
+  // Read the reactive store directly — every store value below is read inside an event handler or a lazy
+  // callback (getTransform/getFromHandle/getStoreItems), so `store.x` yields the current value with the
+  // same reactivity; no per-handle ref projection needed.
+  const store = useStore();
 
-  const {
-    vueFlowRef,
-    transform,
-    connectionMode,
-    connectionRadius,
-    connectionDragThreshold,
-    connectOnClick,
-    connectionStartHandle,
-    connectionClickStartHandle,
-    nodesConnectable,
-    autoPanOnConnect,
-    autoPanSpeed,
-    edges,
-    nodes,
-    isValidConnection: isValidConnectionProp,
-  } = storeToRefs(useStore());
+  const { nodeLookup } = store;
 
   /**
    * Adapt our richer `ValidConnectionFunc` (which receives `{ nodes, edges, sourceNode, targetNode }`)
@@ -70,7 +57,7 @@ export function useHandle({
    * source/target nodes from `nodeLookup` before delegating to the user's callback.
    */
   function buildSystemIsValidConnection(): SystemIsValidConnection | undefined {
-    const userFn = toValue(isValidConnection) || isValidConnectionProp.value;
+    const userFn = toValue(isValidConnection) || store.isValidConnection;
     if (!userFn) {
       return undefined;
     }
@@ -87,22 +74,22 @@ export function useHandle({
           sourceHandle: edge.sourceHandle ?? null,
           targetHandle: edge.targetHandle ?? null,
         },
-        { nodes: nodes.value, edges: edges.value, sourceNode, targetNode },
+        { nodes: store.nodes, edges: store.edges, sourceNode, targetNode },
       );
     };
   }
 
   function handlePointerDown(event: MouseTouchEvent) {
     const handleDomNode = event.currentTarget as Element | null;
-    if (!handleDomNode || !vueFlowRef.value) {
+    if (!handleDomNode || !store.vueFlowRef) {
       return;
     }
 
     XYHandle.onPointerDown(event, {
-      autoPanOnConnect: autoPanOnConnect.value,
-      connectionMode: connectionMode.value,
-      connectionRadius: connectionRadius.value,
-      domNode: vueFlowRef.value as HTMLDivElement,
+      autoPanOnConnect: store.autoPanOnConnect,
+      connectionMode: store.connectionMode,
+      connectionRadius: store.connectionRadius,
+      domNode: store.vueFlowRef as HTMLDivElement,
       handleId: toValue(handleId),
       nodeId: toValue(nodeId),
       isTarget: toValue(type) === 'target',
@@ -111,17 +98,17 @@ export function useHandle({
       flowId,
       // system's own param name stays `edgeUpdaterType`; our prop is `reconnectHandleType`
       edgeUpdaterType: toValue(reconnectHandleType),
-      autoPanSpeed: autoPanSpeed.value,
-      dragThreshold: connectionDragThreshold.value,
+      autoPanSpeed: store.autoPanSpeed,
+      dragThreshold: store.connectionDragThreshold,
       handleDomNode,
       panBy,
       isValidConnection: buildSystemIsValidConnection(),
-      getTransform: () => transform.value,
+      getTransform: () => store.transform,
       // system aborts the move loop if this returns null, so once `startConnection` has populated the
       // store's `connectionStartHandle`, surface it as a system-shaped `Handle`. Width/height aren't
       // tracked on `ConnectingHandle` — fall back to 0; system only reads them for rendering.
       getFromHandle: () => {
-        const h = connectionStartHandle.value;
+        const h = store.connectionStartHandle;
         if (!h) {
           return null;
         }
@@ -140,7 +127,7 @@ export function useHandle({
         if (state.inProgress) {
           // first move emits the in-progress state — mirror it to our split-field store so consumers
           // like `useConnection` and `Pane.vue`'s `connectionInProgress` keep working.
-          if (!connectionStartHandle.value) {
+          if (!store.connectionStartHandle) {
             startConnection({
               nodeId: state.fromHandle.nodeId,
               id: state.fromHandle.id ?? null,
@@ -205,11 +192,11 @@ export function useHandle({
   }
 
   function handleClick(event: MouseEvent) {
-    if (!connectOnClick.value) {
+    if (!store.connectOnClick) {
       return;
     }
 
-    if (!connectionClickStartHandle.value) {
+    if (!store.connectionClickStartHandle) {
       emits.clickConnectStart({
         event,
         nodeId: toValue(nodeId),
@@ -231,11 +218,11 @@ export function useHandle({
       return;
     }
 
-    const isValidConnectionHandler = toValue(isValidConnection) || isValidConnectionProp.value || alwaysValid;
+    const isValidConnectionHandler = toValue(isValidConnection) || store.isValidConnection || alwaysValid;
 
     const node = getNode(toValue(nodeId));
 
-    if (node && (typeof node.connectable === 'undefined' ? nodesConnectable.value : node.connectable) === false) {
+    if (node && (typeof node.connectable === 'undefined' ? store.nodesConnectable : node.connectable) === false) {
       return;
     }
 
@@ -251,17 +238,17 @@ export function useHandle({
           position: Position.Top,
           ...getEventPosition(event),
         },
-        connectionMode: connectionMode.value,
-        fromNodeId: connectionClickStartHandle.value.nodeId,
-        fromHandleId: connectionClickStartHandle.value.id ?? null,
-        fromType: connectionClickStartHandle.value.type,
+        connectionMode: store.connectionMode,
+        fromNodeId: store.connectionClickStartHandle.nodeId,
+        fromHandleId: store.connectionClickStartHandle.id ?? null,
+        fromType: store.connectionClickStartHandle.type,
         isValidConnection: isValidConnectionHandler,
         doc,
         lib: 'vue',
         flowId,
       },
-      edges.value,
-      nodes.value,
+      store.edges,
+      store.nodes,
       getInternalNode,
       nodeLookup,
     );
@@ -276,7 +263,7 @@ export function useHandle({
     // `FinalConnectionState` ourselves from the click-start handle + the resolved end handle, so
     // `clickConnectEnd` carries the same payload shape as `connectEnd` (handles → system `Handle`s by
     // padding the missing width/height, as `getFromHandle` does above).
-    const fromHandle = connectionClickStartHandle.value;
+    const fromHandle = store.connectionClickStartHandle;
     const fromNode = fromHandle ? getInternalNode(fromHandle.nodeId) : undefined;
     const toHandle = result.toHandle;
     const pointer = getEventPosition(event);

--- a/packages/core/src/composables/useNode.ts
+++ b/packages/core/src/composables/useNode.ts
@@ -3,7 +3,6 @@ import { getConnectedEdges } from '@xyflow/system';
 import { computed, inject, shallowRef } from 'vue';
 import { NodeRef } from '../context';
 import { ErrorCode, VueFlowError } from '../utils';
-import { storeToRefs } from './storeToRefs';
 import { useNodeId } from './useNodeId';
 import { useStore } from './useStore';
 import { useVueFlow } from './useVueFlow';
@@ -24,7 +23,7 @@ export function useNode<NodeType extends Node = Node>(id?: string) {
   const nodeEl = inject(NodeRef, shallowRef(null));
 
   const { getInternalNode, emits } = useVueFlow<NodeType>();
-  const { edges } = storeToRefs(useStore<NodeType>());
+  const store = useStore<NodeType>();
 
   // `node` is the enriched `InternalNode` (it carries `internals`/`measured`, which NodeWrapper + custom
   // nodes read) and a `computed` (not a one-time read) so it re-resolves whenever the store replaces this
@@ -40,6 +39,6 @@ export function useNode<NodeType extends Node = Node>(id?: string) {
     nodeEl,
     node,
     parentNode: computed(() => (node.value ? getInternalNode(node.value.parentId) : undefined)),
-    connectedEdges: computed(() => (node.value ? getConnectedEdges([node.value], edges.value) : [])),
+    connectedEdges: computed(() => (node.value ? getConnectedEdges([node.value], store.edges) : [])),
   };
 }

--- a/packages/core/src/composables/useNodeConnections.ts
+++ b/packages/core/src/composables/useNodeConnections.ts
@@ -2,7 +2,6 @@ import type { HandleType, NodeConnection } from '@xyflow/system';
 import type { MaybeRefOrGetter } from 'vue';
 import { areConnectionMapsEqual, handleConnectionChange } from '@xyflow/system';
 import { computed, shallowRef, toValue, watch } from 'vue';
-import { storeToRefs } from './storeToRefs';
 import { useNodeId } from './useNodeId';
 import { useStore } from './useStore';
 
@@ -38,7 +37,7 @@ export type UseNodeConnectionsParams = {
 export function useNodeConnections(params: UseNodeConnectionsParams = {}) {
   const { handleType, handleId, id, onConnect, onDisconnect } = params;
 
-  const { connectionLookup } = storeToRefs(useStore());
+  const store = useStore();
 
   const nodeId = useNodeId();
 
@@ -60,7 +59,7 @@ export function useNodeConnections(params: UseNodeConnectionsParams = {}) {
   });
 
   watch(
-    () => connectionLookup.value.get(lookupKey.value),
+    () => store.connectionLookup.get(lookupKey.value),
     (nextConnections) => {
       if (areConnectionMapsEqual(connections.value, nextConnections)) {
         return;

--- a/packages/core/src/composables/useUpdateNodePositions.ts
+++ b/packages/core/src/composables/useUpdateNodePositions.ts
@@ -2,7 +2,6 @@ import type { XYPosition } from '@xyflow/system';
 import type { NodeDragItem } from '../types';
 import { getNodeDimensions } from '@xyflow/system';
 import { calcNextPosition } from '../utils';
-import { storeToRefs } from './storeToRefs';
 import { useStore } from './useStore';
 import { useVueFlow } from './useVueFlow';
 
@@ -13,13 +12,13 @@ import { useVueFlow } from './useVueFlow';
  */
 export function useUpdateNodePositions() {
   const { getSelectedNodes, updateNodePositions, getInternalNode, emits } = useVueFlow();
-  const { nodeExtent, snapGrid, snapToGrid, nodesDraggable } = storeToRefs(useStore());
+  const store = useStore();
 
   return (positionDiff: XYPosition, isShiftPressed = false) => {
     // by default a node moves 5px on each key press, or 20px if shift is pressed
     // if snap grid is enabled, we use that for the velocity.
-    const xVelo = snapToGrid.value ? snapGrid.value[0] : 5;
-    const yVelo = snapToGrid.value ? snapGrid.value[1] : 5;
+    const xVelo = store.snapToGrid ? store.snapGrid[0] : 5;
+    const yVelo = store.snapToGrid ? store.snapGrid[1] : 5;
     const factor = isShiftPressed ? 4 : 1;
 
     const positionDiffX = positionDiff.x * xVelo * factor;
@@ -27,7 +26,7 @@ export function useUpdateNodePositions() {
 
     const nodeUpdates: NodeDragItem[] = [];
     for (const node of getSelectedNodes.value) {
-      if (node.draggable || (nodesDraggable.value && typeof node.draggable === 'undefined')) {
+      if (node.draggable || (store.nodesDraggable && typeof node.draggable === 'undefined')) {
         // `getSelectedNodes` returns user `Node`s — resolve the enriched InternalNode for internals/measured
         const internalNode = getInternalNode(node.id);
         if (!internalNode) {
@@ -43,7 +42,7 @@ export function useUpdateNodePositions() {
           internalNode,
           nextPosition,
           emits.error,
-          nodeExtent.value,
+          store.nodeExtent,
           node.parentId ? getInternalNode(node.parentId) : undefined,
         );
 


### PR DESCRIPTION
## What

The per-element components (`NodeWrapper`, `EdgeWrapper`, `Handle`) and the per-element composables they call (`useNode`, `useHandle`, `useDrag`, `useUpdateNodePositions`, `useNodeConnections`) now read the reactive store directly — `const store = useStore(); store.x` — instead of `storeToRefs(useStore())`.

## Why

`storeToRefs` is `toRefs(store)`, which allocates a ref for **every** state key (~40) on each call. Those components/composables run **once per node, edge, and handle** (`N + E + 2N` + the composables), so on a large graph that's tens of thousands of refs created for no reason — inside a component's computeds/render/handlers, reading `store.x` already tracks reactively, so the refs are never needed. This also fixes the same cost **leaking into consumer custom nodes/edges** that followed the old pattern.

## Notes / scope

- `useStore` and `storeToRefs` are **unchanged** — `storeToRefs` stays the public way to destructure state into refs and carry them outside a reactive scope.
- The few values handed to helpers that read/write them as refs stay as a single `toRef` (`nodesSelectionActive` in `NodeWrapper`, `isValidConnection` in `EdgeWrapper`). Everything else in `useHandle`/`useDrag` is read inside lazy `getStoreItems`/`getTransform` callbacks / handlers / a `watchEffect`, where direct reads keep identical reactivity.
- **Singleton** components (MiniMap, Controls, Pane, ZoomPane, Viewport, NodeToolbar, ResizeControl, ConnectionLine, A11y, NodesSelection, Panel, …) are intentionally left on `storeToRefs` — they mount once, so the cost is one-time.

## Honest perf framing

The concrete win is eliminated per-element ref churn (`storeToRefs` was ~28.7 ms/1000 nodes in `NodeWrapper` alone, measured), cleaner setups, and the consumer-leak fix. End-to-end cold-mount wall-clock is dominated by Vue rendering thousands of component instances (the framework floor, shared with 1.x), so I'm **not** claiming a large mount-time headline — the saving is real but modest against that floor.

## Verification

- `pnpm --filter @vue-flow/core build` type-clean.
- **17/17** interaction specs pass (drag, connect, reconnect, valid-connection, strict-mode, drag-threshold, selection, basic).
- Migration guide §6 + composables guide updated to recommend direct `store.x` reads in custom nodes/edges; `EasyConnect/CustomNode.vue` example converted. Patch changeset included.

Ported identically to `@xyflow/vue` (`feat/vue` in the fork).

🤖 Generated with [Claude Code](https://claude.com/claude-code)