### PR TITLE
fix(core): add the `selectable` class to edges (xyflow parity)

### DIFF
--- a/.changeset/edge-selectable-class.md
+++ b/.changeset/edge-selectable-class.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Add the `selectable` class to edges (xyflow parity). The edge `<g>` now carries a `selectable` class whenever the edge is selectable (its own `selectable` flag, or `elementsSelectable` when unset), and the CSS keys `cursor: pointer` and the focus edge-path stroke off `.selectable` — matching React/Svelte Flow. Previously `cursor: pointer` was applied to every edge unconditionally, so **non-selectable edges no longer show the pointer cursor**.

--- a/packages/core/src/components/Edges/EdgeWrapper.ts
+++ b/packages/core/src/components/Edges/EdgeWrapper.ts
@@ -196,6 +196,8 @@ const EdgeWrapper = defineComponent({
                 selected: edge.value.selected,
                 animated: edge.value.animated,
                 inactive: !isSelectable.value && !store.hooks.edgeClick.hasListeners(),
+                // xyflow parity: the CSS keys `cursor: pointer` and the focus stroke off `.selectable`
+                selectable: isSelectable.value,
               },
             ],
             'tabIndex': isFocusable.value ? 0 : undefined,

--- a/packages/core/src/styles/_necessary.css
+++ b/packages/core/src/styles/_necessary.css
@@ -146,7 +146,10 @@
 
 .vue-flow__edge {
   pointer-events: visibleStroke;
-  cursor: pointer;
+
+  &.selectable {
+    cursor: pointer;
+  }
 
   &.animated path {
     stroke-dasharray: 5;
@@ -169,8 +172,8 @@
   }
 
   &.selected .vue-flow__edge-path,
-  &:focus .vue-flow__edge-path,
-  &:focus-visible .vue-flow__edge-path {
+  &.selectable:focus .vue-flow__edge-path,
+  &.selectable:focus-visible .vue-flow__edge-path {
     stroke: var(--xy-edge-stroke-selected, var(--xy-edge-stroke-selected-default));
   }
 

--- a/tests/cypress/component/2-vue-flow/edgeSelectable.cy.ts
+++ b/tests/cypress/component/2-vue-flow/edgeSelectable.cy.ts
@@ -1,0 +1,40 @@
+// xyflow parity: the edge `<g>` carries a `selectable` class whenever the edge is selectable (its own
+// `selectable` flag, or `elementsSelectable` when unset). The CSS keys `cursor: pointer` and the
+// focus/selected stroke off `.selectable`, so a non-selectable edge must NOT get it.
+describe('edge `selectable` class', () => {
+  const nodes = [
+    { id: 'a', position: { x: 0, y: 0 }, data: {} },
+    { id: 'b', position: { x: 200, y: 0 }, data: {} },
+  ];
+
+  it('a selectable edge gets the `selectable` class', () => {
+    cy.vueFlow({
+      fitView: false,
+      nodes,
+      edges: [{ id: 'a-b', source: 'a', target: 'b' }],
+    });
+
+    cy.get('.vue-flow__edge[data-id="a-b"]').should('have.class', 'selectable');
+  });
+
+  it('an edge with `selectable: false` omits the class', () => {
+    cy.vueFlow({
+      fitView: false,
+      nodes,
+      edges: [{ id: 'a-b', source: 'a', target: 'b', selectable: false }],
+    });
+
+    cy.get('.vue-flow__edge[data-id="a-b"]').should('not.have.class', 'selectable');
+  });
+
+  it('`elementsSelectable: false` strips the class from all edges', () => {
+    cy.vueFlow({
+      fitView: false,
+      elementsSelectable: false,
+      nodes,
+      edges: [{ id: 'a-b', source: 'a', target: 'b' }],
+    });
+
+    cy.get('.vue-flow__edge[data-id="a-b"]').should('not.have.class', 'selectable');
+  });
+});


### PR DESCRIPTION
## Bug

React/Svelte Flow put a `selectable` class on the edge `<g>` whenever the edge is selectable, and their CSS keys `cursor: pointer` (and the focus edge-path stroke) off `.selectable`. Vue Flow never emitted that class, so our CSS compensated with an **unconditional** `cursor: pointer` and **ungated** `:focus` rules — a divergence from `@xyflow/system`, and the `selectable` class users/CSS expect simply wasn't there.

## Fix

- `EdgeWrapper` now emits `selectable` on the edge `<g>` — `edge.selectable`, falling back to `elementsSelectable` (same resolution as React's `isSelectable`).
- `_necessary.css` now gates `cursor: pointer` behind `&.selectable`, and the `:focus`/`:focus-visible` edge-path stroke behind `&.selectable:focus(-visible)` — matching `@xyflow/system`'s `init.css` exactly.

### Behavior change

**Non-selectable edges no longer show the pointer cursor** (they previously did, unconditionally). This matches React/Svelte Flow.

## Audit (the "anything else for edge/node?" ask)

- **Nodes**: class list already matches React — `selected`, `selectable`, `parent`, `draggable`, `dragging` (+ noPan). No gap.
- **Edges**: `selectable` was the only missing class. `selected`/`animated`/`inactive`/`updating` were already present.
- Non-class note: React sets `data-testid="rf__edge-…"`/`rf__node-…`; we use `data-id`. Left as-is (intentional).

## Tests

New `edgeSelectable.cy.ts` (3): selectable edge has the class; `selectable: false` omits it; `elementsSelectable: false` strips it. Edge regressions green (`edgeZIndex` 5/5, `connect`, `looseReconnect`). Gated rule verified in the built `dist/style.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)