### PR TITLE
fix(core): re-measure when handle bounds are missing (xyflow parity)

### DIFF
--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -343,10 +343,16 @@ export function useActions<NodeType extends Node = Node, EdgeType extends Edge =
       if (node) {
         const dimensions = getDimensions(update.nodeElement);
 
+        // Re-measure when the size changed, when this is a forced update, or when handle bounds are still
+        // missing — matching xyflow/system's guard. The last term keeps a node from being left without
+        // handle bounds if it ever reaches here un-forced with dimensions that already match.
         const doUpdate = !!(
           dimensions.width
           && dimensions.height
-          && (node.measured.width !== dimensions.width || node.measured.height !== dimensions.height || update.forceUpdate)
+          && (node.measured.width !== dimensions.width
+            || node.measured.height !== dimensions.height
+            || !node.internals.handleBounds
+            || update.forceUpdate)
         );
 
         if (doUpdate) {


### PR DESCRIPTION
## What

Adds the missing `!node.internals.handleBounds` term to `updateNodeDimensions`' `doUpdate` guard, matching `@xyflow/system`'s guard (`dimensionChanged || !node.internals.handleBounds || update.force`).

Before, the guard skipped measuring whenever the incoming dimensions matched `node.measured` **and** the update wasn't forced — even if the node still had no `handleBounds`. xyflow includes this term precisely so a node can't be left without handle bounds in that case.

## Why it's safe / inert today

In the normal flow the `ResizeObserver` callback passes `forceUpdate: true` (same as xyflow's RO), so the forced update already fires the first measurement and seeds handle bounds. This term only matters if a node ever reaches the guard **un-forced** with dimensions that already match — a path that doesn't exist today but would silently leave the node without handle bounds (breaking edge attachment) if it did.

So: no behavior change in any current flow — this is parity hardening.

## Test

`pnpm --filter @vue-flow/core build` clean; `nodeInitialDimensions`, `handleBoundsRecommit`, and `connect` component specs pass (6/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)