### PR TITLE
refactor(core): render the zoom-pane slot in Viewport instead of drilling it

### DIFF
--- a/.changeset/zoom-pane-slot-no-drill.md
+++ b/.changeset/zoom-pane-slot-no-drill.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Stop drilling the `zoom-pane` slot through `VueFlow → ZoomPane → Pane → Viewport`. It now renders inside `Viewport` (the transformed layer it belongs to) from the provided `Slots`, via a small propless `ZoomPaneSlot` component. This keeps ZoomPane's slot to Viewport static — so Pane/Viewport bail out of ZoomPane/Pane re-renders — and the slot itself bails out of Viewport's per-frame transform re-renders (invoked once and riding the CSS transform, instead of being rebuilt each pan/zoom frame). No API change.

--- a/packages/core/src/container/Viewport/Viewport.vue
+++ b/packages/core/src/container/Viewport/Viewport.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { computed } from 'vue';
 import { storeToRefs, useStore, useVueFlow } from '../../composables';
+import ZoomPaneSlot from './ZoomPaneSlot';
 
 const { viewport } = useVueFlow();
 
@@ -27,5 +28,9 @@ export default {
 <template>
   <div class="vue-flow__viewport vue-flow__container" :style="{ transform, opacity: isHidden ? 0 : undefined }">
     <slot />
+
+    <!-- the `zoom-pane` slot belongs in this transformed layer; pulled from the provided `Slots` as a
+    propless child so it bails out of this component's per-frame (transform) re-renders -->
+    <ZoomPaneSlot />
   </div>
 </template>

--- a/packages/core/src/container/Viewport/ZoomPaneSlot.ts
+++ b/packages/core/src/container/Viewport/ZoomPaneSlot.ts
@@ -1,0 +1,20 @@
+import { defineComponent, inject } from 'vue';
+import { Slots } from '../../context';
+
+/**
+ * Renders the `zoom-pane` slot from the provided {@link Slots} as its own propless component, so it
+ * bails out of Viewport's per-frame (transform) re-renders: the slot is invoked once and rides the CSS
+ * transform instead of being rebuilt each pan/zoom frame, and its own reactive updates stay contained
+ * here rather than re-rendering Viewport. Same reason the node/edge renderers are child components.
+ *
+ * @internal
+ */
+export default defineComponent({
+  name: 'ZoomPaneSlot',
+  compatConfig: { MODE: 3 },
+  setup() {
+    const slots = inject(Slots);
+
+    return () => slots?.['zoom-pane']?.() ?? null;
+  },
+});

--- a/packages/core/src/container/VueFlow/VueFlow.vue
+++ b/packages/core/src/container/VueFlow/VueFlow.vue
@@ -129,10 +129,9 @@ export default {
 
 <template>
   <div :ref="stateRefs.vueFlowRef" class="vue-flow" :class="colorModeClass">
-    <ZoomPane>
-      <!-- This slot is affected by zooming & panning -->
-      <slot name="zoom-pane" />
-    </ZoomPane>
+    <!-- the `zoom-pane` slot (affected by zooming & panning) renders inside the transformed Viewport via
+    the provided `Slots` (see ZoomPaneSlot), not drilled through ZoomPane → Pane → Viewport -->
+    <ZoomPane />
 
     <!-- This slot is _not_ affected by zooming & panning -->
     <slot />

--- a/packages/core/src/container/ZoomPane/ZoomPane.vue
+++ b/packages/core/src/container/ZoomPane/ZoomPane.vue
@@ -161,8 +161,6 @@ export default {
         <div class="vue-flow__edgelabel-renderer" />
 
         <NodeRenderer />
-
-        <slot />
       </Viewport>
     </Pane>
   </div>

--- a/tests/cypress/component/2-vue-flow/zoomPaneSlot.cy.ts
+++ b/tests/cypress/component/2-vue-flow/zoomPaneSlot.cy.ts
@@ -1,0 +1,24 @@
+import { h } from 'vue';
+
+// The `zoom-pane` slot renders inside the transformed `.vue-flow__viewport` (it pans/zooms with the graph).
+// It's pulled from the provided `Slots` (via ZoomPaneSlot) instead of being drilled through
+// ZoomPane → Pane → Viewport — this guards that the inject path still mounts it in the right place.
+describe('zoom-pane slot', () => {
+  it('renders the `zoom-pane` slot inside the transformed viewport', () => {
+    cy.vueFlow(
+      {
+        fitView: false,
+        nodes: [{ id: '1', position: { x: 0, y: 0 }, data: {} }],
+      },
+      undefined,
+      {
+        'zoom-pane': () => h('div', { class: 'zoom-pane-marker' }, 'in-pane'),
+      },
+    );
+
+    // it renders...
+    cy.get('.zoom-pane-marker').should('exist').and('contain.text', 'in-pane');
+    // ...and it's a descendant of the transformed viewport layer (not a sibling overlay like the default slot)
+    cy.get('.vue-flow__viewport .zoom-pane-marker').should('exist');
+  });
+});


### PR DESCRIPTION
## Problem

The `zoom-pane` slot was forwarded `VueFlow → ZoomPane → Pane → Viewport` via a `<slot />` sitting inside `<Viewport>`. That `<slot />` makes **Pane's and Viewport's slots dynamic**, defeating Vue's component-level re-render bail-out — so Pane and Viewport (and a shallow re-patch of the renderer subtree) are forced to re-render whenever ZoomPane or Pane re-renders. (The *default* slot was never drilled; node/edge/minimap slots already use `provide(Slots)`. This was the one outlier.)

## Change

`zoom-pane` now renders **inside `Viewport`** — the transformed layer it belongs to — pulled from the already-`provide`d `Slots` via a tiny propless `ZoomPaneSlot` render component.

Two boundaries fall out of this:
1. **ZoomPane's slot to Viewport is now static** (just the renderers) → Pane/Viewport bail out of ZoomPane/Pane re-renders (pan start/end, connect start/end, per-frame box-select).
2. **`ZoomPaneSlot` is a propless child**, so it bails out of Viewport's *per-frame transform* re-renders — the slot is invoked **once** and rides the CSS transform, rather than being re-invoked/rebuilt every pan/zoom frame (which inline `inject` rendering in Viewport would do). Same principle that keeps `EdgeRenderer`/`NodeRenderer` off Viewport's per-frame path.

No public API change — `zoom-pane` is still accepted and rendered in the same DOM spot (inside `.vue-flow__viewport`).

## Tests

New `zoomPaneSlot.cy.ts` asserts the slot renders inside the transformed `.vue-flow__viewport`. Regressions green: `basic`, `drag`, `connect`, `selectionClickVsDrag`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)