### PR TITLE
refactor(core): consolidate Handle's per-instance reactivity

### DIFF
--- a/.changeset/simplify-handle-reactivity.md
+++ b/.changeset/simplify-handle-reactivity.md
@@ -1,0 +1,5 @@
+---
+"@vue-flow/core": patch
+---
+
+Simplify `<Handle>`'s per-instance reactivity. The seven connection-state `toRef`s (`connectingFrom`/`connectingTo`/`valid`/`connectionInProcess`/…) all derived from the same global `connection*` store state and were used only in the class binding — they're consolidated into a single `connectionClasses` computed. The redundant `isConnectableStart`/`isConnectableEnd` refs are dropped too (their props already default to `true`). Each handle now allocates ~5 reactive effects instead of ~13 — meaningful since handles are the highest-multiplicity element (~2 per node). Identical rendered classes; no behavior or API change.

--- a/packages/core/src/components/Handle/Handle.vue
+++ b/packages/core/src/components/Handle/Handle.vue
@@ -38,50 +38,6 @@ const handleDataIds = computed<Record<string, string | null>>(() => ({
   'data-handlepos': position,
 }));
 
-const isConnectableStart = toRef(() => (typeof connectableStart !== 'undefined' ? connectableStart : true));
-
-const isConnectableEnd = toRef(() => (typeof connectableEnd !== 'undefined' ? connectableEnd : true));
-
-// Connection-indicator flags, mirroring xyflow/react's `connectingSelector`. A connection is "in process"
-// globally while dragging (`connectionStartHandle`) or click-connecting (`connectionClickStartHandle`);
-// `isPossibleEndHandle` is whether this handle can be the END of the in-progress (drag) connection.
-const connectionInProcess = toRef(() => store.connectionStartHandle !== null);
-
-const clickConnectionInProcess = toRef(() => store.connectionClickStartHandle !== null);
-
-const isPossibleEndHandle = toRef(() => {
-  const fromHandle = store.connectionStartHandle;
-  return store.connectionMode === ConnectionMode.Strict
-    ? fromHandle?.type !== type.value
-    : nodeId !== fromHandle?.nodeId || handleId !== fromHandle?.id;
-});
-
-const isClickConnecting = toRef(
-  () =>
-    store.connectionClickStartHandle?.nodeId === nodeId
-    && store.connectionClickStartHandle?.id === handleId
-    && store.connectionClickStartHandle?.type === type.value,
-);
-
-// xyflow/react + svelte toggle these per handle during a connection: `connectingfrom` on the handle the
-// drag started from, `connectingto` on the handle currently hovered, and `valid` when that hovered handle
-// is a valid target. Core only toggles the classes — coloring is left to user CSS.
-const connectingFrom = toRef(
-  () =>
-    store.connectionStartHandle?.nodeId === nodeId
-    && store.connectionStartHandle?.id === handleId
-    && store.connectionStartHandle?.type === type.value,
-);
-
-const connectingTo = toRef(
-  () =>
-    store.connectionEndHandle?.nodeId === nodeId
-    && store.connectionEndHandle?.id === handleId
-    && store.connectionEndHandle?.type === type.value,
-);
-
-const valid = toRef(() => connectingTo.value && store.connectionStatus === 'valid');
-
 const { handlePointerDown, handleClick } = useHandle({
   nodeId,
   handleId,
@@ -121,6 +77,41 @@ const isHandleConnectable = computed(() => {
   }
 
   return isDef(isConnectable) ? isConnectable : store.nodesConnectable;
+});
+
+// All connection-driven classes in one computed instead of ~7 separate refs: they all derive from the same
+// global `connection*` store state (so they toggle together during a connection) and are used only in the
+// class binding. Mirrors xyflow/react's `connectingSelector`.
+const connectionClasses = computed(() => {
+  const fromHandle = store.connectionStartHandle;
+  const clickFromHandle = store.connectionClickStartHandle;
+  const toHandle = store.connectionEndHandle;
+  const handleType = type.value;
+
+  const connectionInProcess = fromHandle !== null;
+  const clickConnectionInProcess = clickFromHandle !== null;
+  // whether this handle can be the END of the in-progress (drag) connection
+  const isPossibleEndHandle = store.connectionMode === ConnectionMode.Strict
+    ? fromHandle?.type !== handleType
+    : nodeId !== fromHandle?.nodeId || handleId !== fromHandle?.id;
+  const connectingto = toHandle?.nodeId === nodeId && toHandle?.id === handleId && toHandle?.type === handleType;
+
+  return {
+    // resolved value (falls back to `nodesConnectable`), not the raw prop — XYHandle's DOM query targets
+    // `.connectable` to find drop targets, so an unset `:connectable` must still mark it
+    connectable: isHandleConnectable.value,
+    connecting:
+      clickFromHandle?.nodeId === nodeId && clickFromHandle?.id === handleId && clickFromHandle?.type === handleType,
+    connectablestart: connectableStart,
+    connectableend: connectableEnd,
+    connectingfrom: fromHandle?.nodeId === nodeId && fromHandle?.id === handleId && fromHandle?.type === handleType,
+    connectingto,
+    valid: connectingto && store.connectionStatus === 'valid',
+    connectionindicator:
+      isHandleConnectable.value
+      && (!connectionInProcess || isPossibleEndHandle)
+      && ((connectionInProcess || clickConnectionInProcess) ? connectableEnd : connectableStart),
+  };
 });
 
 // todo: remove this and have users handle this themselves using `updateNodeInternals`
@@ -173,13 +164,13 @@ onMounted(() => {
 function onPointerDown(event: MouseEvent | TouchEvent) {
   const isMouseTriggered = isMouseEvent(event);
 
-  if (isHandleConnectable.value && isConnectableStart.value && ((isMouseTriggered && event.button === 0) || !isMouseTriggered)) {
+  if (isHandleConnectable.value && connectableStart && ((isMouseTriggered && event.button === 0) || !isMouseTriggered)) {
     handlePointerDown(event);
   }
 }
 
 function onClick(event: MouseEvent) {
-  if (!nodeId || (!store.connectionClickStartHandle && !isConnectableStart.value)) {
+  if (!nodeId || (!store.connectionClickStartHandle && !connectableStart)) {
     return;
   }
 
@@ -215,21 +206,7 @@ export default {
       store.noDragClassName,
       store.noPanClassName,
       type,
-      {
-        // use the resolved value (falls back to `nodesConnectable`), not the raw prop — XYHandle's DOM
-        // query targets `.connectable` to find drop targets, so an unset `:connectable` must still mark it
-        connectable: isHandleConnectable,
-        connecting: isClickConnecting,
-        connectablestart: isConnectableStart,
-        connectableend: isConnectableEnd,
-        connectingfrom: connectingFrom,
-        connectingto: connectingTo,
-        valid,
-        connectionindicator:
-          isHandleConnectable
-          && (!connectionInProcess || isPossibleEndHandle)
-          && ((connectionInProcess || clickConnectionInProcess) ? isConnectableEnd : isConnectableStart),
-      },
+      connectionClasses,
     ]"
     @mousedown="onPointerDown"
     @touchstart.passive="onPointerDown"


### PR DESCRIPTION
## Why

`<Handle>` is the **highest-multiplicity element** (~2 per node → 1,800 for a 900-node graph). Each instance created **~13 reactive refs/computeds**, of which **7 were connection-state `toRef`s** (`connectingFrom`, `connectingTo`, `valid`, `connectionInProcess`, `clickConnectionInProcess`, `isPossibleEndHandle`, `isClickConnecting`) — all derived from the same **global** `connection*` store state and used **only** in the class binding.

This keeps the public `<Handle>` API (no `<Handles>`-style batching — that'd break xyflow parity), but trims what each handle allocates.

## Change

- Consolidate the 7 connection-state `toRef`s into a single `connectionClasses` computed. They all toggle together during a connection (driven by the same global state), so one effect covers them — and it's also fewer effects to fire on connect-start (where every handle re-renders).
- Drop the redundant `isConnectableStart`/`isConnectableEnd` refs — their props already default to `true`, so the wrapping `toRef` was a no-op; use the props directly in the handlers + the computed.

**~13 → ~5 reactive effects per handle.** Net **−23 lines**. Rendered classes are identical (logic verified line-by-line); no behavior or API change.

## Tests

Connection/handle suite green (15/15): `connect`, `looseReconnect`, `basic`, `selectionClickVsDrag`, `edgeZIndex`. (`connect` passing confirms the functional `connectable`/`connectablestart`/`connectableend` classes still render — XYHandle's drop-target query depends on them.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)