### PR TITLE
perf(core): drop per-frame id-array allocation in the stable-id compare

### DIFF
--- a/.changeset/stable-id-no-alloc.md
+++ b/.changeset/stable-id-no-alloc.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Drop the per-frame id-array allocation in `NodeRenderer`/`EdgeRenderer`. The stable id-list computed previously mapped the whole `nodes`/`edges` array to ids on every commit just to diff it against the previous list. It now compares the live array against the previous id list in place with an indexed loop, allocating a new id array only when membership actually changes — the unchanged path (every drag frame) allocates nothing.

--- a/packages/core/src/container/EdgeRenderer/EdgeRenderer.vue
+++ b/packages/core/src/container/EdgeRenderer/EdgeRenderer.vue
@@ -9,8 +9,23 @@ const { getEdges } = useVueFlow();
 // value-stable id list (see NodeRenderer): keeps this v-for's render effect from re-running on every
 // edge commit — an edge data/selection update then re-renders only that edge's own wrapper, not all of them.
 const edgeIds = computed<string[]>((prev) => {
-  const ids = getEdges.value.map(edge => edge.id);
-  return prev && prev.length === ids.length && prev.every((id, i) => id === ids[i]) ? prev : ids;
+  // hot path: reuse `prev` when edge membership is unchanged, allocating nothing. a plain indexed loop
+  // avoids the per-element callback of `.every`; the rebuild below only runs on a membership change.
+  const edges = getEdges.value;
+  const len = edges.length;
+  if (prev && prev.length === len) {
+    let unchanged = true;
+    for (let i = 0; i < len; i++) {
+      if (edges[i].id !== prev[i]) {
+        unchanged = false;
+        break;
+      }
+    }
+    if (unchanged) {
+      return prev;
+    }
+  }
+  return edges.map(edge => edge.id);
 });
 </script>
 

--- a/packages/core/src/container/NodeRenderer/NodeRenderer.vue
+++ b/packages/core/src/container/NodeRenderer/NodeRenderer.vue
@@ -13,8 +13,24 @@ const { nodeLookup } = useStore();
 // node still re-renders through its own lookup-backed computed in NodeWrapper; this keeps a single-node
 // drag from re-diffing all N children every frame.
 const nodeIds = computed<string[]>((prev) => {
-  const ids = getNodes.value.map(node => node.id);
-  return prev && prev.length === ids.length && prev.every((id, i) => id === ids[i]) ? prev : ids;
+  // hot path (every commit): reuse `prev` when membership is unchanged, allocating nothing. a plain
+  // indexed loop avoids the per-element callback of `.every` on this O(n)-per-frame comparison; the
+  // rebuild below only runs on the rare membership change, so the builtin stays for readability there.
+  const nodes = getNodes.value;
+  const len = nodes.length;
+  if (prev && prev.length === len) {
+    let unchanged = true;
+    for (let i = 0; i < len; i++) {
+      if (nodes[i].id !== prev[i]) {
+        unchanged = false;
+        break;
+      }
+    }
+    if (unchanged) {
+      return prev;
+    }
+  }
+  return nodes.map(node => node.id);
 });
 
 const nodesInitialized = useNodesInitialized();


### PR DESCRIPTION
Follow-up to #2157. That PR added the value-stable id-list to `NodeRenderer`/`EdgeRenderer`; this tightens the computed itself.

## Problem

The `nodeIds`/`edgeIds` computed mapped the whole `nodes`/`edges` array to an id array on **every commit** — then, on the common path, threw that array away and returned `prev`. So every drag frame allocated (and GC'd) an N-length array just to discover membership hadn't changed.

## Fix

Compare the live array against the previous id list **in place** with an indexed loop, and only `.map()` a fresh id array when membership actually changed:

```ts
const nodeIds = computed<string[]>((prev) => {
  const nodes = getNodes.value
  const len = nodes.length
  if (prev && prev.length === len) {
    let unchanged = true
    for (let i = 0; i < len; i++) {
      if (nodes[i].id !== prev[i]) { unchanged = false; break }
    }
    if (unchanged) {
      return prev
    }
  }
  return nodes.map(node => node.id) // only on a real membership change
})
```

- **Unchanged path (every frame): zero allocation.** Previously one N-length array per commit.
- Indexed loop on the hot comparison avoids the per-element `.every` callback; the rebuild keeps `.map` (rare path, clarity).
- Pure internal change — no API or behavior change.

## Tests

Renderer specs green on the rebased base: `edgeZIndex` (5/5, incl. the dynamic runtime-selection elevation test), `drag`, `connect`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)